### PR TITLE
feat(config): initialize default config files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 install: build
 	@mkdir -p $(INSTALL_DIR)
 	@install -m 755 $(BIN) $(INSTALL_DIR)/$(BIN)
+	@bun run src/main.ts init --global
 	@echo "✓ Instalado en $(INSTALL_DIR)/$(BIN)"
 	@echo "  Asegúrate de que $(INSTALL_DIR) está en tu PATH."
 

--- a/README.md
+++ b/README.md
@@ -54,13 +54,16 @@ bun install
 make install
 ```
 
-This leaves `archer` in `~/.local/bin/archer`. Make sure it's in your `PATH`.
+This leaves `archer` in `~/.local/bin/archer` and creates `~/.archer/config.yaml` plus `~/.archer/agents/*.md` with Archer's default configuration if they do not already exist. Make sure `~/.local/bin` is in your `PATH`.
 
 ## Usage
 
 From the root of the target repo, ideally on a working branch:
 
 ```bash
+# create project-local config and prompt files you can customize
+archer init
+
 # inline prompt
 archer "Add onboarding screen with 3 steps and local persistence of progress"
 
@@ -116,6 +119,28 @@ archer --prompt-file prd.md --base develop
 
 # include existing local changes in the first commit of the pipeline
 archer --prompt-file prd.md --include-dirty --max-attempts 1
+```
+
+## Configuration
+
+Archer reads configuration from two places:
+
+```text
+~/.archer/config.yaml      # user defaults, created by make install or archer init --global
+~/.archer/agents/*.md      # user default prompts loaded by matching agent name
+.archer/config.yaml        # project-local overrides, created by archer init
+.archer/agents/*.md        # project-local prompts loaded by matching agent name
+```
+
+Precedence is `CLI flags > project config > global config > built-in defaults`. Project config is useful for repo-specific pipelines, attachments, permissions, prompts, and model choices that should travel with the project.
+
+Useful commands:
+
+```bash
+archer init                # create .archer/config.yaml and .archer/agents/*.md in the current repo
+archer init --dir ../app   # create project config in another repo
+archer init --global       # create ~/.archer/config.yaml and ~/.archer/agents/*.md
+archer init --force        # overwrite the selected config
 ```
 
 In interactive terminals, Archer shows a full-screen OpenTUI dashboard: pipeline progress with per-phase duration and cost, plus an activity panel headed by a compact summary of the active session (current tool/thinking/writing, the agent's todo list, files changed, step count, tokens, cost) above a color-coded event feed. The dashboard never paints backgrounds: the canvas is your terminal's own background and panels are delineated by borders alone, derived as subtle elevations of the terminal's reported background color, with dark or light accents picked by its brightness (and a neutral fallback when the terminal doesn't answer); floating modals repaint the reported color exactly to mask the content beneath them. It follows live theme changes. Press `o`, or click the footer, to open the active OpenCode session in a new terminal window attached to Archer's running OpenCode server — clicking any pipeline row opens that phase's session, including phases that already finished. Ghostty is preferred when installed; Terminal.app is the fallback (`ARCHER_TERMINAL=ghostty|terminal` forces a backend). Press `Shift+Tab` to toggle auto-accept (see the permission gate below). Press `Ctrl+C` once to abort the active OpenCode session and shut down Archer cleanly; press it again to force exit if cleanup hangs. The dashboard suspends for the whole `human-review` checkpoint — the prompts, your app command's output, and interactive OpenCode iterations own the terminal — and resumes when the gate finishes. Use `--no-tui` to fall back to plain logs.
@@ -179,6 +204,17 @@ Built-in agent prompts live as Markdown files under `prompts/`. A project can fu
 
 When a project override exists, it replaces that agent's built-in prompt completely. Archer still appends its non-replaceable runtime safety guard rails from `prompts/runtime-safety.md`.
 
+Config entries and Markdown prompts are matched by name. `archer init` leaves this section commented as a format guide, but the generated `agents/*.md` prompts are still picked up by name:
+
+```yaml
+# agents:
+#   implementer: {}
+```
+
+The prompt for that entry lives at `agents/implementer.md` next to the config file.
+
+Prompt precedence is `.archer/agents/<name>.md > ~/.archer/agents/<name>.md > built-in prompt`.
+
 ## Efficient Attachments
 
 `--file` is repeatable and accepts files or directories. Relative paths are resolved against the target repo.
@@ -217,7 +253,7 @@ Each invocation creates `~/.archer/runs/<run-id>/`:
 
 The run dir is deleted on successful completion unless `--keep-run-dir`. If it fails, it's preserved for inspecting reports, diffs, and logs.
 
-The target repo only sees commits with prefix `archer(<phase>): ...`, made on the current branch. No CLI files are left in the project.
+The target repo only sees commits with prefix `archer(<phase>): ...`, made on the current branch. Normal runs leave no CLI files in the project; `archer init` intentionally creates `.archer/config.yaml` when you want project-local configuration.
 
 ## Development
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url"
 import type { AgentConfig, Config } from "@opencode-ai/sdk/v2"
 import { builtInAgents } from "./pipeline"
 import type { AgentSpec, PermissionAdditions } from "./types"
+import { archerRoot } from "./workspace"
 
 const sourceDir = dirname(fileURLToPath(import.meta.url))
 const builtInPromptsDir = join(sourceDir, "..", "prompts")
@@ -20,7 +21,7 @@ export function opencodeConfig(
 ): Config {
   const agent: Record<string, AgentConfig> = {}
   for (const spec of agents) {
-    agent[spec.name] = agentConfig(spec.description, spec.temperature, loadAgentPrompt(spec.name, targetDir), runDir, targetDir, false, permissions)
+    agent[spec.name] = agentConfig(spec.description, spec.temperature, loadAgentPrompt(spec, targetDir), runDir, targetDir, false, permissions)
   }
 
   return {
@@ -32,8 +33,11 @@ export function opencodeConfig(
   }
 }
 
-export function loadAgentPrompt(agentName: string, targetDir = process.cwd()) {
-  const agentPrompt = readProjectAgentPrompt(agentName, targetDir) ?? readBuiltInPrompt(agentName)
+export function loadAgentPrompt(agent: string | AgentSpec, targetDir = process.cwd()) {
+  const agentName = typeof agent === "string" ? agent : agent.name
+  const projectPrompt = readProjectAgentPrompt(agentName, targetDir)
+  const globalPrompt = readGlobalAgentPrompt(agentName)
+  const agentPrompt = projectPrompt ?? globalPrompt ?? readBuiltInPrompt(agentName)
   const safetyPrompt = readBuiltInPrompt(runtimeSafetyPrompt)
   return [agentPrompt.trimEnd(), "", "---", "", safetyPrompt.trim()].join("\n")
 }
@@ -42,12 +46,22 @@ export function projectAgentPromptPath(agentName: string, targetDir: string) {
   return join(targetDir, ".archer", "agents", `${agentName}.md`)
 }
 
+export function globalAgentPromptPath(agentName: string) {
+  return join(archerRoot(), "agents", `${agentName}.md`)
+}
+
 export function builtInPromptPath(promptName: string) {
   return join(builtInPromptsDir, `${promptName}.md`)
 }
 
 function readProjectAgentPrompt(agentName: string, targetDir: string) {
   const path = projectAgentPromptPath(agentName, targetDir)
+  if (!isFile(path)) return undefined
+  return readFileSync(path, "utf8")
+}
+
+function readGlobalAgentPrompt(agentName: string) {
+  const path = globalAgentPromptPath(agentName)
   if (!isFile(path)) return undefined
   return readFileSync(path, "utf8")
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
-import { buildAgentRegistry, loadArcherConfig, selectPipelineSpec, type ArcherDefaults } from "./config"
+import { buildAgentRegistry, loadArcherConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ArcherDefaults } from "./config"
 import { defaultGptModel, defaultGptVariant, defaultPipeline, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
 import { parseModel, run } from "./runner"
 import { browseRuns } from "./runs"
@@ -11,7 +11,7 @@ import { isValidRunID } from "./workspace"
 /**
  * Flags as written: every scalar stays undefined until the user sets it, so
  * resolveRunOptions can tell "flag given" from "flag at its default" and apply
- * the precedence chain flag > .archer/config.yaml defaults > built-in default.
+ * the precedence chain flag > project config > global config > built-in default.
  */
 export type ParsedArgs = {
   prompt?: string
@@ -37,10 +37,18 @@ export type ParsedArgs = {
   yolo?: boolean
 }
 
+export type InitOptions = {
+  targetDir: string
+  global: boolean
+  force: boolean
+  quiet: boolean
+}
+
 export type CliCommand =
   | { type: "help"; text: string }
   | { type: "run"; options: RunOptions }
   | { type: "runs"; runID?: string }
+  | { type: "init"; options: InitOptions }
 
 export async function parseAndRun(argv: string[]) {
   const command = await parseCommand(argv)
@@ -51,6 +59,16 @@ export async function parseAndRun(argv: string[]) {
   if (command.type === "runs") {
     const resolution = await browseRuns(command.runID)
     if (resolution.type === "resume") await run(await resumeOptions(resolution.runID, resolution.targetDir))
+    return
+  }
+  if (command.type === "init") {
+    const result = command.options.global
+      ? await writeDefaultGlobalConfig(command.options.force)
+      : await writeDefaultProjectConfig(command.options.targetDir, command.options.force)
+    if (!command.options.quiet) {
+      const scope = command.options.global ? "global config" : "project config"
+      process.stdout.write(`${result.created ? "created" : "ensured"} ${scope}: ${result.path}\n`)
+    }
     return
   }
 
@@ -73,6 +91,11 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
     if (rest[0] !== undefined && !isValidRunID(rest[0])) throw new Error(`invalid run id: ${rest[0]}`)
     return { type: "runs", runID: rest[0] }
   }
+  if (argv[0] === "init") {
+    const parsed = parseInitArgs(argv.slice(1))
+    if (parsed.help) return { type: "help", text: initHelp() }
+    return { type: "init", options: parsed }
+  }
 
   const parsed = parseArgs(argv)
   if (parsed.help) return { type: "help", text: help() }
@@ -94,6 +117,63 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
   }
 
   return { type: "run", options: { ...(await resolveRunOptions(parsed)), prompt } }
+}
+
+type ParsedInitArgs = InitOptions & { help?: boolean }
+
+function parseInitArgs(argv: string[]): ParsedInitArgs {
+  const parsed: ParsedInitArgs = {
+    targetDir: process.cwd(),
+    global: false,
+    force: false,
+    quiet: false,
+  }
+  let hasDir = false
+
+  for (let i = 0; i < argv.length; i++) {
+    const raw = argv[i]!
+    if (!raw.startsWith("-")) throw new Error("usage: archer init [--global] [--force] [--dir <path>]")
+
+    const { flag, value } = splitFlag(raw)
+    const noValue = () => {
+      if (value !== undefined) throw new Error(`${flag} does not take a value`)
+    }
+    const takeValue = () => {
+      if (value !== undefined) return value
+      const next = argv[++i]
+      if (next === undefined || (next.startsWith("-") && next !== "-")) throw new Error(`${flag} requires a value`)
+      return next
+    }
+
+    switch (flag) {
+      case "--help":
+      case "-h":
+        noValue()
+        parsed.help = true
+        return parsed
+      case "--global":
+        noValue()
+        parsed.global = true
+        break
+      case "--force":
+        noValue()
+        parsed.force = true
+        break
+      case "--quiet":
+        noValue()
+        parsed.quiet = true
+        break
+      case "--dir":
+        parsed.targetDir = resolve(process.cwd(), takeValue())
+        hasDir = true
+        break
+      default:
+        throw new Error(`unknown init flag: ${flag}`)
+    }
+  }
+
+  if (parsed.global && hasDir) throw new Error("use either --global or --dir, not both")
+  return parsed
 }
 
 /** Applies the precedence chain and resolves the pipeline the run will execute. */
