### PR TITLE
feat(config): global config + `archer config` TUI editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,29 @@
 # archer
 
-Sequential [OpenCode](https://opencode.ai) agent pipeline for implementing features on software repos. It works with Flutter, web, backend, CLI, and mixed projects by detecting the repo's existing stack and conventions. Takes a PRD, runs agents in chain, and leaves one commit per phase.
+Sequential [OpenCode](https://opencode.ai) agent pipeline for implementing features on software repos. It works with Flutter, web, backend, CLI, and mixed projects by detecting the repo's existing stack and conventions. Takes a PRD, runs agents in chain, and leaves one commit per step.
+
+Pipelines are data, not code: archer ships a built-in `default` pipeline, and a project can define its own — any number of steps, its own agents, its own models, with `human-review` gates anywhere — in `.archer/config.yaml`.
 
 Archer is written in Bun + TypeScript and uses `@opencode-ai/sdk` to control OpenCode. The SDK starts/controls the OpenCode server; Archer no longer manually calls `opencode run` nor parses stdout.
 
-## The Pipeline
+## The default pipeline
 
 ```
-PRD ──► implementer ──► human-review ──► pattern-auditor ──► security-auditor ──► design-polisher ──► test-engineer ──► adversarial-reviewer
-         │                                │                    │                    │                  │                │
-         └────────────────────────────────┴────────────────────┴────────────────────┴──────────────────┴────────────────┘
-                                                              commit per phase
+PRD ──► implementer ──► human-review ──► patterns ──► security ──► design ──► tests ──► adversarial
+         │                                │            │            │          │         │
+         └────────────────────────────────┴────────────┴────────────┴──────────┴─────────┘
+                                                              commit per step
 ```
 
-| Phase | Model | What it does |
-|---|---|---|
-| `implementer` | `openai/gpt-5.5#xhigh` | Implements the feature respecting repo patterns |
-| `human-review` | interactive checkpoint | Runs the app, waits for approval, or hands control to OpenCode for manual iteration |
-| `patterns` | `openai/gpt-5.5#xhigh` | Refactors without changing behavior, aligns with the rest of the code |
-| `security` | `openai/gpt-5.5#xhigh` | Audits and fixes security issues |
-| `design` | `anthropic/claude-opus-4-7` | Polishes UI following the repo's design system |
-| `tests` | `openai/gpt-5.5#xhigh` | Automated tests + relevant E2E/integration coverage |
-| `adversarial` | `anthropic/claude-opus-4-7` | Final adversarial review before PR creation |
+| Step | Agent | Model | What it does |
+|---|---|---|---|
+| `implementer` | `implementer` | `openai/gpt-5.5#xhigh` | Implements the feature respecting repo patterns |
+| `human-review` | — | interactive checkpoint | Runs the app, waits for approval, or hands control to OpenCode for manual iteration |
+| `patterns` | `pattern-auditor` | `openai/gpt-5.5#xhigh` | Refactors without changing behavior, aligns with the rest of the code |
+| `security` | `security-auditor` | `openai/gpt-5.5#xhigh` | Audits and fixes security issues |
+| `design` | `design-polisher` | `anthropic/claude-opus-4-7` | Polishes UI following the repo's design system |
+| `tests` | `test-engineer` | `openai/gpt-5.5#xhigh` | Automated tests + relevant E2E/integration coverage |
+| `adversarial` | `adversarial-reviewer` | `anthropic/claude-opus-4-7` | Final adversarial review before PR creation |
 
 ## Requirements
 
@@ -70,13 +72,16 @@ archer --prompt-file prd.md
 # attach files or directories to all phases
 archer --prompt-file prd.md --file src/features/onboarding --file tests/onboarding.test.ts
 
-# only one phase
+# run a project-defined pipeline (see "Project configuration" below)
+archer --prompt-file bug.md --pipeline bug-fix
+
+# only one step
 archer --prompt-file prd.md --only implementer
 
-# skip phases
+# skip steps
 archer --prompt-file prd.md --skip security,design
 
-# force a different model for all phases
+# force a different model for all steps
 archer --prompt-file prd.md --model anthropic/claude-sonnet-4-6
 
 # disable the OpenTUI progress footer
@@ -103,6 +108,11 @@ archer --resume 20260519-103045-x7q2
 # Without a TTY (pipes/CI) it falls back to a plain listing.
 archer runs
 archer runs 20260519-103045-x7q2
+
+# view and edit the global (~/.archer) and current project config in a TUI:
+# two tabs (Global / Project), pick models with autocomplete, edit pipelines
+# and steps, or initialize a starter config when none exists.
+archer config
 
 # auto-allow ask-level permissions (the hard denylist still applies)
 archer --prompt-file prd.md --yolo
@@ -138,7 +148,7 @@ approve? [o]nce, [a]lways, [r]eject >
 - `a` allows future calls matching the same pattern for the rest of the run.
 - `r` rejects the call (the agent receives a denial and decides what to do next).
 
-In non-interactive runs (no TTY), unknown commands are auto-rejected and logged. Tighten the policy further or expand the allowlist in `src/agents.ts` (`bashPolicy`).
+In non-interactive runs (no TTY), unknown commands are auto-rejected and logged. Per-project, extend the lists with `permissions.allow`/`permissions.deny` in `.archer/config.yaml`; the global policy lives in `src/agents.ts` (`bashPolicy`).
 
 Archer also allowlists the target repo's own `package.json` scripts whose names look like checks (`test`, `lint`, `typecheck`, `type-check`, `check`, `build`, `format`, `validate`, including suffixed forms like `test:unit`), excluding anything whose name suggests side effects (`deploy`, `publish`, `release`, `migrate`, `seed`, `reset`). Note the trust model: agents can edit the repo, including script bodies, so allowlisted scripts mean trusting the repo's contents — the denylist protects against accidents, it is not a security boundary against a malicious agent.
 
@@ -151,6 +161,86 @@ Archer also allowlists the target repo's own `package.json` scripts whose names 
 Before each commit Archer scans the staged files for common secret names (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `credentials*`, `*.p12`, `*.keystore`, ...). If any match, the commit is aborted, the index reset, and Archer asks you to add them to `.gitignore` (or delete them) before re-running. Combined with `--include-dirty` this is the only line of defense against accidentally publishing a secret your working tree had lying around — review the resulting commits with `git show` before pushing.
 
 During `human-review`, Archer waits 10 seconds for an explicit action. If nobody answers, it prepares the configured app command in the target worktree. By default the app command is disabled; pass `--app-run-command "pnpm dev"`, `--app-run-command "flutter run"`, or the repo's equivalent. Archer only launches a Flutter emulator when `--emulator <id>` is explicitly provided.
+
+## Project configuration (`.archer/config.yaml`)
+
+A project can reshape archer entirely from one file. Everything is optional — the file only declares what differs from the defaults. The same schema also lives globally at `~/.archer/config.yaml` (see [Global configuration](#global-configuration)); the project file is merged on top of it.
+
+```yaml
+version: 1
+
+defaults:
+  model: openai/gpt-5.5#xhigh     # provider/model[#variant], used by steps with no model of their own
+  maxAttempts: 2
+  baseRef: main
+  pipeline: quick                  # pipeline used when -p/--pipeline is not given
+  appRunCommand: pnpm dev          # app command for human-review gates
+  emulator: Pixel_8                # optional Flutter emulator for human-review gates
+  interactiveModel: openai/gpt-5.5#xhigh
+
+# Project agents: the prompt lives at .archer/agents/<name>.md (required).
+# Naming a built-in agent here overrides its model/temperature instead.
+agents:
+  api-reviewer:
+    description: Reviews public API consistency
+    model: anthropic/claude-opus-4-7
+    temperature: 0.1
+
+pipelines:
+  quick:
+    description: Implementation, manual gate, tests
+    steps:
+      - implementer                # string = agent (or alias) with that step name
+      - human-review               # reserved keyword: manual review gate, placeable anywhere, repeatable
+      - agent: tests
+        maxAttempts: 3
+  api:
+    steps:
+      - implementer
+      - api-reviewer               # project agent defined above
+      - human-review
+      - agent: security
+        reports: all               # attach every previous step report (default: the nearest one)
+      - agent: adversarial
+        name: final-check          # step name (report file, commit prefix, --only/--skip)
+        reports: [implementer, security]
+
+permissions:                       # additive only; a config allow can never undo a deny
+  allow:
+    - "supabase gen types*"
+  deny:
+    - "stripe *"
+
+attachments:                       # attached to every step, like repeatable --file flags
+  - docs/architecture.md
+```
+
+The rules:
+
+- **Precedence**: CLI flag > project config > global config > built-in default. Within a config, for models specifically: step `model` > agent `model` > `defaults.model` > the agent's built-in preference (opus for design/adversarial) > `openai/gpt-5.5#xhigh`. `--model` overrides everything.
+- **Conventions over wiring**: every agent step gets the PRD, the cumulative diff against the base branch (except the first step; opt out with `diff: false`), and the previous step's report (`reports: previous|all|none|[names]`). Its report lands at `reports/<step>.md` and its commit is `archer(<step>): …`.
+- **Aliases**: the built-in agents answer to their short names in steps — `patterns`, `security`, `design`, `tests`, `adversarial` — as well as their full names.
+- **Project pipelines shadow built-ins**: defining `pipelines.default` replaces the built-in default.
+- **`--no-human-review`** (and non-TTY runs) drop every `human-review` gate from the pipeline.
+- **Resume is frozen**: the resolved pipeline is persisted in the run's `metadata.json`; `--resume` replays it even if the config changed since.
+- **Permissions are additive**: `permissions.deny` extends the hard denylist, `permissions.allow` extends the allowlist, deny always wins, and there is deliberately no way for a repo to grant itself `--yolo`.
+
+## Global configuration
+
+`~/.archer/config.yaml` uses the exact same schema as the project file and sets your personal defaults across every repo — most usefully `defaults.model`, but also custom agents and pipelines. Global custom agents bring their prompt at `~/.archer/agents/<name>.md` (the same convention a project uses, relative to your home).
+
+Both files are merged before a run, with the project winning: `defaults`, `agents`, and `pipelines` merge by key/name (a project entry overrides the global one of the same name), while `permissions` and `attachments` concatenate (global first; `deny` still wins). The home directory archer reads can be relocated with `ARCHER_HOME` (it points at the directory that holds `.archer`, and also moves `~/.archer/runs`).
+
+## Editing config interactively (`archer config`)
+
+`archer config` opens a TUI to view and edit both configs without hand-editing YAML — two tabs, **Global** (`~/.archer/config.yaml`) and **Project** (the current repo's `.archer/config.yaml`):
+
+- Pick models from an autocompleting list: it queries OpenCode for the models your enabled providers expose (including reasoning variants like `#xhigh`), falling back to the full [models.dev](https://models.dev) catalog when OpenCode can't answer, and always accepts a free-typed `provider/model[#variant]`.
+- Edit `defaults` (model, interactiveModel, maxAttempts, baseRef, pipeline, app command, emulator) and each agent's model/temperature override.
+- Browse pipelines and their steps; add, delete, reorder steps, set a per-step model or max-attempts, and add new pipelines. Permissions and attachments are shown read-only (edit those in the YAML).
+- When a tab has no file yet, `initialize` writes a starter config (the built-in `default` pipeline, expanded and ready to edit).
+
+Keys: `↑/↓` move, `enter` edit/expand, `tab` switch tab, `a` add, `d` delete a step, `shift+↑/↓` reorder a step, `t` agent temperature, `m` step max-attempts, `s` save the active tab, `q` quit. Saving re-validates and rewrites clean YAML (comments are not preserved); the dashboard never paints backgrounds, like the run TUIs. Needs an interactive terminal.
 
 ## Project Context And Custom Agents
 
@@ -168,16 +258,14 @@ Built-in agent prompts live as Markdown files under `prompts/`. A project can fu
 
 ```text
 .archer/
+├── config.yaml          # defaults, agents, pipelines, permissions, attachments
 └── agents/
-    ├── implementer.md
+    ├── implementer.md   # overrides the built-in implementer prompt
     ├── pattern-auditor.md
-    ├── security-auditor.md
-    ├── design-polisher.md
-    ├── test-engineer.md
-    └── adversarial-reviewer.md
+    └── api-reviewer.md  # prompt for a project agent declared in config.yaml
 ```
 
-When a project override exists, it replaces that agent's built-in prompt completely. Archer still appends its non-replaceable runtime safety guard rails from `prompts/runtime-safety.md`.
+When a project override exists, it replaces that agent's built-in prompt completely. Project agents declared in `config.yaml` must bring their prompt at `.archer/agents/<name>.md` (validated at startup). In both cases Archer still appends its non-replaceable runtime safety guard rails from `prompts/runtime-safety.md`.
 
 ## Efficient Attachments
 
@@ -213,7 +301,7 @@ Each invocation creates `~/.archer/runs/<run-id>/`:
 └── SUMMARY.md
 ```
 
-`metadata.json` records each phase's status, session ID, timing, cost, tokens, and model as the run progresses (written atomically, debounced). On `--resume`, phases that already wrote their report are restored in the dashboard with their real duration, cost, and session — and their session can still be opened by clicking the pipeline row.
+`metadata.json` records the resolved pipeline the run executes plus each step's status, session ID, timing, cost, tokens, and model as the run progresses (written atomically, debounced). On `--resume`, the frozen pipeline is replayed — even if `.archer/config.yaml` changed since — and steps that already wrote their report are restored in the dashboard with their real duration, cost, and session, which can still be opened by clicking the pipeline row.
 
 The run dir is deleted on successful completion unless `--keep-run-dir`. If it fails, it's preserved for inspecting reports, diffs, and logs.
 
@@ -242,10 +330,14 @@ archer/
 │   ├── permissions.ts   # live permission gate for tool calls that fall outside the allowlist
 │   ├── attachments.ts   # FilePartInput for --file and internal attachments
 │   ├── git.ts           # diff, commit, and pre-commit secret scan
-│   ├── workspace.ts     # run dir
+│   ├── workspace.ts     # run dir, ~/.archer home (ARCHER_HOME), global config/agents paths
 │   ├── runs.ts          # interactive run-history browser (archer runs)
-│   ├── metadata.ts      # per-run metadata.json for --resume restore
-│   └── phases.ts        # declarative phase definition
+│   ├── runs-tui.ts      # OpenTUI run-history browser rendering
+│   ├── metadata.ts      # per-run metadata.json: frozen pipeline + --resume restore
+│   ├── config.ts        # config loader/validation, global+project merge, YAML writer
+│   ├── config-tui.ts    # interactive config editor (archer config)
+│   ├── model-catalog.ts # available-model list via OpenCode SDK, models.dev fallback
+│   └── pipeline.ts      # built-in agents/pipeline and pipeline-spec resolution
 ├── prompts/             # built-in agent prompts and runtime safety guard rails
 ├── test/                # unit tests for CLI/orchestration
 ├── package.json

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url"
 import type { AgentConfig, Config } from "@opencode-ai/sdk/v2"
 import { builtInAgents } from "./pipeline"
 import type { AgentSpec, PermissionAdditions } from "./types"
+import { globalAgentsDir } from "./workspace"
 
 const sourceDir = dirname(fileURLToPath(import.meta.url))
 const builtInPromptsDir = join(sourceDir, "..", "prompts")
@@ -33,7 +34,8 @@ export function opencodeConfig(
 }
 
 export function loadAgentPrompt(agentName: string, targetDir = process.cwd()) {
-  const agentPrompt = readProjectAgentPrompt(agentName, targetDir) ?? readBuiltInPrompt(agentName)
+  // Precedence mirrors config merge: project override > global override > built-in.
+  const agentPrompt = readProjectAgentPrompt(agentName, targetDir) ?? readGlobalAgentPrompt(agentName) ?? readBuiltInPrompt(agentName)
   const safetyPrompt = readBuiltInPrompt(runtimeSafetyPrompt)
   return [agentPrompt.trimEnd(), "", "---", "", safetyPrompt.trim()].join("\n")
 }
@@ -48,6 +50,12 @@ export function builtInPromptPath(promptName: string) {
 
 function readProjectAgentPrompt(agentName: string, targetDir: string) {
   const path = projectAgentPromptPath(agentName, targetDir)
+  if (!isFile(path)) return undefined
+  return readFileSync(path, "utf8")
+}
+
+function readGlobalAgentPrompt(agentName: string) {
+  const path = join(globalAgentsDir(), `${agentName}.md`)
   if (!isFile(path)) return undefined
   return readFileSync(path, "utf8")
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
-import { buildAgentRegistry, loadArcherConfig, selectPipelineSpec, type ArcherDefaults } from "./config"
+import { buildAgentRegistry, loadMergedArcherConfig, selectPipelineSpec, type ArcherDefaults } from "./config"
 import { defaultGptModel, defaultGptVariant, defaultPipeline, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
 import { parseModel, run } from "./runner"
 import { browseRuns } from "./runs"
@@ -41,6 +41,7 @@ export type CliCommand =
   | { type: "help"; text: string }
   | { type: "run"; options: RunOptions }
   | { type: "runs"; runID?: string }
+  | { type: "config"; targetDir: string }
 
 export async function parseAndRun(argv: string[]) {
   const command = await parseCommand(argv)
@@ -51,6 +52,12 @@ export async function parseAndRun(argv: string[]) {
   if (command.type === "runs") {
     const resolution = await browseRuns(command.runID)
     if (resolution.type === "resume") await run(await resumeOptions(resolution.runID, resolution.targetDir))
+    return
+  }
+  if (command.type === "config") {
+    // Imported lazily so normal runs never pull in the opentui editor.
+    const { editConfigTui } = await import("./config-tui")
+    await editConfigTui({ targetDir: command.targetDir })
     return
   }
 
@@ -72,6 +79,10 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
     if (rest.length > 1) throw new Error("usage: archer runs [run-id]")
     if (rest[0] !== undefined && !isValidRunID(rest[0])) throw new Error(`invalid run id: ${rest[0]}`)
     return { type: "runs", runID: rest[0] }
+  }
+  if (argv[0] === "config") {
+    if (argv.length > 1) throw new Error("usage: archer config")
+    return { type: "config", targetDir: process.cwd() }
   }
 
   const parsed = parseArgs(argv)
@@ -98,7 +109,7 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
 
 /** Applies the precedence chain and resolves the pipeline the run will execute. */
 export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOptions, "prompt">> {
-  const config = await loadArcherConfig(parsed.targetDir)
+  const config = await loadMergedArcherConfig(parsed.targetDir)
   const defaults = config?.defaults ?? {}
 
   const humanReview = parsed.humanReview ?? Boolean(process.stdin.isTTY && process.stdout.isTTY)
@@ -301,10 +312,12 @@ Usage:
   archer --prompt-file prd.md --file lib/onboarding --file test/onboarding_test.dart
   archer --pipeline bug-fix --prompt-file bug.md
   archer runs [run-id]
+  archer config
 
 Commands:
   runs [run-id]            Browse run history: resume a run, read its summary/reports,
                            or open a subshell in its run dir (under ~/.archer/runs)
+  config                   View and edit the global (~/.archer) and current project config in a TUI
 
 Flags:
   --prompt-file <path>     Read the PRD/prompt from a file
@@ -338,6 +351,7 @@ Project config (.archer/config.yaml):
   pipelines:               named step lists mixing agents and human-review gates
   permissions:             allow/deny additions to the bash policy (deny always wins)
   attachments:             files attached to every step
-  CLI flags always win over config defaults.
+  The same schema lives globally at ~/.archer/config.yaml; project config merges on top.
+  Precedence: CLI flags > project config > global config > built-in defaults.
 `
 }

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -1,0 +1,1138 @@
+import { join } from "node:path"
+
+import { BoxRenderable, StyledText, TextRenderable, bold, createCliRenderer, fg } from "@opentui/core"
+
+import {
+  buildAgentRegistry,
+  defaultConfigTemplate,
+  isValidModelString,
+  loadArcherConfig,
+  loadGlobalArcherConfig,
+  writeArcherConfig,
+  type ArcherConfig,
+  type ArcherDefaults,
+  type ConfigAgent,
+} from "./config"
+import { listModels, type ModelChoice } from "./model-catalog"
+import { humanReviewStep, type PipelineSpec, type StepSpec } from "./pipeline"
+import {
+  joinLines,
+  padBetween,
+  paletteForTerminal,
+  plain,
+  raw,
+  setTheme,
+  spinnerFrame,
+  terminalBackgroundHex,
+  theme,
+  truncate,
+} from "./tui-theme"
+import { archerRoot, globalConfigPath } from "./workspace"
+
+import type { BoxOptions, CliRenderer, KeyEvent, TextChunk } from "@opentui/core"
+import type { PaletteColor } from "./tui-theme"
+
+export async function editConfigTui(options: { targetDir: string }): Promise<void> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error("archer config needs an interactive terminal")
+  }
+  const [globalConfig, projectConfig] = await Promise.all([loadGlobalArcherConfig(), loadArcherConfig(options.targetDir)])
+
+  const renderer = await createCliRenderer({
+    screenMode: "alternate-screen",
+    consoleMode: "console-overlay",
+    exitOnCtrlC: false,
+    targetFps: 12,
+  })
+  const mode = await renderer.waitForThemeMode(1_000).catch(() => null)
+  setTheme(paletteForTerminal(mode, terminalBackgroundHex(renderer)))
+  await new ConfigEditor(renderer, options.targetDir, globalConfig, projectConfig).result
+}
+
+type Tab = {
+  readonly title: string
+  readonly path: string
+  /** Where agent-prompt validation resolves on save: archerHome() for global, the repo for project. */
+  readonly validateDir: string
+  config?: ArcherConfig
+  dirty: boolean
+}
+
+type ChooseItem = { value: string; label: string; hint?: string }
+
+type Modal =
+  | { kind: "input"; title: string; help: string; value: string; error?: string; validate?: (value: string) => string | undefined; commit: (value: string) => void }
+  | { kind: "model"; title: string; filter: string; loading: boolean; options: ModelChoice[]; index: number; commit: (value: string | undefined) => void }
+  | { kind: "choose"; title: string; filter: string; options: ChooseItem[]; index: number; commit: (value: string) => void }
+  | { kind: "confirm"; title: string; message: string; onYes: () => void }
+  | { kind: "message"; title: string; message: string }
+
+/** What the focused row represents; drives `enter` and the secondary keys. */
+type RowMeta =
+  | { t: "initialize" }
+  | { t: "default"; field: DefaultField }
+  | { t: "agent"; name: string }
+  | { t: "pipeline"; name: string }
+  | { t: "step"; pipeline: string; index: number }
+  | { t: "add-step"; pipeline: string }
+  | { t: "add-pipeline" }
+
+type DefaultField = { key: keyof ArcherDefaults; type: "model" | "number" | "string" }
+
+type Row = {
+  chunks: (selected: boolean, width: number) => TextChunk[]
+  meta?: RowMeta
+}
+
+const defaultFields: DefaultField[] = [
+  { key: "model", type: "model" },
+  { key: "interactiveModel", type: "model" },
+  { key: "maxAttempts", type: "number" },
+  { key: "baseRef", type: "string" },
+  { key: "pipeline", type: "string" },
+  { key: "appRunCommand", type: "string" },
+  { key: "emulator", type: "string" },
+]
+
+const modalListHeight = 12
+
+/** Synthetic top entry in the model picker; its empty value means "inherit / clear the override". */
+const clearOption: ModelChoice = { value: "", label: "inherit — clear override", providerID: "" }
+
+export class ConfigEditor {
+  readonly result: Promise<void>
+  private resolveResult!: () => void
+
+  private readonly tabs: [Tab, Tab]
+  private active = 0
+  private selected = 0
+  private scroll = 0
+  private readonly expanded = new Set<string>()
+  private modal?: Modal
+  private rows: Row[] = []
+
+  private readonly ticker: ReturnType<typeof setInterval>
+  private readonly headerText: TextRenderable
+  private readonly listText: TextRenderable
+  private readonly detailText: TextRenderable
+  private readonly detailBox: BoxRenderable
+  private readonly footerText: TextRenderable
+  private readonly overlay: BoxRenderable
+  private readonly modalBox: BoxRenderable
+  private readonly modalText: TextRenderable
+  private readonly paletteTargets: Array<{ box: BoxRenderable; background: PaletteColor; border?: PaletteColor }> = []
+
+  private readonly handleThemeMode = (mode: unknown) => {
+    if (mode !== "dark" && mode !== "light") return
+    setTheme(paletteForTerminal(mode, terminalBackgroundHex(this.renderer)))
+    this.applyPalette()
+    this.render()
+  }
+
+  private readonly handleKeyPress = (key: KeyEvent) => {
+    if ((key.ctrl && key.name === "c") || key.raw === "") {
+      key.preventDefault()
+      key.stopPropagation()
+      this.tryQuit()
+      return
+    }
+    key.preventDefault()
+    key.stopPropagation()
+    if (this.modal) this.handleModalKey(key)
+    else this.handleListKey(key)
+  }
+
+  constructor(
+    private readonly renderer: CliRenderer,
+    targetDir: string,
+    globalConfig: ArcherConfig | undefined,
+    projectConfig: ArcherConfig | undefined,
+  ) {
+    this.tabs = [
+      { title: "Global", path: globalConfigPath(), validateDir: archerRoot(), config: globalConfig, dirty: false },
+      { title: "Project", path: join(targetDir, ".archer", "config.yaml"), validateDir: targetDir, config: projectConfig, dirty: false },
+    ]
+    this.result = new Promise((resolve) => {
+      this.resolveResult = resolve
+    })
+
+    const shell = new BoxRenderable(renderer, {
+      id: "archer-config-shell",
+      width: "100%",
+      height: "100%",
+      backgroundColor: theme.bg,
+      flexDirection: "column",
+      paddingX: 1,
+    })
+
+    const header = this.panel({ id: "archer-config-header", height: 4, borderColor: theme.border, backgroundColor: theme.bg })
+    const body = new BoxRenderable(renderer, { id: "archer-config-body", width: "100%", flexGrow: 1, flexDirection: "row", gap: 1 })
+    const list = this.panel({
+      id: "archer-config-list",
+      height: "100%",
+      flexGrow: 1,
+      borderColor: theme.borderDim,
+      backgroundColor: theme.bg,
+      title: " configuration ",
+      titleAlignment: "left",
+    })
+    const detail = this.panel({
+      id: "archer-config-detail",
+      width: this.detailWidth(),
+      height: "100%",
+      borderColor: theme.borderDim,
+      backgroundColor: theme.bg,
+      title: " field ",
+      titleAlignment: "left",
+    })
+    const footer = this.panel({ id: "archer-config-footer", height: 3, borderColor: theme.borderDim, backgroundColor: theme.bg })
+
+    this.headerText = header.text
+    this.listText = list.text
+    this.detailText = detail.text
+    this.detailBox = detail.box
+    this.footerText = footer.text
+
+    this.paletteTargets.push(
+      { box: shell, background: "bg" },
+      { box: header.box, background: "bg", border: "border" },
+      { box: list.box, background: "bg", border: "borderDim" },
+      { box: detail.box, background: "bg", border: "borderDim" },
+      { box: footer.box, background: "bg", border: "borderDim" },
+    )
+
+    body.add(list.box)
+    body.add(detail.box)
+    shell.add(header.box)
+    shell.add(body)
+    shell.add(footer.box)
+    renderer.root.add(shell)
+
+    this.overlay = new BoxRenderable(renderer, {
+      id: "archer-config-overlay",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: "100%",
+      height: "100%",
+      zIndex: 100,
+      alignItems: "center",
+      justifyContent: "center",
+      visible: false,
+    })
+    this.modalBox = new BoxRenderable(renderer, {
+      id: "archer-config-modal",
+      border: true,
+      borderStyle: "rounded",
+      borderColor: theme.accent,
+      backgroundColor: theme.overlay,
+      paddingX: 2,
+      paddingY: 1,
+      title: " edit ",
+      titleAlignment: "left",
+    })
+    this.modalText = new TextRenderable(renderer, { content: "", fg: theme.text, width: "100%", height: "100%" })
+    this.modalBox.add(this.modalText)
+    this.overlay.add(this.modalBox)
+    renderer.root.add(this.overlay)
+    this.paletteTargets.push({ box: this.modalBox, background: "overlay", border: "accent" })
+
+    renderer.keyInput.on("keypress", this.handleKeyPress)
+    renderer.on("theme_mode", this.handleThemeMode)
+
+    this.ticker = setInterval(() => this.render(), 250)
+    this.render()
+    this.selected = this.firstSelectable()
+    this.render()
+  }
+
+  private tab() {
+    return this.tabs[this.active]!
+  }
+
+  // ---- key handling -------------------------------------------------------
+
+  private handleListKey(key: KeyEvent) {
+    switch (key.name) {
+      case "tab":
+        this.active = this.active === 0 ? 1 : 0
+        this.selected = this.firstSelectable()
+        this.scroll = 0
+        this.render()
+        return
+      case "up":
+      case "k":
+        if (key.shift) this.moveStep(-1)
+        else this.moveSelection(-1)
+        return
+      case "down":
+      case "j":
+        if (key.shift) this.moveStep(1)
+        else this.moveSelection(1)
+        return
+      case "pageup":
+        this.moveSelection(-this.listHeight())
+        return
+      case "pagedown":
+        this.moveSelection(this.listHeight())
+        return
+      case "return":
+      case "linefeed":
+        this.activateRow()
+        return
+      case "s":
+        void this.save()
+        return
+      case "q":
+      case "escape":
+        this.tryQuit()
+        return
+      case "t":
+        this.editTemperature()
+        return
+      case "m":
+        this.editStepMaxAttempts()
+        return
+      case "d":
+        this.deleteStep()
+        return
+      case "a":
+        this.addUnderCursor()
+        return
+    }
+  }
+
+  private handleModalKey(key: KeyEvent) {
+    const modal = this.modal
+    if (!modal) return
+
+    if (modal.kind === "message") {
+      this.modal = undefined
+      this.render()
+      return
+    }
+    if (modal.kind === "confirm") {
+      if (key.name === "y") {
+        this.modal = undefined
+        modal.onYes()
+      } else if (key.name === "n" || key.name === "escape" || key.name === "q") {
+        this.modal = undefined
+      }
+      this.render()
+      return
+    }
+    if (key.name === "escape") {
+      this.modal = undefined
+      this.render()
+      return
+    }
+
+    if (modal.kind === "input") {
+      if (key.name === "return" || key.name === "linefeed") {
+        const error = modal.validate?.(modal.value)
+        if (error) {
+          modal.error = error
+        } else {
+          this.modal = undefined
+          modal.commit(modal.value)
+        }
+      } else if (key.name === "backspace") {
+        modal.value = modal.value.slice(0, -1)
+        modal.error = undefined
+      } else {
+        const char = typedChar(key)
+        if (char !== undefined) {
+          modal.value += char
+          modal.error = undefined
+        }
+      }
+      this.render()
+      return
+    }
+
+    // model + choose share filter/navigation behavior
+    const filtered = this.filteredOptions(modal)
+    if (key.name === "up") {
+      modal.index = Math.max(0, modal.index - 1)
+    } else if (key.name === "down") {
+      modal.index = Math.min(Math.max(0, filtered.length - 1), modal.index + 1)
+    } else if (key.name === "backspace") {
+      modal.filter = modal.filter.slice(0, -1)
+      modal.index = 0
+    } else if (key.name === "return" || key.name === "linefeed") {
+      this.commitOption(modal, filtered)
+      return
+    } else {
+      const char = typedChar(key)
+      if (char !== undefined) {
+        modal.filter += char
+        modal.index = 0
+      }
+    }
+    this.render()
+  }
+
+  private commitOption(modal: Modal & { kind: "model" | "choose" }, filtered: Array<ModelChoice | ChooseItem>) {
+    if (modal.kind === "model") {
+      const chosen = filtered[modal.index] as ModelChoice | undefined
+      if (chosen) {
+        this.modal = undefined
+        // The synthetic clear entry has an empty value: it means "inherit / clear".
+        modal.commit(chosen.value === "" ? undefined : chosen.value)
+        this.render()
+        return
+      }
+      // Nothing highlighted: accept the typed text as a free-form model id.
+      const text = modal.filter.trim()
+      if (!isValidModelString(text)) {
+        this.render()
+        return
+      }
+      this.modal = undefined
+      modal.commit(text)
+      this.render()
+      return
+    }
+    const chosen = filtered[modal.index] as ChooseItem | undefined
+    if (chosen) {
+      this.modal = undefined
+      modal.commit(chosen.value)
+    }
+    this.render()
+  }
+
+  private filteredOptions(modal: Modal): Array<ModelChoice | ChooseItem> {
+    if (modal.kind === "model") return modal.options.filter((option) => matches(modal.filter, option.value, option.label))
+    if (modal.kind === "choose") return modal.options.filter((option) => matches(modal.filter, option.value, option.label, option.hint ?? ""))
+    return []
+  }
+
+  // ---- actions ------------------------------------------------------------
+
+  private activateRow() {
+    const meta = this.rows[this.selected]?.meta
+    if (!meta) return
+    switch (meta.t) {
+      case "initialize":
+        this.tab().config = defaultConfigTemplate()
+        this.tab().dirty = true
+        this.selected = this.firstSelectable()
+        this.render()
+        return
+      case "default":
+        this.editDefault(meta.field)
+        return
+      case "agent":
+        this.editAgentModel(meta.name)
+        return
+      case "pipeline":
+        this.togglePipeline(meta.name)
+        return
+      case "step":
+        this.editStepModel(meta.pipeline, meta.index)
+        return
+      case "add-step":
+        this.addStep(meta.pipeline)
+        return
+      case "add-pipeline":
+        this.addPipeline()
+        return
+    }
+  }
+
+  private addUnderCursor() {
+    const meta = this.rows[this.selected]?.meta
+    if (meta?.t === "pipeline") this.addStep(meta.name)
+    else if (meta?.t === "step") this.addStep(meta.pipeline)
+    else if (meta?.t === "add-pipeline") this.addPipeline()
+  }
+
+  private editDefault(field: DefaultField) {
+    const config = this.tab().config
+    if (!config) return
+    const current = config.defaults[field.key]
+    if (field.type === "model") {
+      this.openModelPicker(`defaults.${field.key}`, typeof current === "string" ? current : undefined, (value) => {
+        setDefault(config.defaults, field.key, value)
+        this.markDirty()
+      })
+      return
+    }
+    if (field.type === "number") {
+      this.openInput(`defaults.${field.key}`, current === undefined ? "" : String(current), "positive integer, empty to clear", {
+        validate: (value) => (value.trim() === "" || isPositiveInt(value) ? undefined : "must be a positive integer"),
+        commit: (value) => {
+          setDefault(config.defaults, field.key, value.trim() === "" ? undefined : Number(value))
+          this.markDirty()
+        },
+      })
+      return
+    }
+    this.openInput(`defaults.${field.key}`, current === undefined ? "" : String(current), "text, empty to clear", {
+      commit: (value) => {
+        setDefault(config.defaults, field.key, value.trim() === "" ? undefined : value.trim())
+        this.markDirty()
+      },
+    })
+  }
+
+  private editAgentModel(name: string) {
+    const config = this.tab().config
+    if (!config) return
+    const current = config.agents[name]?.model
+    this.openModelPicker(`agents.${name}.model`, current, (value) => {
+      const entry: ConfigAgent = { ...config.agents[name] }
+      if (value === undefined) delete entry.model
+      else entry.model = value
+      if (Object.keys(entry).length === 0) delete config.agents[name]
+      else config.agents[name] = entry
+      this.markDirty()
+    })
+  }
+
+  private editTemperature() {
+    const meta = this.rows[this.selected]?.meta
+    const config = this.tab().config
+    if (!config || meta?.t !== "agent") return
+    const current = config.agents[meta.name]?.temperature
+    this.openInput(`agents.${meta.name}.temperature`, current === undefined ? "" : String(current), "0–2, empty to clear", {
+      validate: (value) => (value.trim() === "" || isTemperature(value) ? undefined : "must be a number between 0 and 2"),
+      commit: (value) => {
+        const entry: ConfigAgent = { ...config.agents[meta.name] }
+        if (value.trim() === "") delete entry.temperature
+        else entry.temperature = Number(value)
+        if (Object.keys(entry).length === 0) delete config.agents[meta.name]
+        else config.agents[meta.name] = entry
+        this.markDirty()
+      },
+    })
+  }
+
+  private editStepModel(pipelineName: string, index: number) {
+    const steps = this.tab().config?.pipelines[pipelineName]?.steps
+    const spec = steps?.[index]
+    if (!steps || spec === undefined || agentOf(spec) === humanReviewStep) return
+    const obj = asStepObject(spec)
+    this.openModelPicker(`${pipelineName}[${index + 1}].model`, obj.model, (value) => {
+      const next = { ...obj }
+      if (value === undefined) delete next.model
+      else next.model = value
+      steps[index] = collapseStep(next)
+      this.markDirty()
+    })
+  }
+
+  private editStepMaxAttempts() {
+    const meta = this.rows[this.selected]?.meta
+    if (meta?.t !== "step") return
+    const steps = this.tab().config?.pipelines[meta.pipeline]?.steps
+    const spec = steps?.[meta.index]
+    if (!steps || spec === undefined || agentOf(spec) === humanReviewStep) return
+    const obj = asStepObject(spec)
+    this.openInput(`${meta.pipeline}[${meta.index + 1}].maxAttempts`, obj.maxAttempts === undefined ? "" : String(obj.maxAttempts), "positive integer, empty to clear", {
+      validate: (value) => (value.trim() === "" || isPositiveInt(value) ? undefined : "must be a positive integer"),
+      commit: (value) => {
+        const next = { ...obj }
+        if (value.trim() === "") delete next.maxAttempts
+        else next.maxAttempts = Number(value)
+        steps[meta.index] = collapseStep(next)
+        this.markDirty()
+      },
+    })
+  }
+
+  private addStep(pipelineName: string) {
+    const config = this.tab().config
+    const pipeline = config?.pipelines[pipelineName]
+    if (!config || !pipeline) return
+    const options: ChooseItem[] = [
+      { value: humanReviewStep, label: humanReviewStep, hint: "manual review gate" },
+      ...buildAgentRegistry(config).map((agent) => ({ value: agent.name, label: agent.name, hint: agent.description })),
+    ]
+    this.modal = {
+      kind: "choose",
+      title: `add step to "${pipelineName}"`,
+      filter: "",
+      index: 0,
+      options,
+      commit: (value) => {
+        pipeline.steps.push(value)
+        this.expanded.add(this.expandKey(pipelineName))
+        this.markDirty()
+      },
+    }
+    this.render()
+  }
+
+  private deleteStep() {
+    const meta = this.rows[this.selected]?.meta
+    if (meta?.t !== "step") return
+    const steps = this.tab().config?.pipelines[meta.pipeline]?.steps
+    if (!steps) return
+    const agentSteps = steps.filter((step) => agentOf(step) !== humanReviewStep).length
+    if (agentSteps <= 1 && agentOf(steps[meta.index]!) !== humanReviewStep) {
+      this.message("Can't delete", "A pipeline needs at least one agent step.")
+      return
+    }
+    steps.splice(meta.index, 1)
+    this.markDirty()
+  }
+
+  private moveStep(direction: -1 | 1) {
+    const meta = this.rows[this.selected]?.meta
+    if (meta?.t !== "step") return
+    const steps = this.tab().config?.pipelines[meta.pipeline]?.steps
+    if (!steps) return
+    const target = meta.index + direction
+    if (target < 0 || target >= steps.length) return
+    ;[steps[meta.index], steps[target]] = [steps[target]!, steps[meta.index]!]
+    this.markDirty()
+    this.moveSelection(direction)
+  }
+
+  private addPipeline() {
+    const config = this.tab().config
+    if (!config) return
+    this.openInput("new pipeline name", "", "lowercase name, e.g. quick", {
+      validate: (value) => {
+        const name = value.trim()
+        if (!name) return "name can't be empty"
+        if (config.pipelines[name]) return `pipeline "${name}" already exists`
+        return undefined
+      },
+      commit: (value) => {
+        const name = value.trim()
+        config.pipelines[name] = { steps: ["implementer"] }
+        this.expanded.add(this.expandKey(name))
+        this.markDirty()
+      },
+    })
+  }
+
+  private togglePipeline(name: string) {
+    const key = this.expandKey(name)
+    if (this.expanded.has(key)) this.expanded.delete(key)
+    else this.expanded.add(key)
+    this.render()
+  }
+
+  private markDirty() {
+    this.tab().dirty = true
+    this.render()
+  }
+
+  private async save() {
+    const tab = this.tab()
+    if (!tab.config) return
+    const config = pruneConfig(tab.config)
+    try {
+      await writeArcherConfig(tab.path, config, tab.validateDir)
+      tab.config = config
+      tab.dirty = false
+      this.message("Saved", tab.path)
+    } catch (error) {
+      this.message("Save failed", error instanceof Error ? error.message : String(error))
+    }
+  }
+
+  private tryQuit() {
+    if (this.tabs.some((tab) => tab.dirty)) {
+      this.modal = {
+        kind: "confirm",
+        title: "Unsaved changes",
+        message: "Discard unsaved changes and quit? [y/n]",
+        onYes: () => this.finish(),
+      }
+      this.render()
+      return
+    }
+    this.finish()
+  }
+
+  // ---- modal openers ------------------------------------------------------
+
+  private openInput(title: string, value: string, help: string, options: { validate?: (value: string) => string | undefined; commit: (value: string) => void }) {
+    this.modal = { kind: "input", title, help, value, validate: options.validate, commit: options.commit }
+    this.render()
+  }
+
+  private openModelPicker(title: string, current: string | undefined, commit: (value: string | undefined) => void) {
+    const modal: Modal = { kind: "model", title, filter: "", loading: true, options: [clearOption], index: 0, commit }
+    this.modal = modal
+    this.render()
+    // Model edits target the project repo for provider resolution; the global tab has none of its own.
+    const dir = this.tab().validateDir === archerRoot() ? process.cwd() : this.tab().validateDir
+    listModels(dir)
+      .then((choices) => {
+        if (this.modal !== modal) return
+        modal.options = [clearOption, ...choices]
+        modal.loading = false
+        if (current) {
+          const at = modal.options.findIndex((choice) => choice.value === current)
+          if (at >= 0) modal.index = at
+        }
+        this.render()
+      })
+      .catch(() => {
+        if (this.modal !== modal) return
+        modal.loading = false
+        this.render()
+      })
+  }
+
+  private message(title: string, message: string) {
+    this.modal = { kind: "message", title, message }
+    this.render()
+  }
+
+  private finish() {
+    clearInterval(this.ticker)
+    this.renderer.keyInput.off("keypress", this.handleKeyPress)
+    this.renderer.off("theme_mode", this.handleThemeMode)
+    if (!this.renderer.isDestroyed) this.renderer.destroy()
+    this.resolveResult()
+  }
+
+  // ---- navigation ---------------------------------------------------------
+
+  private moveSelection(delta: number) {
+    if (this.rows.length === 0) return
+    const step = delta === 0 ? 0 : delta > 0 ? 1 : -1
+    let index = this.selected
+    let remaining = Math.abs(delta)
+    while (remaining > 0) {
+      let next = index + step
+      while (next >= 0 && next < this.rows.length && !this.rows[next]!.meta) next += step
+      if (next < 0 || next >= this.rows.length) break
+      index = next
+      remaining--
+    }
+    this.selected = index
+    this.render()
+  }
+
+  private firstSelectable() {
+    const at = this.rows.findIndex((row) => row.meta)
+    return at < 0 ? 0 : at
+  }
+
+  private expandKey(name: string) {
+    return `${this.active}:${name}`
+  }
+
+  // ---- row model ----------------------------------------------------------
+
+  private buildRows(): Row[] {
+    const config = this.tab().config
+    if (!config) {
+      return [
+        sectionRow("No config file yet"),
+        infoRow(`Nothing at ${shortenPath(this.tab().path)}.`),
+        blankRow(),
+        actionRow("⊕ Initialize default config", { t: "initialize" }),
+      ]
+    }
+
+    const rows: Row[] = []
+
+    rows.push(sectionRow("Defaults"))
+    for (const field of defaultFields) {
+      const value = config.defaults[field.key]
+      rows.push(fieldRow(field.key, value === undefined ? "(unset)" : String(value), { t: "default", field }))
+    }
+
+    rows.push(blankRow(), sectionRow("Agents"))
+    for (const agent of buildAgentRegistry(config)) {
+      const model = config.agents[agent.name]?.model
+      const temp = config.agents[agent.name]?.temperature
+      const value = (model ?? "(inherits)") + (temp !== undefined ? `  ·  temp ${temp}` : "")
+      rows.push(fieldRow(agent.name, value, { t: "agent", name: agent.name }))
+    }
+
+    rows.push(blankRow(), sectionRow("Pipelines"))
+    const pipelineNames = Object.keys(config.pipelines)
+    if (pipelineNames.length === 0) {
+      rows.push(infoRow("none defined here — built-in 'default' is used"))
+    }
+    for (const name of pipelineNames) {
+      const open = this.expanded.has(this.expandKey(name))
+      rows.push(pipelineRow(name, config.pipelines[name]!, open))
+      if (open) {
+        const steps = config.pipelines[name]!.steps
+        steps.forEach((spec, index) => rows.push(stepRow(name, index, spec)))
+        rows.push(actionRow("  ⊕ add step", { t: "add-step", pipeline: name }))
+      }
+    }
+    rows.push(actionRow("⊕ add pipeline", { t: "add-pipeline" }))
+
+    rows.push(blankRow(), sectionRow("Permissions  (read-only — edit in .archer/config.yaml)"))
+    rows.push(infoRow(readonlyList("allow", config.permissions.allow)))
+    rows.push(infoRow(readonlyList("deny", config.permissions.deny)))
+    rows.push(blankRow(), sectionRow("Attachments  (read-only — edit in .archer/config.yaml)"))
+    rows.push(infoRow(readonlyList("files", config.attachments)))
+
+    return rows
+  }
+
+  // ---- rendering ----------------------------------------------------------
+
+  private detailWidth() {
+    return Math.max(30, Math.min(48, this.renderer.width - 60))
+  }
+
+  private listHeight() {
+    return Math.max(3, this.renderer.height - 9)
+  }
+
+  private render() {
+    if (this.renderer.isDestroyed) return
+    this.rows = this.buildRows()
+    if (this.selected >= this.rows.length) this.selected = this.firstSelectable()
+    if (!this.rows[this.selected]?.meta) this.selected = this.firstSelectable()
+
+    const innerWidth = Math.max(40, this.renderer.width - 6)
+    const detailWidth = this.detailWidth()
+    const listWidth = Math.max(30, this.renderer.width - detailWidth - 7)
+
+    this.detailBox.width = detailWidth
+    this.headerText.content = this.headerContent(innerWidth)
+    this.listText.content = this.listContent(listWidth)
+    this.detailText.content = this.detailContent(detailWidth - 4)
+    this.footerText.content = this.footerContent(innerWidth)
+    this.renderModal()
+    this.renderer.requestRender()
+  }
+
+  private headerContent(width: number) {
+    const tabs: TextChunk[] = []
+    this.tabs.forEach((tab, index) => {
+      if (index > 0) tabs.push(fg(theme.faint)("   "))
+      const label = `${tab.title}${tab.dirty ? " ●" : ""}`
+      tabs.push(index === this.active ? bold(fg(theme.accent)(`▸ ${label}`)) : fg(theme.dim)(`  ${label}`))
+    })
+    const title: TextChunk[] = [bold(fg(theme.accent)("◆ archer")), fg(theme.faint)("  ·  "), fg(theme.text)("config")]
+    const line1 = padBetween(title, tabs, width)
+    const line2 = new StyledText([fg(theme.dim)(truncate(shortenPath(this.tab().path), width))])
+    return joinLines([line1, line2])
+  }
+
+  private listContent(width: number) {
+    const visible = this.listHeight()
+    if (this.selected < this.scroll) this.scroll = this.selected
+    if (this.selected >= this.scroll + visible) this.scroll = this.selected - visible + 1
+    const slice = this.rows.slice(this.scroll, this.scroll + visible)
+    const lines = slice.map((row, offset) => new StyledText(row.chunks(this.scroll + offset === this.selected, width)))
+    while (lines.length < visible) lines.push(plain(""))
+    return joinLines(lines)
+  }
+
+  private detailContent(width: number) {
+    const meta = this.rows[this.selected]?.meta
+    const lines: StyledText[] = []
+    const push = (chunks: TextChunk[]) => lines.push(new StyledText(chunks))
+
+    if (!meta) {
+      push([fg(theme.dim)("—")])
+      return joinLines(lines)
+    }
+    switch (meta.t) {
+      case "initialize":
+        push([fg(theme.text)("Create a starter config")])
+        push([fg(theme.faint)("with the built-in default")])
+        push([fg(theme.faint)("pipeline and models, ready")])
+        push([fg(theme.faint)("to edit.")])
+        lines.push(plain(""))
+        push([fg(theme.accent)("enter"), fg(theme.dim)(" initialize")])
+        break
+      case "default":
+        push([fg(theme.text)(`defaults.${meta.field.key}`)])
+        push([fg(theme.faint)(describeDefault(meta.field.key))])
+        lines.push(plain(""))
+        push([fg(theme.accent)("enter"), fg(theme.dim)(meta.field.type === "model" ? " pick a model" : " edit value")])
+        break
+      case "agent":
+        push([fg(theme.text)(`agent: ${meta.name}`)])
+        push([fg(theme.faint)("Model override for this agent.")])
+        push([fg(theme.faint)("Empty = inherit defaults.model.")])
+        lines.push(plain(""))
+        push([fg(theme.accent)("enter"), fg(theme.dim)(" pick model   "), fg(theme.accent)("t"), fg(theme.dim)(" temperature")])
+        break
+      case "pipeline":
+        push([fg(theme.text)(`pipeline: ${meta.name}`)])
+        lines.push(plain(""))
+        push([fg(theme.accent)("enter"), fg(theme.dim)(" expand/collapse   "), fg(theme.accent)("a"), fg(theme.dim)(" add step")])
+        break
+      case "step":
+        push([fg(theme.text)(`step ${meta.index + 1} of ${meta.pipeline}`)])
+        lines.push(plain(""))
+        push([fg(theme.accent)("enter"), fg(theme.dim)(" pick model")])
+        push([fg(theme.accent)("m"), fg(theme.dim)(" max-attempts   "), fg(theme.accent)("d"), fg(theme.dim)(" delete")])
+        push([fg(theme.accent)("shift+↑/↓"), fg(theme.dim)(" reorder")])
+        break
+      case "add-step":
+        push([fg(theme.text)("Add a step")])
+        push([fg(theme.accent)("enter"), fg(theme.dim)(" choose an agent or gate")])
+        break
+      case "add-pipeline":
+        push([fg(theme.text)("Add a pipeline")])
+        push([fg(theme.accent)("enter"), fg(theme.dim)(" name a new pipeline")])
+        break
+    }
+    return joinLines(lines)
+  }
+
+  private footerContent(width: number) {
+    const left: TextChunk[] = [
+      fg(theme.dim)("↑/↓ move · "),
+      fg(theme.accent)("enter"),
+      fg(theme.dim)(" edit · "),
+      fg(theme.accent)("s"),
+      fg(theme.dim)("ave · "),
+      fg(theme.accent)("tab"),
+      fg(theme.dim)(" switch · "),
+      fg(theme.accent)("q"),
+      fg(theme.dim)("uit"),
+    ]
+    const dirty = this.tab().dirty ? fg(theme.yellow)("● unsaved") : fg(theme.faint)("saved")
+    return padBetween(left, [dirty], width)
+  }
+
+  private modalWidth() {
+    return Math.max(46, Math.min(80, this.renderer.width - 10))
+  }
+
+  private renderModal() {
+    const modal = this.modal
+    this.overlay.visible = Boolean(modal)
+    if (!modal) return
+    const boxWidth = this.modalWidth()
+    const width = boxWidth - 6
+    const lines: StyledText[] = []
+    const push = (chunks: TextChunk[]) => lines.push(new StyledText(chunks))
+
+    this.modalBox.title = ` ${truncate(modal.title, boxWidth - 8)} `
+
+    if (modal.kind === "message" || modal.kind === "confirm") {
+      push([fg(theme.text)(truncate(modal.message, width))])
+      lines.push(plain(""))
+      push([fg(theme.dim)(modal.kind === "confirm" ? "y / n" : "press any key to dismiss")])
+    } else if (modal.kind === "input") {
+      push([fg(theme.faint)(modal.help)])
+      lines.push(plain(""))
+      push([fg(theme.accent)("> "), fg(theme.text)(modal.value), fg(theme.dim)("▏")])
+      lines.push(plain(""))
+      if (modal.error) push([fg(theme.red)(modal.error)])
+      else push([fg(theme.dim)("enter confirm · esc cancel")])
+    } else {
+      // model / choose
+      push([fg(theme.accent)("filter: "), fg(theme.text)(modal.filter), fg(theme.dim)("▏")])
+      lines.push(plain(""))
+      const filtered = this.filteredOptions(modal)
+      if (modal.kind === "model" && modal.loading) {
+        push([fg(theme.accent)(spinnerFrame(Date.now())), fg(theme.dim)(" loading models…")])
+      } else if (filtered.length === 0) {
+        const hint = modal.kind === "model" && isValidModelString(modal.filter.trim()) ? "no match — enter uses typed value" : "no matches"
+        push([fg(theme.dim)(hint)])
+      } else {
+        const start = Math.max(0, Math.min(modal.index - Math.floor(modalListHeight / 2), filtered.length - modalListHeight))
+        const windowed = filtered.slice(start, start + modalListHeight)
+        windowed.forEach((option, offset) => {
+          const index = start + offset
+          const selected = index === modal.index
+          const valueText = truncateChunkSafe(option.value, Math.max(12, Math.floor(width * 0.5)))
+          const marker = selected ? fg(theme.accent)("▸ ") : raw("  ")
+          const value = selected ? bold(fg(theme.text)(valueText)) : fg(theme.text)(valueText)
+          const hint = optionHint(option)
+          const chunks: TextChunk[] = [marker, value]
+          if (hint) chunks.push(fg(theme.faint)(`   ${truncateChunkSafe(hint, Math.max(8, width - valueText.length - 6))}`))
+          push(chunks)
+        })
+      }
+      lines.push(plain(""))
+      const help = modal.kind === "model" ? "↑/↓ select · type to filter · enter set · esc cancel" : "↑/↓ select · type to filter · enter add · esc cancel"
+      push([fg(theme.dim)(help)])
+    }
+
+    this.modalBox.width = boxWidth
+    this.modalBox.height = lines.length + 4
+    this.modalText.content = joinLines(lines)
+  }
+
+  private applyPalette() {
+    for (const target of this.paletteTargets) {
+      target.box.backgroundColor = theme[target.background]
+      if (target.border) target.box.borderColor = theme[target.border]
+    }
+  }
+
+  private panel(options: BoxOptions) {
+    const box = new BoxRenderable(this.renderer, { border: true, borderStyle: "rounded", paddingX: 1, paddingY: 0, ...options })
+    const text = new TextRenderable(this.renderer, { content: "", fg: theme.text, width: "100%", height: "100%" })
+    box.add(text)
+    return { box, text }
+  }
+}
+
+// ---- row builders ---------------------------------------------------------
+
+function sectionRow(text: string): Row {
+  return { chunks: (_selected, width) => [bold(fg(theme.accent)(truncateChunkSafe(text, width)))] }
+}
+
+function blankRow(): Row {
+  return { chunks: () => [raw("")] }
+}
+
+function infoRow(text: string): Row {
+  return { chunks: (_selected, width) => [fg(theme.faint)(truncateChunkSafe(text, width))] }
+}
+
+function fieldRow(label: string, value: string, meta: RowMeta): Row {
+  const labelCol = label.padEnd(18)
+  return {
+    meta,
+    chunks: (selected, width) => [
+      selected ? fg(theme.accent)("▸ ") : raw("  "),
+      selected ? bold(fg(theme.text)(labelCol)) : fg(theme.text)(labelCol),
+      // Explicit gap so names longer than the column still separate from the value.
+      raw(" "),
+      fg(theme.dim)(truncateChunkSafe(value, Math.max(8, width - 23))),
+    ],
+  }
+}
+
+function actionRow(label: string, meta: RowMeta): Row {
+  return { meta, chunks: (selected, width) => [selected ? fg(theme.accent)("▸ ") : raw("  "), fg(theme.accent)(truncateChunkSafe(label, Math.max(8, width - 2)))] }
+}
+
+function pipelineRow(name: string, spec: PipelineSpec, open: boolean): Row {
+  const count = `  (${spec.steps.length} step${spec.steps.length === 1 ? "" : "s"})`
+  return {
+    meta: { t: "pipeline", name },
+    chunks: (selected, width) => [
+      selected ? fg(theme.accent)("▸ ") : raw("  "),
+      fg(theme.dim)(open ? "▾ " : "▸ "),
+      selected ? bold(fg(theme.text)(truncateChunkSafe(name, Math.max(8, width - count.length - 6)))) : fg(theme.text)(truncateChunkSafe(name, Math.max(8, width - count.length - 6))),
+      fg(theme.faint)(count),
+    ],
+  }
+}
+
+function stepRow(pipeline: string, index: number, spec: StepSpec): Row {
+  const agent = agentOf(spec)
+  const model = typeof spec === "string" ? undefined : spec.model
+  const human = agent === humanReviewStep
+  return {
+    meta: { t: "step", pipeline, index },
+    chunks: (selected, width) => {
+      const chunks: TextChunk[] = [
+        selected ? fg(theme.accent)("    ▸ ") : raw("      "),
+        fg(theme.faint)(`${index + 1}. `),
+        selected ? bold(fg(theme.text)(truncateChunkSafe(agent, 24))) : fg(human ? theme.magenta : theme.text)(truncateChunkSafe(agent, 24)),
+      ]
+      if (!human) chunks.push(fg(theme.dim)(`   ${truncateChunkSafe(model ?? "(inherits)", Math.max(8, width - 40))}`))
+      return chunks
+    },
+  }
+}
+
+// ---- pure helpers ----------------------------------------------------------
+
+function setDefault(defaults: ArcherDefaults, key: keyof ArcherDefaults, value: string | number | undefined) {
+  const record = defaults as Record<string, unknown>
+  if (value === undefined) delete record[key]
+  else record[key] = value
+}
+
+function agentOf(spec: StepSpec): string {
+  return typeof spec === "string" ? spec : spec.agent
+}
+
+function asStepObject(spec: StepSpec): Exclude<StepSpec, string> {
+  return typeof spec === "string" ? { agent: spec } : { ...spec }
+}
+
+function collapseStep(spec: Exclude<StepSpec, string>): StepSpec {
+  return Object.keys(spec).length === 1 ? spec.agent : spec
+}
+
+/** Drops empty agent override entries so they don't serialize as `name: {}`. */
+function pruneConfig(config: ArcherConfig): ArcherConfig {
+  const agents: Record<string, ConfigAgent> = {}
+  for (const [name, agent] of Object.entries(config.agents)) {
+    if (Object.keys(agent).length > 0) agents[name] = agent
+  }
+  return { ...config, agents }
+}
+
+function isPositiveInt(value: string) {
+  const n = Number(value)
+  return Number.isInteger(n) && n >= 1
+}
+
+function isTemperature(value: string) {
+  const n = Number(value)
+  return Number.isFinite(n) && n >= 0 && n <= 2
+}
+
+function matches(filter: string, ...fields: string[]) {
+  const needle = filter.trim().toLowerCase()
+  if (!needle) return true
+  const hay = fields.join(" ").toLowerCase()
+  return needle.split(/\s+/).every((part) => hay.includes(part))
+}
+
+function optionHint(option: ModelChoice | ChooseItem): string {
+  if ("providerID" in option) {
+    const parts = [option.label]
+    if (option.contextK) parts.push(`${option.contextK}k`)
+    if (option.status) parts.push(option.status)
+    return parts.join(" · ")
+  }
+  return option.hint ?? ""
+}
+
+function describeDefault(key: keyof ArcherDefaults): string {
+  switch (key) {
+    case "model":
+      return "Default model for steps with no model of their own."
+    case "interactiveModel":
+      return "Model used by manual OpenCode iterations in human-review."
+    case "maxAttempts":
+      return "Attempts per step before failing."
+    case "baseRef":
+      return "Branch/base used to diff between steps."
+    case "pipeline":
+      return "Pipeline used when -p/--pipeline is not given."
+    case "appRunCommand":
+      return "App command run during human-review gates."
+    case "emulator":
+      return "Flutter emulator launched during human-review."
+    default:
+      return ""
+  }
+}
+
+function readonlyList(label: string, values: string[]): string {
+  return `${label}: ${values.length === 0 ? "—" : values.join(", ")}`
+}
+
+function shortenPath(path: string): string {
+  const home = process.env.HOME
+  return home && path.startsWith(home) ? `~${path.slice(home.length)}` : path
+}
+
+function truncateChunkSafe(text: string, width: number): string {
+  if (text.length <= width) return text
+  return `${text.slice(0, Math.max(0, width - 1))}…`
+}
+
+function typedChar(key: KeyEvent): string | undefined {
+  if (key.ctrl) return undefined
+  const raw = key.raw
+  if (typeof raw === "string" && raw.length === 1) {
+    const code = raw.codePointAt(0)!
+    if (code >= 0x20 && code !== 0x7f) return raw
+  }
+  return undefined
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,22 @@
 import { statSync } from "node:fs"
-import { readFile } from "node:fs/promises"
-import { join } from "node:path"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
 
 import { projectAgentPromptPath } from "./agents"
 import { log } from "./log"
-import { agentAliases, builtInAgents, builtInPipelines, humanReviewStep, splitModelVariant, type PipelineSpec, type StepSpec } from "./pipeline"
+import {
+  agentAliases,
+  builtInAgents,
+  builtInPipelines,
+  defaultGptModel,
+  defaultGptVariant,
+  humanReviewStep,
+  splitModelVariant,
+  type PipelineSpec,
+  type StepSpec,
+} from "./pipeline"
 import type { AgentSpec, PermissionAdditions } from "./types"
+import { archerHome, archerRoot } from "./workspace"
 
 /**
  * Project configuration loaded from .archer/config.yaml. Everything is
@@ -57,6 +68,52 @@ export async function loadArcherConfig(targetDir: string): Promise<ArcherConfig 
     return parseArcherConfig(body, `.archer/${fileName}`, targetDir)
   }
   return undefined
+}
+
+/**
+ * The per-user config at ~/.archer/config.yaml. Parsed with targetDir set to
+ * archerRoot() — the directory that holds `.archer` — so agent-prompt validation
+ * resolves to ~/.archer/agents/<name>.md, exactly like a project repo.
+ */
+export async function loadGlobalArcherConfig(): Promise<ArcherConfig | undefined> {
+  for (const fileName of configFileNames) {
+    const path = join(archerHome(), fileName)
+    let body: string
+    try {
+      body = await readFile(path, "utf8")
+    } catch {
+      continue
+    }
+    return parseArcherConfig(body, `~/.archer/${fileName}`, archerRoot())
+  }
+  return undefined
+}
+
+/**
+ * Merges the global config under the project one: project keys win on
+ * defaults/agents/pipelines (shallow, by key/name), and permissions/attachments
+ * concatenate (global first). deny still wins over allow in bashPolicy, so the
+ * concatenation order is irrelevant there.
+ */
+export function mergeArcherConfigs(global: ArcherConfig | undefined, project: ArcherConfig | undefined): ArcherConfig | undefined {
+  if (!global) return project
+  if (!project) return global
+  return {
+    defaults: { ...global.defaults, ...project.defaults },
+    agents: { ...global.agents, ...project.agents },
+    pipelines: { ...global.pipelines, ...project.pipelines },
+    permissions: {
+      allow: [...global.permissions.allow, ...project.permissions.allow],
+      deny: [...global.permissions.deny, ...project.permissions.deny],
+    },
+    attachments: [...global.attachments, ...project.attachments],
+  }
+}
+
+/** The effective config for a run: global merged under the project config. */
+export async function loadMergedArcherConfig(targetDir: string): Promise<ArcherConfig | undefined> {
+  const [global, project] = await Promise.all([loadGlobalArcherConfig(), loadArcherConfig(targetDir)])
+  return mergeArcherConfigs(global, project)
 }
 
 export function parseArcherConfig(body: string, source: string, targetDir: string): ArcherConfig {
@@ -220,6 +277,71 @@ export function selectPipelineSpec(config: ArcherConfig | undefined, name: strin
   throw new ConfigError(`unknown pipeline "${name}" (available: ${available.join(", ")})`)
 }
 
+/** True when a string is a valid `provider/model` or `provider/model#variant`. Shared by config validation and the config TUI. */
+export function isValidModelString(value: string): boolean {
+  if (typeof value !== "string" || !value.trim()) return false
+  try {
+    const { model } = splitModelVariant(value)
+    const provider = model.split("/")[0]
+    const rest = model.split("/").slice(1).join("/")
+    return Boolean(provider && rest)
+  } catch {
+    return false
+  }
+}
+
+/** Serializes a config back to YAML, omitting empty sections, with `version: 1` first. Comments are not preserved. */
+export function serializeArcherConfig(config: ArcherConfig): string {
+  const out: Record<string, unknown> = { version: 1 }
+  if (Object.keys(config.defaults).length > 0) out.defaults = config.defaults
+  if (Object.keys(config.agents).length > 0) out.agents = config.agents
+  if (Object.keys(config.pipelines).length > 0) out.pipelines = config.pipelines
+  const permissions: Record<string, string[]> = {}
+  if (config.permissions.allow.length > 0) permissions.allow = config.permissions.allow
+  if (config.permissions.deny.length > 0) permissions.deny = config.permissions.deny
+  if (Object.keys(permissions).length > 0) out.permissions = permissions
+  if (config.attachments.length > 0) out.attachments = config.attachments
+  return Bun.YAML.stringify(out, null, 2)
+}
+
+/** Serializes, validates by re-parsing, then writes. Never persists YAML that wouldn't load back. */
+export async function writeArcherConfig(path: string, config: ArcherConfig, targetDir: string): Promise<void> {
+  const body = serializeArcherConfig(config)
+  parseArcherConfig(body, path, targetDir)
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, body, "utf8")
+}
+
+/**
+ * Boilerplate written by the config TUI's "initialize" action: the current
+ * effective defaults plus the built-in `default` pipeline expanded so it stays
+ * editable. Agent model preferences that differ from defaults.model are inlined
+ * on their steps, because defaults.model would otherwise shadow them.
+ */
+export function defaultConfigTemplate(): ArcherConfig {
+  const globalModel = `${defaultGptModel}#${defaultGptVariant}`
+  return {
+    defaults: { model: globalModel, maxAttempts: 2 },
+    agents: {},
+    pipelines: { default: templatePipeline(builtInPipelines.default!, globalModel) },
+    permissions: { allow: [], deny: [] },
+    attachments: [],
+  }
+}
+
+function templatePipeline(spec: PipelineSpec, globalModel: string): PipelineSpec {
+  const steps = spec.steps.map<StepSpec>((raw) => {
+    const step = typeof raw === "string" ? { agent: raw } : { ...raw }
+    if (step.agent === humanReviewStep) return step.agent
+    const agent = builtInAgents.find((candidate) => candidate.name === (agentAliases[step.agent] ?? step.agent))
+    const preferred = agent?.defaultModel
+    const withModel = preferred && preferred !== globalModel ? { ...step, model: preferred } : step
+    // Collapse a bare { agent } back to its string shorthand for clean YAML.
+    return Object.keys(withModel).length === 1 ? withModel.agent : withModel
+  })
+  return { ...(spec.description ? { description: spec.description } : {}), steps }
+}
+
 class Validator {
   constructor(private readonly source: string) {}
 
@@ -261,12 +383,7 @@ class Validator {
 
   model(value: unknown, path: string): string {
     const text = this.nonEmptyString(value, path)
-    try {
-      const { model } = splitModelVariant(text)
-      if (!model.split("/")[0] || !model.split("/").slice(1).join("/")) throw new Error("missing provider or model")
-    } catch {
-      this.fail(path, `must look like provider/model or provider/model#variant, got "${text}"`)
-    }
+    if (!isValidModelString(text)) this.fail(path, `must look like provider/model or provider/model#variant, got "${text}"`)
     return text
   }
 

--- a/src/model-catalog.ts
+++ b/src/model-catalog.ts
@@ -1,0 +1,125 @@
+import type { ModelV2Info, ProviderV2Info } from "@opencode-ai/sdk/v2"
+
+import { log } from "./log"
+import { startOpencode } from "./opencode"
+
+/** A selectable model for the config TUI's picker. `value` is what gets written to config. */
+export type ModelChoice = {
+  /** Canonical `provider/model` or `provider/model#variant`. */
+  value: string
+  /** Human-readable model name (with the variant in parentheses). */
+  label: string
+  providerID: string
+  /** Non-"active" status (alpha/beta/deprecated), surfaced as a hint; undefined when active. */
+  status?: string
+  /** Context window in thousands of tokens, for the description line. */
+  contextK?: number
+}
+
+const catalogTimeoutMs = 12_000
+const modelsDevUrl = "https://models.dev/api.json"
+
+let cached: ModelChoice[] | undefined
+
+/**
+ * The models offered in the picker: first the OpenCode SDK (filtered to the
+ * user's enabled providers, with variants expanded), falling back to the full
+ * models.dev catalog when the SDK can't answer (no auth / offline). Returns []
+ * if both fail, since the picker always also accepts free-typed text. Cached
+ * per process once a non-empty list is obtained.
+ */
+export async function listModels(targetDir: string): Promise<ModelChoice[]> {
+  if (cached) return cached
+
+  const fromSdk = await safe(() => listModelsFromSdk(targetDir), "opencode SDK")
+  if (fromSdk && fromSdk.length > 0) return (cached = fromSdk)
+
+  const fromDev = await safe(() => fetchModelsDev(), "models.dev")
+  if (fromDev && fromDev.length > 0) return (cached = fromDev)
+
+  return []
+}
+
+async function listModelsFromSdk(targetDir: string): Promise<ModelChoice[]> {
+  const handle = await startOpencode({}, AbortSignal.timeout(catalogTimeoutMs))
+  try {
+    const [providers, models] = await Promise.all([
+      handle.client.v2.provider.list({ location: { directory: targetDir } }),
+      handle.client.v2.model.list({ location: { directory: targetDir } }),
+    ])
+    if (providers.error || models.error) throw new Error("opencode returned an error listing providers/models")
+    return toModelChoices(providers.data ?? [], models.data ?? [])
+  } finally {
+    handle.close()
+  }
+}
+
+/**
+ * Pure transform from the SDK's provider/model lists to picker choices. Keeps
+ * only models whose provider is enabled, preserves the SDK's release-date order,
+ * and expands each model into its base entry plus one per variant.
+ */
+export function toModelChoices(providers: readonly ProviderV2Info[], models: readonly ModelV2Info[]): ModelChoice[] {
+  const enabled = new Set(providers.filter((provider) => provider.enabled !== false).map((provider) => provider.id))
+  const choices: ModelChoice[] = []
+  const seen = new Set<string>()
+
+  const push = (choice: ModelChoice) => {
+    if (seen.has(choice.value)) return
+    seen.add(choice.value)
+    choices.push(choice)
+  }
+
+  for (const model of models) {
+    // When provider info is present, keep only enabled providers; otherwise keep all.
+    if (enabled.size > 0 && !enabled.has(model.providerID)) continue
+    const base = `${model.providerID}/${model.id}`
+    const status = model.status && model.status !== "active" ? model.status : undefined
+    const contextK = model.limit?.context ? Math.round(model.limit.context / 1000) : undefined
+
+    push({ value: base, label: model.name, providerID: model.providerID, ...(status ? { status } : {}), ...(contextK ? { contextK } : {}) })
+    for (const variant of model.variants ?? []) {
+      push({
+        value: `${base}#${variant.id}`,
+        label: `${model.name} (${variant.id})`,
+        providerID: model.providerID,
+        ...(status ? { status } : {}),
+        ...(contextK ? { contextK } : {}),
+      })
+    }
+  }
+  return choices
+}
+
+type ModelsDevModel = { name?: string; limit?: { context?: number } }
+type ModelsDevProvider = { models?: Record<string, ModelsDevModel> }
+
+/** Fallback catalog from models.dev. No variants and no enabled-provider filter; the full public list. */
+export async function fetchModelsDev(): Promise<ModelChoice[]> {
+  const response = await fetch(modelsDevUrl, { signal: AbortSignal.timeout(catalogTimeoutMs) })
+  if (!response.ok) throw new Error(`models.dev returned ${response.status}`)
+  const data = (await response.json()) as Record<string, ModelsDevProvider>
+  return parseModelsDev(data)
+}
+
+/** Pure transform of the models.dev payload, split out so it can be unit-tested with a fixture. */
+export function parseModelsDev(data: Record<string, ModelsDevProvider>): ModelChoice[] {
+  const choices: ModelChoice[] = []
+  for (const [providerID, provider] of Object.entries(data)) {
+    for (const [modelID, model] of Object.entries(provider?.models ?? {})) {
+      const contextK = model?.limit?.context ? Math.round(model.limit.context / 1000) : undefined
+      choices.push({ value: `${providerID}/${modelID}`, label: model?.name ?? modelID, providerID, ...(contextK ? { contextK } : {}) })
+    }
+  }
+  choices.sort((a, b) => a.value.localeCompare(b.value))
+  return choices
+}
+
+async function safe(fn: () => Promise<ModelChoice[]>, source: string): Promise<ModelChoice[] | undefined> {
+  try {
+    return await fn()
+  } catch (error) {
+    log.warn(`model catalog: ${source} unavailable (${error instanceof Error ? error.message : String(error)})`)
+    return undefined
+  }
+}

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -58,7 +58,32 @@ export function runDir(runID: string) {
 }
 
 export function runsRoot() {
-  return join(homedir(), ".archer", "runs")
+  return join(archerHome(), "runs")
+}
+
+/**
+ * The directory that contains archer's `.archer` home — the user's home by
+ * default, relocatable via ARCHER_HOME. It plays the same role for the global
+ * config that a repo root plays for a project, so agent-prompt paths resolve
+ * the same way (`<root>/.archer/agents/<name>.md`).
+ */
+export function archerRoot() {
+  return process.env.ARCHER_HOME || homedir()
+}
+
+/** Archer's per-user home, holding run history and the global config. */
+export function archerHome() {
+  return join(archerRoot(), ".archer")
+}
+
+/** Path of the global config file (default name); the loader also accepts config.yml. */
+export function globalConfigPath() {
+  return join(archerHome(), "config.yaml")
+}
+
+/** Where prompts for global custom agents live, mirroring a project's .archer/agents. */
+export function globalAgentsDir() {
+  return join(archerHome(), "agents")
 }
 
 export function isValidRunID(runID: string) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -2,9 +2,22 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { afterAll, describe, expect, test } from "bun:test"
+import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test"
 
-import { buildAgentRegistry, loadArcherConfig, parseArcherConfig, selectPipelineSpec, ConfigError } from "../src/config"
+import {
+  buildAgentRegistry,
+  ConfigError,
+  defaultConfigTemplate,
+  isValidModelString,
+  loadArcherConfig,
+  loadGlobalArcherConfig,
+  loadMergedArcherConfig,
+  mergeArcherConfigs,
+  parseArcherConfig,
+  selectPipelineSpec,
+  serializeArcherConfig,
+} from "../src/config"
+import { defaultGptModel, defaultGptVariant, defaultOpusModel } from "../src/pipeline"
 
 const dirs: string[] = []
 
@@ -161,5 +174,111 @@ describe("pipeline selection", () => {
     expect(selectPipelineSpec(undefined, "default").steps.length).toBeGreaterThan(1)
     expect(() => selectPipelineSpec(config, "ghost")).toThrow('unknown pipeline "ghost" (available: default, quick)')
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(ConfigError)
+  })
+})
+
+describe("isValidModelString", () => {
+  test("accepts provider/model and provider/model#variant, rejects the rest", () => {
+    expect(isValidModelString("openai/gpt-5.5")).toBe(true)
+    expect(isValidModelString("openai/gpt-5.5#xhigh")).toBe(true)
+    expect(isValidModelString("anthropic/claude/opus")).toBe(true)
+    expect(isValidModelString("gpt-5.5")).toBe(false)
+    expect(isValidModelString("openai/")).toBe(false)
+    expect(isValidModelString("")).toBe(false)
+  })
+})
+
+describe("config merging", () => {
+  test("defaults merge shallow by key; project wins", () => {
+    const global = parse("defaults:\n  model: openai/gpt-5.5#xhigh\n  maxAttempts: 9")
+    const project = parse("defaults:\n  maxAttempts: 2\n  baseRef: dev")
+    expect(mergeArcherConfigs(global, project)?.defaults).toEqual({ model: "openai/gpt-5.5#xhigh", maxAttempts: 2, baseRef: "dev" })
+  })
+
+  test("agents and pipelines merge by name; project entry wins wholesale", () => {
+    const global = parse("agents:\n  design-polisher:\n    model: openai/gpt-5.5#xhigh\npipelines:\n  default:\n    steps:\n      - tests\n  shared:\n    steps:\n      - implementer")
+    const project = parse("agents:\n  design-polisher:\n    temperature: 0.2\npipelines:\n  default:\n    steps:\n      - implementer")
+    const merged = mergeArcherConfigs(global, project)!
+    expect(merged.agents["design-polisher"]).toEqual({ temperature: 0.2 })
+    expect(merged.pipelines.default?.steps).toEqual(["implementer"])
+    expect(merged.pipelines.shared?.steps).toEqual(["implementer"])
+  })
+
+  test("permissions and attachments concatenate, global first", () => {
+    const global = parse("permissions:\n  allow:\n    - 'a'\nattachments:\n  - 'g.md'")
+    const project = parse("permissions:\n  allow:\n    - 'b'\n  deny:\n    - 'x'\nattachments:\n  - 'p.md'")
+    const merged = mergeArcherConfigs(global, project)!
+    expect(merged.permissions).toEqual({ allow: ["a", "b"], deny: ["x"] })
+    expect(merged.attachments).toEqual(["g.md", "p.md"])
+  })
+
+  test("a missing side passes the other through unchanged", () => {
+    const only = parse("defaults:\n  model: openai/gpt-5.5")
+    expect(mergeArcherConfigs(undefined, undefined)).toBeUndefined()
+    expect(mergeArcherConfigs(only, undefined)).toBe(only)
+    expect(mergeArcherConfigs(undefined, only)).toBe(only)
+  })
+})
+
+describe("serialization", () => {
+  test("omits empty sections and round-trips through parse", () => {
+    const config = parse("defaults:\n  model: openai/gpt-5.5#xhigh\npipelines:\n  default:\n    steps:\n      - implementer\n      - human-review")
+    const yaml = serializeArcherConfig(config)
+    expect(yaml).toContain("version: 1")
+    expect(yaml).not.toContain("agents")
+    expect(yaml).not.toContain("permissions")
+    expect(yaml).not.toContain("attachments")
+    const reparsed = parse(yaml)
+    expect(reparsed.defaults).toEqual(config.defaults)
+    expect(reparsed.pipelines).toEqual(config.pipelines)
+  })
+
+  test("defaultConfigTemplate inlines opus on design and round-trips", () => {
+    const template = defaultConfigTemplate()
+    expect(template.defaults.model).toBe(`${defaultGptModel}#${defaultGptVariant}`)
+    const steps = template.pipelines.default!.steps
+    expect(steps.find((step) => typeof step !== "string" && step.agent === "design")).toEqual({ agent: "design", model: defaultOpusModel })
+    const reparsed = parse(serializeArcherConfig(template))
+    expect(reparsed.defaults).toEqual(template.defaults)
+    expect(reparsed.pipelines).toEqual(template.pipelines)
+  })
+})
+
+describe("global config", () => {
+  let savedHome: string | undefined
+  beforeEach(() => {
+    savedHome = process.env.ARCHER_HOME
+  })
+  afterEach(() => {
+    if (savedHome === undefined) delete process.env.ARCHER_HOME
+    else process.env.ARCHER_HOME = savedHome
+  })
+
+  // ARCHER_HOME points at the directory that contains .archer, like a repo root.
+  async function globalHome(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), "archer-home-"))
+    dirs.push(root)
+    await mkdir(join(root, ".archer", "agents"), { recursive: true })
+    process.env.ARCHER_HOME = root
+    return join(root, ".archer")
+  }
+
+  test("loads ~/.archer/config.yaml and validates global agents against ~/.archer/agents", async () => {
+    const home = await globalHome()
+    await writeFile(join(home, "agents", "global-agent.md"), "# global-agent\n")
+    await writeFile(join(home, "config.yaml"), "defaults:\n  model: openai/gpt-5.5#xhigh\nagents:\n  global-agent:\n    description: A global agent\n    model: anthropic/claude-opus-4-7\n")
+
+    const config = await loadGlobalArcherConfig()
+    expect(config?.defaults.model).toBe("openai/gpt-5.5#xhigh")
+    expect(config?.agents["global-agent"]).toMatchObject({ model: "anthropic/claude-opus-4-7" })
+  })
+
+  test("merges global under project so the project wins", async () => {
+    const home = await globalHome()
+    await writeFile(join(home, "config.yaml"), "defaults:\n  model: openai/gpt-5.5#xhigh\n  maxAttempts: 9\n")
+
+    const project = await projectDir("defaults:\n  maxAttempts: 2\n")
+    const merged = await loadMergedArcherConfig(project)
+    expect(merged?.defaults).toEqual({ model: "openai/gpt-5.5#xhigh", maxAttempts: 2 })
   })
 })

--- a/test/model-catalog.test.ts
+++ b/test/model-catalog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test"
+
+import type { ModelV2Info, ProviderV2Info } from "@opencode-ai/sdk/v2"
+
+import { parseModelsDev, toModelChoices } from "../src/model-catalog"
+
+describe("toModelChoices", () => {
+  test("keeps enabled providers, expands variants, preserves SDK order", () => {
+    const providers = [
+      { id: "openai", enabled: { via: "env", name: "OPENAI_API_KEY" } },
+      { id: "anthropic", enabled: false },
+    ] as unknown as ProviderV2Info[]
+    const models = [
+      { providerID: "openai", id: "gpt-5.5", name: "GPT-5.5", status: "active", limit: { context: 400_000 }, variants: [{ id: "xhigh" }, { id: "high" }] },
+      { providerID: "anthropic", id: "claude-opus-4-7", name: "Opus", status: "active", variants: [] },
+    ] as unknown as ModelV2Info[]
+
+    const choices = toModelChoices(providers, models)
+    expect(choices.map((choice) => choice.value)).toEqual(["openai/gpt-5.5", "openai/gpt-5.5#xhigh", "openai/gpt-5.5#high"])
+    expect(choices[0]).toMatchObject({ value: "openai/gpt-5.5", label: "GPT-5.5", providerID: "openai", contextK: 400 })
+    expect(choices[1]).toMatchObject({ value: "openai/gpt-5.5#xhigh", label: "GPT-5.5 (xhigh)" })
+  })
+
+  test("with no provider info, keeps every model", () => {
+    const models = [{ providerID: "x", id: "m", name: "M", variants: [] }] as unknown as ModelV2Info[]
+    expect(toModelChoices([], models).map((choice) => choice.value)).toEqual(["x/m"])
+  })
+
+  test("surfaces a non-active status and skips it when active", () => {
+    const models = [
+      { providerID: "x", id: "beta", name: "Beta", status: "beta", variants: [] },
+      { providerID: "x", id: "stable", name: "Stable", status: "active", variants: [] },
+    ] as unknown as ModelV2Info[]
+    const choices = toModelChoices([], models)
+    expect(choices[0]).toMatchObject({ status: "beta" })
+    expect(choices[1]?.status).toBeUndefined()
+  })
+
+  test("dedupes repeated values", () => {
+    const models = [
+      { providerID: "x", id: "m", name: "M", variants: [] },
+      { providerID: "x", id: "m", name: "M again", variants: [] },
+    ] as unknown as ModelV2Info[]
+    expect(toModelChoices([], models).map((choice) => choice.value)).toEqual(["x/m"])
+  })
+})
+
+describe("parseModelsDev", () => {
+  test("flattens providers/models and sorts by value", () => {
+    const data = {
+      openai: { models: { "gpt-5.5": { name: "GPT-5.5", limit: { context: 400_000 } } } },
+      anthropic: { models: { "claude-opus-4-7": { name: "Opus" } } },
+    }
+    const choices = parseModelsDev(data)
+    expect(choices.map((choice) => choice.value)).toEqual(["anthropic/claude-opus-4-7", "openai/gpt-5.5"])
+    expect(choices.find((choice) => choice.value === "openai/gpt-5.5")).toMatchObject({ label: "GPT-5.5", contextK: 400 })
+  })
+
+  test("tolerates providers without models", () => {
+    expect(parseModelsDev({ openai: {} })).toEqual([])
+  })
+})


### PR DESCRIPTION
## What

Adds a per-user **global config** and an interactive **`archer config`** editor, so default models, agents, and pipelines can be set once for all repos and edited without hand-writing YAML.

### Global config (`~/.archer/config.yaml`)
- Same schema as the project file, merged underneath it: **project > global > built-in**. `defaults`/`agents`/`pipelines` merge by key/name; `permissions`/`attachments` concatenate (deny still wins).
- Takes effect on real runs (`resolveRunOptions` now loads the merged config), not just in the TUI.
- Global custom agents resolve their prompt at `~/.archer/agents/<name>.md`; prompt precedence is project > global > built-in.
- Home is relocatable via `ARCHER_HOME` (points at the directory holding `.archer`; also moves `~/.archer/runs`).

### `archer config` TUI
- Two tabs **Global / Project**, each editing its own file.
- **Model picker with autocomplete**: queries the OpenCode SDK for models exposed by your enabled providers (including reasoning variants like `#xhigh`), falls back to the full [models.dev](https://models.dev) catalog, and always accepts a free-typed `provider/model[#variant]`.
- Edit `defaults`, per-agent model/temperature, and pipelines (browse, add/delete/reorder steps, per-step model & max-attempts, add pipelines). Permissions/attachments are read-only.
- `initialize` writes a starter config when a tab has no file. Saving re-validates and rewrites clean YAML. No painted backgrounds, like the run TUIs.

## Files
- New: `src/config-tui.ts`, `src/model-catalog.ts`, `test/model-catalog.test.ts`
- Changed: `src/config.ts` (merge/serialize/writer/template), `src/workspace.ts` (archerHome/archerRoot), `src/cli.ts` (subcommand + merged config), `src/agents.ts` (global prompt fallback), `test/config.test.ts`, `README.md`

## Verification
- `bunx tsc --noEmit` clean, `bun test` → **92 pass / 0 fail** (added merge/serialize/global-load + model-catalog transform tests), `bun run build` OK.
- TUI rendered headlessly via `createTestRenderer` at 120×38 and 92×30: tabs, sections, detail panel, initialize state, input modal, and the model picker (loading state) all render correctly.

## Notes
- The model picker spins up a short-lived OpenCode server on first open (~1–2s, cached after); falls back to models.dev when OpenCode can't answer.
- The README diff also includes pre-existing uncommitted documentation for the prior `feat(pipelines)` work (renames phase→step, the default-pipeline table, the "Project configuration" section) that was already in the working tree before this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