@@ -300,9 +380,12 @@ Usage:
   archer "Add onboarding"
   archer --prompt-file prd.md --file lib/onboarding --file test/onboarding_test.dart
   archer --pipeline bug-fix --prompt-file bug.md
+  archer init
   archer runs [run-id]
 
 Commands:
+  init                     Create .archer/config.yaml and .archer/agents/*.md in the target repo
+  init --global            Create ~/.archer/config.yaml and ~/.archer/agents/*.md
   runs [run-id]            Browse run history: resume a run, read its summary/reports,
                            or open a subshell in its run dir (under ~/.archer/runs)
 
@@ -332,12 +415,30 @@ Flags:
   --base <ref>             Branch/base for calculating diffs (default: main)
   --dir <path>             Target repo (default: cwd)
 
-Project config (.archer/config.yaml):
+Config files:
+  ~/.archer/config.yaml    user defaults, created by make install or archer init --global
+  .archer/config.yaml      project-local overrides, created by archer init
+  agents/*.md              Markdown prompts loaded by matching the agent name
+
+Config keys:
   defaults:                model, maxAttempts, baseRef, pipeline, appRunCommand, emulator, interactiveModel
-  agents:                  project agents (prompt at .archer/agents/<name>.md) or built-in overrides
+  agents:                  project agents or built-in overrides; prompts live at agents/<name>.md
   pipelines:               named step lists mixing agents and human-review gates
   permissions:             allow/deny additions to the bash policy (deny always wins)
   attachments:             files attached to every step
-  CLI flags always win over config defaults.
+  Precedence: CLI flags > project config > global config > built-in defaults.
+`
+}
+
+function initHelp() {
+  return `archer init [--global] [--force] [--dir <path>]
+
+Create Archer's default config file and agent prompt Markdown files. Existing files are not overwritten unless --force is set.
+
+Options:
+  --global                 Write ~/.archer/config.yaml instead of a project config
+  --dir <path>             Target repo for .archer/config.yaml (default: cwd)
+  --force                  Overwrite an existing config file
+  --quiet                  Suppress status output
 `
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,17 @@
 import { statSync } from "node:fs"
-import { readFile } from "node:fs/promises"
-import { join } from "node:path"
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises"
+import { dirname, isAbsolute, join, resolve } from "node:path"
 
-import { projectAgentPromptPath } from "./agents"
+import { builtInPromptPath, globalAgentPromptPath, projectAgentPromptPath } from "./agents"
 import { log } from "./log"
 import { agentAliases, builtInAgents, builtInPipelines, humanReviewStep, splitModelVariant, type PipelineSpec, type StepSpec } from "./pipeline"
 import type { AgentSpec, PermissionAdditions } from "./types"
+import { archerRoot } from "./workspace"
 
 /**
- * Project configuration loaded from .archer/config.yaml. Everything is
- * optional: the file only declares what differs from archer's defaults.
+ * Configuration loaded from ~/.archer/config.yaml and .archer/config.yaml.
+ * Everything is optional: files only declare what differs from archer's
+ * built-in defaults.
  */
 export type ArcherConfig = {
   defaults: ArcherDefaults
@@ -45,21 +47,166 @@ export class ConfigError extends Error {
 
 const configFileNames = ["config.yaml", "config.yml"]
 
+export const defaultArcherConfig = `# Archer configuration.
+# Global default path: ~/.archer/config.yaml
+# Project override path: .archer/config.yaml
+
+version: 1
+
+defaults:
+  # maxAttempts: 2
+  # baseRef: main
+  # pipeline: default
+  # interactiveModel: openai/gpt-5.5#xhigh
+  # model: openai/gpt-5.5#xhigh # optional: unset by default; uncomment to force every agent unless a step/agent overrides it
+  # appRunCommand: pnpm dev # optional: unset by default; used during human-review
+  # emulator: Pixel_8 # optional: unset by default; used during human-review
+
+# Agents are matched by name with Markdown prompts next to this config:
+#   agents/<name>.md
+# Uncomment entries to override metadata/model/temperature or to add custom agents.
+# Custom agents must have a matching agents/<name>.md prompt file.
+# agents:
+#   implementer:
+#     description: Implements the feature described in the PRD respecting repo patterns
+#     model: openai/gpt-5.5#xhigh
+#   design-polisher:
+#     description: Polishes new UI following the repo's design system, without redesigning
+#     model: anthropic/claude-opus-4-7
+#     temperature: 0.2
+#   api-reviewer:
+#     description: Reviews API consistency
+#     model: openai/gpt-5.5#xhigh
+
+pipelines:
+  default:
+    description: Implementation, pattern/security audits, design polish, tests, and adversarial review
+    steps:
+      - agent: implementer
+        reports: none
+      - human-review
+      - patterns
+      - security
+      - design
+      - agent: tests
+        reports: none
+      - agent: adversarial
+        reports: all
+
+permissions:
+  allow: []
+  deny: []
+
+attachments: []
+`
+
+export type ConfigWriteResult = {
+  path: string
+  created: boolean
+}
+
+export function globalConfigPath() {
+  return join(archerRoot(), "config.yaml")
+}
+
+export function projectConfigPath(targetDir: string) {
+  return join(targetDir, ".archer", "config.yaml")
+}
+
 export async function loadArcherConfig(targetDir: string): Promise<ArcherConfig | undefined> {
+  const configs: ArcherConfig[] = []
+  const global = await readConfigFile(globalConfigPath(), globalConfigPath(), targetDir)
+  if (global) configs.push(global)
+
+  const local = await loadProjectArcherConfig(targetDir)
+  if (local) configs.push(local)
+
+  return configs.length > 0 ? mergeArcherConfigs(configs) : undefined
+}
+
+export async function loadProjectArcherConfig(targetDir: string): Promise<ArcherConfig | undefined> {
   for (const fileName of configFileNames) {
     const path = join(targetDir, ".archer", fileName)
-    let body: string
-    try {
-      body = await readFile(path, "utf8")
-    } catch {
-      continue
-    }
-    return parseArcherConfig(body, `.archer/${fileName}`, targetDir)
+    const config = await readConfigFile(path, `.archer/${fileName}`, targetDir)
+    if (config) return config
   }
   return undefined
 }
 
-export function parseArcherConfig(body: string, source: string, targetDir: string): ArcherConfig {
+export function mergeArcherConfigs(configs: readonly ArcherConfig[]): ArcherConfig {
+  const merged: ArcherConfig = { defaults: {}, agents: {}, pipelines: {}, permissions: { allow: [], deny: [] }, attachments: [] }
+
+  for (const config of configs) {
+    merged.defaults = { ...merged.defaults, ...config.defaults }
+    for (const [name, agent] of Object.entries(config.agents)) {
+      merged.agents[name] = { ...merged.agents[name], ...agent }
+    }
+    for (const [name, pipeline] of Object.entries(config.pipelines)) merged.pipelines[name] = pipeline
+    merged.permissions.allow.push(...config.permissions.allow)
+    merged.permissions.deny.push(...config.permissions.deny)
+    merged.attachments.push(...config.attachments)
+  }
+
+  return merged
+}
+
+export async function writeDefaultGlobalConfig(force = false): Promise<ConfigWriteResult> {
+  return writeDefaultArcherConfig(globalConfigPath(), force)
+}
+
+export async function writeDefaultProjectConfig(targetDir: string, force = false): Promise<ConfigWriteResult> {
+  await assertDirectory(targetDir)
+  return writeDefaultArcherConfig(projectConfigPath(targetDir), force)
+}
+
+export async function writeDefaultArcherConfig(path: string, force = false): Promise<ConfigWriteResult> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeDefaultAgentPrompts(path, force)
+  try {
+    await writeFile(path, defaultArcherConfig, { flag: force ? "w" : "wx" })
+    return { path, created: true }
+  } catch (error) {
+    if (!force && isErrno(error, "EEXIST")) return { path, created: false }
+    throw error
+  }
+}
+
+async function writeDefaultAgentPrompts(configPath: string, force: boolean) {
+  const agentsDir = join(dirname(configPath), "agents")
+  await mkdir(agentsDir, { recursive: true })
+  for (const agent of builtInAgents) {
+    const target = join(agentsDir, `${agent.name}.md`)
+    const body = await readFile(builtInPromptPath(agent.name), "utf8")
+    try {
+      await writeFile(target, body, { flag: force ? "w" : "wx" })
+    } catch (error) {
+      if (!force && isErrno(error, "EEXIST")) continue
+      throw error
+    }
+  }
+}
+
+async function readConfigFile(path: string, source: string, targetDir: string): Promise<ArcherConfig | undefined> {
+  let body: string
+  try {
+    body = await readFile(path, "utf8")
+  } catch {
+    return undefined
+  }
+  return parseArcherConfig(body, source, targetDir, dirname(path))
+}
+
+async function assertDirectory(path: string) {
+  let info: Awaited<ReturnType<typeof stat>>
+  try {
+    info = await stat(path)
+  } catch {
+    throw new Error(`target directory does not exist: ${path}`)
+  }
+  if (!info.isDirectory()) throw new Error(`target path is not a directory: ${path}`)
+}
+
+export function parseArcherConfig(body: string, source: string, targetDir: string, configDir = configDirectory(source, targetDir)): ArcherConfig {
   let raw: unknown
   try {
     raw = Bun.YAML.parse(body)
@@ -78,8 +225,8 @@ export function parseArcherConfig(body: string, source: string, targetDir: strin
 
   if (root.version !== undefined && root.version !== 1) v.fail("version", `unsupported value ${JSON.stringify(root.version)}; this archer reads version 1`)
 
-  if (root.defaults !== undefined) config.defaults = validateDefaults(v, root.defaults)
-  if (root.agents !== undefined) config.agents = validateAgents(v, root.agents, targetDir)
+  if (root.defaults !== undefined && root.defaults !== null) config.defaults = validateDefaults(v, root.defaults)
+  if (root.agents !== undefined) config.agents = validateAgents(v, root.agents, targetDir, configDir)
   if (root.pipelines !== undefined) config.pipelines = validatePipelines(v, root.pipelines)
   if (root.permissions !== undefined) config.permissions = validatePermissions(v, root.permissions)
   if (root.attachments !== undefined) config.attachments = v.stringArray(root.attachments, "attachments")
@@ -102,7 +249,7 @@ function validateDefaults(v: Validator, raw: unknown): ArcherDefaults {
   return defaults
 }
 
-function validateAgents(v: Validator, raw: unknown, targetDir: string): Record<string, ConfigAgent> {
+function validateAgents(v: Validator, raw: unknown, targetDir: string, configDir: string): Record<string, ConfigAgent> {
   const record = v.record(raw, "agents")
   const agents: Record<string, ConfigAgent> = {}
 
@@ -122,8 +269,8 @@ function validateAgents(v: Validator, raw: unknown, targetDir: string): Record<s
     // Project agents bring their own prompt; built-in overrides keep theirs
     // (optionally replaced via the same path). Fail at load, not mid-run.
     const builtIn = builtInAgents.some((candidate) => candidate.name === name)
-    if (!builtIn && !isFile(projectAgentPromptPath(name, targetDir))) {
-      v.fail(path, `agent "${name}" needs a prompt at .archer/agents/${name}.md`)
+    if (!builtIn && !hasConfiguredAgentPrompt(name, targetDir, configDir)) {
+      v.fail(path, `agent "${name}" needs a prompt at agents/${name}.md next to the config`)
     }
 
     agents[name] = agent
@@ -282,4 +429,16 @@ function isFile(path: string) {
   } catch {
     return false
   }
+}
+
+function configDirectory(source: string, targetDir: string) {
+  return dirname(isAbsolute(source) ? source : resolve(targetDir, source))
+}
+
+function hasConfiguredAgentPrompt(agentName: string, targetDir: string, configDir: string) {
+  return isFile(join(configDir, "agents", `${agentName}.md`)) || isFile(projectAgentPromptPath(agentName, targetDir)) || isFile(globalAgentPromptPath(agentName))
+}
+
+function isErrno(error: unknown, code: string) {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === code
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1211,7 +1211,7 @@ function ensureAgentsAvailable(pipeline: Pipeline, agents: readonly AgentSpec[])
   const available = new Set(agents.map((agent) => agent.name))
   for (const step of pipeline.steps) {
     if (step.type !== "agent" || available.has(step.agentName)) continue
-    throw new Error(`pipeline "${pipeline.name}" needs agent "${step.agentName}", which is not defined (removed from .archer/config.yaml?)`)
+    throw new Error(`pipeline "${pipeline.name}" needs agent "${step.agentName}", which is not defined (removed from Archer config?)`)
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export type PermissionAdditions = {
 /**
  * An agent definition: who can run as a pipeline step. Built-ins ship with
  * archer; projects add their own (prompt at .archer/agents/<name>.md) or
- * override built-in model/temperature from .archer/config.yaml.
+ * config files override built-in model/temperature.
  */
 export type AgentSpec = {
   name: string

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -52,13 +52,17 @@ export async function writeSummary(workspace: Workspace, phaseNames: string[]) {
   await writeFile(join(workspace.dir, "SUMMARY.md"), chunks.join("\n"))
 }
 
+export function archerRoot() {
+  return process.env.ARCHER_HOME ? resolve(process.env.ARCHER_HOME) : join(homedir(), ".archer")
+}
+
 export function runDir(runID: string) {
   validateRunID(runID)
   return childPath(runsRoot(), runID)
 }
 
 export function runsRoot() {
-  return join(homedir(), ".archer", "runs")
+  return join(archerRoot(), "runs")
 }
 
 export function isValidRunID(runID: string) {

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -41,6 +41,49 @@ describe("opencode config", () => {
     }
   })
 
+  test("global agent prompts replace built-ins but keep runtime safety", async () => {
+    const previousHome = process.env.ARCHER_HOME
+    const home = await mkdtemp(join(tmpdir(), "archer-agent-global-home-"))
+    try {
+      process.env.ARCHER_HOME = home
+      await mkdir(join(home, "agents"), { recursive: true })
+      await writeFile(join(home, "agents", "implementer.md"), "# Global Implementer\n\nGlobal prompt.")
+
+      const prompt = loadAgentPrompt("implementer", "/tmp/non-existent-archer-target")
+
+      expect(prompt.startsWith("# Global Implementer")).toBe(true)
+      expect(prompt).toContain("Global prompt.")
+      expect(prompt).toContain("# Archer Runtime Safety")
+    } finally {
+      if (previousHome === undefined) delete process.env.ARCHER_HOME
+      else process.env.ARCHER_HOME = previousHome
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
+  test("project prompt path beats a global prompt path", async () => {
+    const previousHome = process.env.ARCHER_HOME
+    const dir = await mkdtemp(join(tmpdir(), "archer-agent-global-prompt-"))
+    const home = await mkdtemp(join(tmpdir(), "archer-agent-global-home-"))
+    try {
+      process.env.ARCHER_HOME = home
+      await mkdir(join(home, "agents"), { recursive: true })
+      await writeFile(join(home, "agents", "implementer.md"), "# Global Implementer\n\nGlobal prompt.")
+      await mkdir(join(dir, ".archer", "agents"), { recursive: true })
+      await writeFile(join(dir, ".archer", "agents", "implementer.md"), "# Local Implementer\n\nLocal prompt.")
+
+      const prompt = loadAgentPrompt("implementer", dir)
+
+      expect(prompt.startsWith("# Local Implementer")).toBe(true)
+      expect(prompt).not.toContain("# Global Implementer")
+    } finally {
+      if (previousHome === undefined) delete process.env.ARCHER_HOME
+      else process.env.ARCHER_HOME = previousHome
+      await rm(dir, { recursive: true, force: true })
+      await rm(home, { recursive: true, force: true })
+    }
+  })
+
   test("bash policy includes web checks and keeps dangerous operations denied", () => {
     const policy = bashPolicy()
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,10 +1,12 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import "./env"
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterAll, describe, expect, test } from "bun:test"
 
-import { parseArgs, parseCommand } from "../src/cli"
+import { parseAndRun, parseArgs, parseCommand } from "../src/cli"
 import { stepNames } from "../src/pipeline"
 
 describe("cli parsing", () => {
@@ -121,6 +123,56 @@ describe("cli parsing", () => {
   })
 })
 
+describe("init command", () => {
+  const dirs: string[] = []
+
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  test("parses init options without requiring a prompt", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-cli-init-"))
+    dirs.push(dir)
+
+    const local = await parseCommand(["init", "--dir", dir, "--force", "--quiet"])
+    expect(local.type).toBe("init")
+    if (local.type === "init") {
+      expect(local.options).toMatchObject({ targetDir: dir, global: false, force: true, quiet: true })
+    }
+
+    const global = await parseCommand(["init", "--global", "--force"])
+    expect(global.type).toBe("init")
+    if (global.type === "init") expect(global.options).toMatchObject({ global: true, force: true })
+  })
+
+  test("rejects incompatible init options", async () => {
+    await expect(parseCommand(["init", "--global", "--dir", "."])).rejects.toThrow("either --global or --dir")
+    await expect(parseCommand(["init", "extra"])).rejects.toThrow("usage: archer init")
+  })
+
+  test("creates project config without overwriting unless forced", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-cli-init-write-"))
+    dirs.push(dir)
+    const path = join(dir, ".archer", "config.yaml")
+
+    await parseAndRun(["init", "--dir", dir, "--quiet"])
+    expect(await readFile(path, "utf8")).toContain("version: 1")
+    expect(await readFile(path, "utf8")).toContain("#   implementer:")
+    expect(await readFile(path, "utf8")).toContain("# maxAttempts: 2")
+    expect(await readFile(join(dir, ".archer", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+
+    await writeFile(path, "version: 1\nattachments:\n  - custom.md\n")
+    await writeFile(join(dir, ".archer", "agents", "implementer.md"), "# Custom Implementer\n")
+    await parseAndRun(["init", "--dir", dir, "--quiet"])
+    expect(await readFile(path, "utf8")).toContain("custom.md")
+    expect(await readFile(join(dir, ".archer", "agents", "implementer.md"), "utf8")).toContain("# Custom Implementer")
+
+    await parseAndRun(["init", "--dir", dir, "--force", "--quiet"])
+    expect(await readFile(path, "utf8")).not.toContain("custom.md")
+    expect(await readFile(join(dir, ".archer", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+  })
+})
+
 describe("config precedence", () => {
   const dirs: string[] = []
 
@@ -165,6 +217,45 @@ describe("config precedence", () => {
     expect(command.options.pipeline.name).toBe("quick")
     expect(stepNames(command.options.pipeline)).toEqual(["implementer", "tests"])
     expect(command.options.files).toEqual(["docs.md"])
+  })
+
+  test("global config applies when project config is absent", async () => {
+    const previousHome = process.env.ARCHER_HOME
+    const home = await mkdtemp(join(tmpdir(), "archer-cli-home-"))
+    const dir = await mkdtemp(join(tmpdir(), "archer-cli-target-"))
+    dirs.push(home, dir)
+    process.env.ARCHER_HOME = home
+
+    try {
+      await writeFile(
+        join(home, "config.yaml"),
+        [
+          "defaults:",
+          "  maxAttempts: 4",
+          "  baseRef: trunk",
+          "  pipeline: lean",
+          "pipelines:",
+          "  lean:",
+          "    steps:",
+          "      - implementer",
+          "attachments:",
+          "  - global.md",
+        ].join("\n"),
+      )
+
+      const command = await parseCommand(["--dir", dir, "prompt"])
+
+      expect(command.type).toBe("run")
+      if (command.type !== "run") return
+      expect(command.options.maxAttempts).toBe(4)
+      expect(command.options.baseRef).toBe("trunk")
+      expect(command.options.pipeline.name).toBe("lean")
+      expect(stepNames(command.options.pipeline)).toEqual(["implementer"])
+      expect(command.options.files).toEqual(["global.md"])
+    } finally {
+      if (previousHome === undefined) delete process.env.ARCHER_HOME
+      else process.env.ARCHER_HOME = previousHome
+    }
   })
 
   test("CLI flags always win over config defaults", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,10 +1,21 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import "./env"
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterAll, describe, expect, test } from "bun:test"
 
-import { buildAgentRegistry, loadArcherConfig, parseArcherConfig, selectPipelineSpec, ConfigError } from "../src/config"
+import { builtInAgents } from "../src/pipeline"
+import {
+  buildAgentRegistry,
+  loadArcherConfig,
+  parseArcherConfig,
+  selectPipelineSpec,
+  writeDefaultArcherConfig,
+  writeDefaultProjectConfig,
+  ConfigError,
+} from "../src/config"
 
 const dirs: string[] = []
 
@@ -29,6 +40,42 @@ describe("config loading", () => {
   test("no config file means no config", async () => {
     const dir = await projectDir()
     expect(await loadArcherConfig(dir)).toBeUndefined()
+  })
+
+  test("the default config template is valid and explicit", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-default-config-"))
+    dirs.push(dir)
+    const path = join(dir, "config.yaml")
+    await writeDefaultArcherConfig(path)
+
+    const body = await readFile(path, "utf8")
+    const config = parseArcherConfig(body, path, dir)
+
+    expect(body).toContain("# maxAttempts: 2")
+    expect(body).toContain("# baseRef: main")
+    expect(body).toContain("# pipeline: default")
+    expect(body).toContain("# interactiveModel: openai/gpt-5.5#xhigh")
+    expect(body).toContain("# appRunCommand: pnpm dev")
+    expect(body).toContain("# agents:")
+    expect(body).toContain("#   implementer:")
+    expect(body).toContain("#   design-polisher:")
+    expect(body).toContain("#   api-reviewer:")
+    expect(config.defaults).toEqual({})
+    expect(config.agents).toEqual({})
+    for (const agent of builtInAgents) {
+      expect(await readFile(join(dir, "agents", `${agent.name}.md`), "utf8")).toContain("#")
+    }
+    expect(config.pipelines.default?.steps).toEqual([
+      { agent: "implementer", reports: "none" },
+      "human-review",
+      "patterns",
+      "security",
+      "design",
+      { agent: "tests", reports: "none" },
+      { agent: "adversarial", reports: "all" },
+    ])
+    expect(config.permissions).toEqual({ allow: [], deny: [] })
+    expect(config.attachments).toEqual([])
   })
 
   test("an empty file is a valid, empty config", () => {
@@ -90,6 +137,92 @@ describe("config loading", () => {
     expect(config.attachments).toEqual(["docs/architecture.md"])
   })
 
+  test("loads global config before project overrides", async () => {
+    const previousHome = process.env.ARCHER_HOME
+    const home = await mkdtemp(join(tmpdir(), "archer-config-home-"))
+    dirs.push(home)
+    process.env.ARCHER_HOME = home
+
+    try {
+      await writeFile(
+        join(home, "config.yaml"),
+        [
+          "defaults:",
+          "  maxAttempts: 4",
+          "  baseRef: trunk",
+          "  pipeline: global-only",
+          "pipelines:",
+          "  global-only:",
+          "    steps:",
+          "      - implementer",
+          "permissions:",
+          "  allow:",
+          '    - "global-check *"',
+          "attachments:",
+          "  - global.md",
+        ].join("\n"),
+      )
+      const dir = await projectDir(
+        [
+          "defaults:",
+          "  maxAttempts: 1",
+          "  pipeline: quick",
+          "pipelines:",
+          "  quick:",
+          "    steps:",
+          "      - tests",
+          "permissions:",
+          "  deny:",
+          '    - "local-danger *"',
+          "attachments:",
+          "  - local.md",
+        ].join("\n"),
+      )
+
+      const config = await loadArcherConfig(dir)
+
+      expect(config?.defaults).toEqual({ maxAttempts: 1, baseRef: "trunk", pipeline: "quick" })
+      expect(config?.permissions).toEqual({ allow: ["global-check *"], deny: ["local-danger *"] })
+      expect(config?.attachments).toEqual(["global.md", "local.md"])
+      expect(selectPipelineSpec(config, "global-only").steps).toEqual(["implementer"])
+      expect(selectPipelineSpec(config, "quick").steps).toEqual(["tests"])
+    } finally {
+      if (previousHome === undefined) delete process.env.ARCHER_HOME
+      else process.env.ARCHER_HOME = previousHome
+    }
+  })
+
+  test("writes default config without overwriting unless forced", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-config-write-"))
+    dirs.push(dir)
+    const path = join(dir, "config.yaml")
+
+    expect(await writeDefaultArcherConfig(path)).toEqual({ path, created: true })
+    expect(await readFile(path, "utf8")).toContain("version: 1")
+    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+
+    await writeFile(path, "version: 1\nattachments:\n  - custom.md\n")
+    await writeFile(join(dir, "agents", "implementer.md"), "# Custom Implementer\n")
+    expect(await writeDefaultArcherConfig(path)).toEqual({ path, created: false })
+    expect(await readFile(path, "utf8")).toContain("custom.md")
+    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Custom Implementer")
+
+    expect(await writeDefaultArcherConfig(path, true)).toEqual({ path, created: true })
+    expect(await readFile(path, "utf8")).not.toContain("custom.md")
+    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+  })
+
+  test("writes project default config under .archer", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-project-config-"))
+    dirs.push(dir)
+    const path = join(dir, ".archer", "config.yaml")
+
+    expect(await writeDefaultProjectConfig(dir)).toEqual({ path, created: true })
+    expect(await writeDefaultProjectConfig(dir)).toEqual({ path, created: false })
+    expect(await readFile(path, "utf8")).toContain("pipelines:")
+    expect(await readFile(join(dir, ".archer", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+  })
+
   test("rejects configs with errors that point at the offending field", async () => {
     expect(() => parse("version: 2")).toThrow("version")
     expect(() => parse("defaults:\n  maxAttempts: 0")).toThrow("defaults.maxAttempts must be a positive integer")
@@ -107,10 +240,31 @@ describe("config loading", () => {
 
   test("project agents must bring a prompt file", async () => {
     const without = await projectDir()
-    expect(() => parse("agents:\n  ghost: {}", without)).toThrow("needs a prompt at .archer/agents/ghost.md")
+    expect(() => parse("agents:\n  ghost: {}", without)).toThrow("needs a prompt at agents/ghost.md next to the config")
 
     const withPrompt = await projectDir(undefined, ["ghost"])
     expect(() => parse("agents:\n  ghost: {}", withPrompt)).not.toThrow()
+  })
+
+  test("global project agents use same-name prompts next to global config", async () => {
+    const previousHome = process.env.ARCHER_HOME
+    const home = await mkdtemp(join(tmpdir(), "archer-global-custom-agent-"))
+    const target = await projectDir()
+    dirs.push(home)
+    process.env.ARCHER_HOME = home
+
+    try {
+      await mkdir(join(home, "agents"), { recursive: true })
+      await writeFile(join(home, "config.yaml"), "agents:\n  ghost: {}")
+      await writeFile(join(home, "agents", "ghost.md"), "# Ghost\n\nGlobal prompt.")
+
+      const config = await loadArcherConfig(target)
+
+      expect(config?.agents.ghost).toEqual({})
+    } finally {
+      if (previousHome === undefined) delete process.env.ARCHER_HOME
+      else process.env.ARCHER_HOME = previousHome
+    }
   })
 
   test("built-in overrides don't need a prompt, aliases and reserved names are rejected", async () => {

--- a/test/env.ts
+++ b/test/env.ts
@@ -1,0 +1,6 @@
+import { mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+process.env.ARCHER_HOME ??= join(tmpdir(), `archer-test-home-${process.pid}`)
+mkdirSync(process.env.ARCHER_HOME, { recursive: true })


### PR DESCRIPTION
## Summary
- create default global/project config files via install and archer init
- load config from global and project scopes with CLI override precedence
- generate default agent prompt Markdown files and load prompts by name
- document config/init behavior and isolate tests from real user config

## Tests
- bun run typecheck
- bun test