### PR TITLE
feat(config): add `archer init` command, reconciled with the config TUI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ build:
 install: build
 	@mkdir -p $(INSTALL_DIR)
 	@install -m 755 $(BIN) $(INSTALL_DIR)/$(BIN)
+	@bun run src/main.ts init --global --quiet
 	@echo "✓ Instalado en $(INSTALL_DIR)/$(BIN)"
 	@echo "  Asegúrate de que $(INSTALL_DIR) está en tu PATH."
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ bun install
 make install
 ```
 
-This leaves `archer` in `~/.local/bin/archer`. Make sure it's in your `PATH`.
+This leaves `archer` in `~/.local/bin/archer` and creates `~/.archer/config.yaml` plus `~/.archer/agents/*.md` with Archer's default configuration if they do not already exist. Make sure `~/.local/bin` is in your `PATH`.
 
 ## Usage
 
@@ -113,6 +113,15 @@ archer runs 20260519-103045-x7q2
 # two tabs (Global / Project), pick models with autocomplete, edit pipelines
 # and steps, or initialize a starter config when none exists.
 archer config
+
+# create project-local config and prompt files you can customize
+archer init
+
+# create global defaults (~/.archer) instead of project-local
+archer init --global
+
+# overwrite an existing config file
+archer init --force
 
 # auto-allow ask-level permissions (the hard denylist still applies)
 archer --prompt-file prd.md --yolo
@@ -242,6 +251,19 @@ Both files are merged before a run, with the project winning: `defaults`, `agent
 
 Keys: `↑/↓` move, `enter` edit/expand, `tab` switch tab, `a` add, `d` delete a step, `shift+↑/↓` reorder a step, `t` agent temperature, `m` step max-attempts, `s` save the active tab, `q` quit. Saving re-validates and rewrites clean YAML (comments are not preserved); the dashboard never paints backgrounds, like the run TUIs. Needs an interactive terminal.
 
+## Initializing config files (`archer init`)
+
+`archer config` is interactive; `archer init` is its non-interactive counterpart: it writes a commented starter config and copies the built-in agent prompts so you can customize them in place.
+
+```bash
+archer init                # .archer/config.yaml + .archer/agents/*.md in the current repo
+archer init --dir ../app   # same, in another repo
+archer init --global       # ~/.archer/config.yaml + ~/.archer/agents/*.md
+archer init --force        # overwrite existing files
+```
+
+The generated config documents every key (commented out) and inlines the built-in `default` pipeline so it's immediately editable. The copied `agents/*.md` prompts are picked up by name — edit them to override a built-in agent's prompt, or declare a new agent in the config and add its prompt file. Existing files are never overwritten unless `--force` is given. `make install` runs `archer init --global` automatically, so a fresh install ships with a ready-to-edit global config.
+
 ## Project Context And Custom Agents
 
 Archer automatically attaches these target-repo files to every phase when they exist:
@@ -265,7 +287,7 @@ Built-in agent prompts live as Markdown files under `prompts/`. A project can fu
     └── api-reviewer.md  # prompt for a project agent declared in config.yaml
 ```
 
-When a project override exists, it replaces that agent's built-in prompt completely. Project agents declared in `config.yaml` must bring their prompt at `.archer/agents/<name>.md` (validated at startup). In both cases Archer still appends its non-replaceable runtime safety guard rails from `prompts/runtime-safety.md`.
+When a project override exists, it replaces that agent's built-in prompt completely. Project agents declared in `config.yaml` must bring their prompt at `.archer/agents/<name>.md` (validated at startup). The same convention applies globally: `~/.archer/agents/<name>.md` overrides a built-in for every repo. Prompt precedence is `.archer/agents/<name>.md` (project) > `~/.archer/agents/<name>.md` (global) > the built-in prompt. In all cases Archer still appends its non-replaceable runtime safety guard rails from `prompts/runtime-safety.md`.
 
 ## Efficient Attachments
 
@@ -305,7 +327,7 @@ Each invocation creates `~/.archer/runs/<run-id>/`:
 
 The run dir is deleted on successful completion unless `--keep-run-dir`. If it fails, it's preserved for inspecting reports, diffs, and logs.
 
-The target repo only sees commits with prefix `archer(<phase>): ...`, made on the current branch. No CLI files are left in the project.
+The target repo only sees commits with prefix `archer(<phase>): ...`, made on the current branch. Normal runs leave no CLI files in the project; `archer init` intentionally creates `.archer/config.yaml` when you want project-local configuration.
 
 ## Development
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./test/env.ts"]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
-import { buildAgentRegistry, loadMergedArcherConfig, selectPipelineSpec, type ArcherDefaults } from "./config"
+import { buildAgentRegistry, loadMergedArcherConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ArcherDefaults } from "./config"
 import { defaultGptModel, defaultGptVariant, defaultPipeline, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
 import { parseModel, run } from "./runner"
 import { browseRuns } from "./runs"
@@ -37,11 +37,19 @@ export type ParsedArgs = {
   yolo?: boolean
 }
 
+export type InitOptions = {
+  targetDir: string
+  global: boolean
+  force: boolean
+  quiet: boolean
+}
+
 export type CliCommand =
   | { type: "help"; text: string }
   | { type: "run"; options: RunOptions }
   | { type: "runs"; runID?: string }
   | { type: "config"; targetDir: string }
+  | { type: "init"; options: InitOptions }
 
 export async function parseAndRun(argv: string[]) {
   const command = await parseCommand(argv)
@@ -58,6 +66,16 @@ export async function parseAndRun(argv: string[]) {
     // Imported lazily so normal runs never pull in the opentui editor.
     const { editConfigTui } = await import("./config-tui")
     await editConfigTui({ targetDir: command.targetDir })
+    return
+  }
+  if (command.type === "init") {
+    const result = command.options.global
+      ? await writeDefaultGlobalConfig(command.options.force)
+      : await writeDefaultProjectConfig(command.options.targetDir, command.options.force)
+    if (!command.options.quiet) {
+      const scope = command.options.global ? "global config" : "project config"
+      process.stdout.write(`${result.created ? "created" : "ensured"} ${scope}: ${result.path}\n`)
+    }
     return
   }
 
@@ -84,6 +102,11 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
     if (argv.length > 1) throw new Error("usage: archer config")
     return { type: "config", targetDir: process.cwd() }
   }
+  if (argv[0] === "init") {
+    const parsed = parseInitArgs(argv.slice(1))
+    if (parsed.help) return { type: "help", text: initHelp() }
+    return { type: "init", options: parsed }
+  }
 
   const parsed = parseArgs(argv)
   if (parsed.help) return { type: "help", text: help() }
@@ -105,6 +128,63 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
   }
 
   return { type: "run", options: { ...(await resolveRunOptions(parsed)), prompt } }
+}
+
+type ParsedInitArgs = InitOptions & { help?: boolean }
+
+function parseInitArgs(argv: string[]): ParsedInitArgs {
+  const parsed: ParsedInitArgs = {
+    targetDir: process.cwd(),
+    global: false,
+    force: false,
+    quiet: false,
+  }
+  let hasDir = false
+
+  for (let i = 0; i < argv.length; i++) {
+    const raw = argv[i]!
+    if (!raw.startsWith("-")) throw new Error("usage: archer init [--global] [--force] [--dir <path>]")
+
+    const { flag, value } = splitFlag(raw)
+    const noValue = () => {
+      if (value !== undefined) throw new Error(`${flag} does not take a value`)
+    }
+    const takeValue = () => {
+      if (value !== undefined) return value
+      const next = argv[++i]
+      if (next === undefined || (next.startsWith("-") && next !== "-")) throw new Error(`${flag} requires a value`)
+      return next
+    }
+
+    switch (flag) {
+      case "--help":
+      case "-h":
+        noValue()
+        parsed.help = true
+        return parsed
+      case "--global":
+        noValue()
+        parsed.global = true
+        break
+      case "--force":
+        noValue()
+        parsed.force = true
+        break
+      case "--quiet":
+        noValue()
+        parsed.quiet = true
+        break
+      case "--dir":
+        parsed.targetDir = resolve(process.cwd(), takeValue())
+        hasDir = true
+        break
+      default:
+        throw new Error(`unknown init flag: ${flag}`)
+    }
+  }
+
+  if (parsed.global && hasDir) throw new Error("use either --global or --dir, not both")
+  return parsed
 }
 
 /** Applies the precedence chain and resolves the pipeline the run will execute. */
@@ -311,10 +391,13 @@ Usage:
   archer "Add onboarding"
   archer --prompt-file prd.md --file lib/onboarding --file test/onboarding_test.dart
   archer --pipeline bug-fix --prompt-file bug.md
+  archer init
   archer runs [run-id]
   archer config
 
 Commands:
+  init                     Create .archer/config.yaml and .archer/agents/*.md in the target repo
+  init --global            Create ~/.archer/config.yaml and ~/.archer/agents/*.md
   runs [run-id]            Browse run history: resume a run, read its summary/reports,
                            or open a subshell in its run dir (under ~/.archer/runs)
   config                   View and edit the global (~/.archer) and current project config in a TUI
@@ -345,13 +428,31 @@ Flags:
   --base <ref>             Branch/base for calculating diffs (default: main)
   --dir <path>             Target repo (default: cwd)
 
-Project config (.archer/config.yaml):
+Config files:
+  ~/.archer/config.yaml    user defaults, created by make install or archer init --global
+  .archer/config.yaml      project-local overrides, created by archer init
+  agents/*.md              Markdown prompts loaded by matching the agent name
+
+Config keys:
   defaults:                model, maxAttempts, baseRef, pipeline, appRunCommand, emulator, interactiveModel
-  agents:                  project agents (prompt at .archer/agents/<name>.md) or built-in overrides
+  agents:                  project agents or built-in overrides; prompts live at agents/<name>.md
   pipelines:               named step lists mixing agents and human-review gates
   permissions:             allow/deny additions to the bash policy (deny always wins)
   attachments:             files attached to every step
   The same schema lives globally at ~/.archer/config.yaml; project config merges on top.
   Precedence: CLI flags > project config > global config > built-in defaults.
+`
+}
+
+function initHelp() {
+  return `archer init [--global] [--force] [--dir <path>]
+
+Create Archer's default config file and agent prompt Markdown files. Existing files are not overwritten unless --force is set.
+
+Options:
+  --global                 Write ~/.archer/config.yaml instead of a project config
+  --dir <path>             Target repo for .archer/config.yaml (default: cwd)
+  --force                  Overwrite an existing config file
+  --quiet                  Suppress status output
 `
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,8 +1,8 @@
 import { statSync } from "node:fs"
-import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 
-import { projectAgentPromptPath } from "./agents"
+import { builtInPromptPath, projectAgentPromptPath } from "./agents"
 import { log } from "./log"
 import {
   agentAliases,
@@ -16,7 +16,7 @@ import {
   type StepSpec,
 } from "./pipeline"
 import type { AgentSpec, PermissionAdditions } from "./types"
-import { archerHome, archerRoot } from "./workspace"
+import { archerHome, archerRoot, globalConfigPath } from "./workspace"
 
 /**
  * Project configuration loaded from .archer/config.yaml. Everything is
@@ -116,6 +116,137 @@ export async function loadMergedArcherConfig(targetDir: string): Promise<ArcherC
   return mergeArcherConfigs(global, project)
 }
 
+/**
+ * The commented YAML template written by `archer init`. It documents every key
+ * (commented out) and inlines the built-in `default` pipeline so it's an
+ * immediately editable starting point. Unlike `defaultConfigTemplate` (used by
+ * the TUI's initialize action), this is a human-readable string with comments.
+ */
+export const defaultArcherConfig = `# Archer configuration.
+# Global default path: ~/.archer/config.yaml
+# Project override path: .archer/config.yaml
+
+version: 1
+
+defaults:
+  # model: openai/gpt-5.5#xhigh # optional: uncomment to force every agent unless a step/agent overrides it
+  # maxAttempts: 2
+  # baseRef: main
+  # pipeline: default
+  # interactiveModel: openai/gpt-5.5#xhigh
+  # appRunCommand: pnpm dev # optional: unset by default; used during human-review
+  # emulator: Pixel_8 # optional: unset by default; used during human-review
+
+# Agents are matched by name with Markdown prompts next to this config:
+#   agents/<name>.md
+# Uncomment entries to override metadata/model/temperature or to add custom agents.
+# Custom agents must have a matching agents/<name>.md prompt file.
+# agents:
+#   implementer:
+#     description: Implements the feature described in the PRD respecting repo patterns
+#     model: openai/gpt-5.5#xhigh
+#   design-polisher:
+#     description: Polishes new UI following the repo's design system, without redesigning
+#     model: anthropic/claude-opus-4-7
+#     temperature: 0.2
+#   api-reviewer:
+#     description: Reviews API consistency
+#     model: openai/gpt-5.5#xhigh
+
+pipelines:
+  default:
+    description: Implementation, pattern/security audits, design polish, tests, and adversarial review
+    steps:
+      - agent: implementer
+        reports: none
+      - human-review
+      - patterns
+      - security
+      - design
+      - agent: tests
+        reports: none
+      - agent: adversarial
+        reports: all
+
+permissions:
+  allow: []
+  deny: []
+
+attachments: []
+`
+
+export type ConfigWriteResult = {
+  path: string
+  created: boolean
+}
+
+/** Path of the project config file (default name). */
+export function projectConfigPath(targetDir: string) {
+  return join(targetDir, ".archer", "config.yaml")
+}
+
+/** Re-exported from workspace so callers don't need both modules. */
+export { globalConfigPath }
+
+/** Writes the global config at ~/.archer/config.yaml (plus default agent prompts). */
+export async function writeDefaultGlobalConfig(force = false): Promise<ConfigWriteResult> {
+  return writeDefaultArcherConfig(globalConfigPath(), force)
+}
+
+/** Writes a project config at <targetDir>/.archer/config.yaml (plus default agent prompts). */
+export async function writeDefaultProjectConfig(targetDir: string, force = false): Promise<ConfigWriteResult> {
+  await assertDirectory(targetDir)
+  return writeDefaultArcherConfig(projectConfigPath(targetDir), force)
+}
+
+/**
+ * Writes the commented template config and copies every built-in agent prompt
+ * to `<dirname(path)>/agents/<name>.md`. Existing files are left alone unless
+ * `force` is set. Agent prompts live next to the config file under `agents/`,
+ * mirroring how the loader discovers them.
+ */
+export async function writeDefaultArcherConfig(path: string, force = false): Promise<ConfigWriteResult> {
+  const configDir = dirname(path)
+  await mkdir(configDir, { recursive: true })
+  await writeDefaultAgentPrompts(configDir, force)
+  try {
+    await writeFile(path, defaultArcherConfig, { flag: force ? "w" : "wx" })
+    return { path, created: true }
+  } catch (error) {
+    if (!force && isErrno(error, "EEXIST")) return { path, created: false }
+    throw error
+  }
+}
+
+async function writeDefaultAgentPrompts(configDir: string, force: boolean) {
+  const agentsDir = join(configDir, "agents")
+  await mkdir(agentsDir, { recursive: true })
+  for (const agent of builtInAgents) {
+    const target = join(agentsDir, `${agent.name}.md`)
+    const body = await readFile(builtInPromptPath(agent.name), "utf8")
+    try {
+      await writeFile(target, body, { flag: force ? "w" : "wx" })
+    } catch (error) {
+      if (!force && isErrno(error, "EEXIST")) continue
+      throw error
+    }
+  }
+}
+
+async function assertDirectory(path: string) {
+  let info: Awaited<ReturnType<typeof stat>>
+  try {
+    info = await stat(path)
+  } catch {
+    throw new Error(`target directory does not exist: ${path}`)
+  }
+  if (!info.isDirectory()) throw new Error(`target path is not a directory: ${path}`)
+}
+
+function isErrno(error: unknown, code: string) {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === code
+}
+
 export function parseArcherConfig(body: string, source: string, targetDir: string): ArcherConfig {
   let raw: unknown
   try {
@@ -135,7 +266,7 @@ export function parseArcherConfig(body: string, source: string, targetDir: strin
 
   if (root.version !== undefined && root.version !== 1) v.fail("version", `unsupported value ${JSON.stringify(root.version)}; this archer reads version 1`)
 
-  if (root.defaults !== undefined) config.defaults = validateDefaults(v, root.defaults)
+  if (root.defaults !== undefined && root.defaults !== null) config.defaults = validateDefaults(v, root.defaults)
   if (root.agents !== undefined) config.agents = validateAgents(v, root.agents, targetDir)
   if (root.pipelines !== undefined) config.pipelines = validatePipelines(v, root.pipelines)
   if (root.permissions !== undefined) config.permissions = validatePermissions(v, root.permissions)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,10 +1,10 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterAll, describe, expect, test } from "bun:test"
 
-import { parseArgs, parseCommand } from "../src/cli"
+import { parseAndRun, parseArgs, parseCommand } from "../src/cli"
 import { stepNames } from "../src/pipeline"
 
 describe("cli parsing", () => {
@@ -195,5 +195,55 @@ describe("config precedence", () => {
     await expect(parseCommand(["--dir", dir, "--pipeline", "ghost", "prompt"])).rejects.toThrow(
       'unknown pipeline "ghost" (available: default, quick)',
     )
+  })
+})
+
+describe("init command", () => {
+  const dirs: string[] = []
+
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  test("parses init options without requiring a prompt", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-cli-init-"))
+    dirs.push(dir)
+
+    const local = await parseCommand(["init", "--dir", dir, "--force", "--quiet"])
+    expect(local.type).toBe("init")
+    if (local.type === "init") {
+      expect(local.options).toMatchObject({ targetDir: dir, global: false, force: true, quiet: true })
+    }
+
+    const global = await parseCommand(["init", "--global", "--force"])
+    expect(global.type).toBe("init")
+    if (global.type === "init") expect(global.options).toMatchObject({ global: true, force: true })
+  })
+
+  test("rejects incompatible init options", async () => {
+    await expect(parseCommand(["init", "--global", "--dir", "."])).rejects.toThrow("either --global or --dir")
+    await expect(parseCommand(["init", "extra"])).rejects.toThrow("usage: archer init")
+  })
+
+  test("creates project config without overwriting unless forced", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-cli-init-write-"))
+    dirs.push(dir)
+    const path = join(dir, ".archer", "config.yaml")
+
+    await parseAndRun(["init", "--dir", dir, "--quiet"])
+    expect(await readFile(path, "utf8")).toContain("version: 1")
+    expect(await readFile(path, "utf8")).toContain("#   implementer:")
+    expect(await readFile(path, "utf8")).toContain("# maxAttempts: 2")
+    expect(await readFile(join(dir, ".archer", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+
+    await writeFile(path, "version: 1\nattachments:\n  - custom.md\n")
+    await writeFile(join(dir, ".archer", "agents", "implementer.md"), "# Custom Implementer\n")
+    await parseAndRun(["init", "--dir", dir, "--quiet"])
+    expect(await readFile(path, "utf8")).toContain("custom.md")
+    expect(await readFile(join(dir, ".archer", "agents", "implementer.md"), "utf8")).toContain("# Custom Implementer")
+
+    await parseAndRun(["init", "--dir", dir, "--force", "--quiet"])
+    expect(await readFile(path, "utf8")).not.toContain("custom.md")
+    expect(await readFile(join(dir, ".archer", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -16,8 +16,10 @@ import {
   parseArcherConfig,
   selectPipelineSpec,
   serializeArcherConfig,
+  writeDefaultArcherConfig,
+  writeDefaultProjectConfig,
 } from "../src/config"
-import { defaultGptModel, defaultGptVariant, defaultOpusModel } from "../src/pipeline"
+import { builtInAgents, defaultGptModel, defaultGptVariant, defaultOpusModel } from "../src/pipeline"
 
 const dirs: string[] = []
 
@@ -280,5 +282,74 @@ describe("global config", () => {
     const project = await projectDir("defaults:\n  maxAttempts: 2\n")
     const merged = await loadMergedArcherConfig(project)
     expect(merged?.defaults).toEqual({ model: "openai/gpt-5.5#xhigh", maxAttempts: 2 })
+  })
+})
+
+describe("default config init", () => {
+  test("the default config template is valid and explicit", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-default-config-"))
+    dirs.push(dir)
+    const path = join(dir, "config.yaml")
+    await writeDefaultArcherConfig(path)
+
+    const body = await readFile(path, "utf8")
+    const config = parseArcherConfig(body, path, dir)
+
+    expect(body).toContain("# maxAttempts: 2")
+    expect(body).toContain("# baseRef: main")
+    expect(body).toContain("# pipeline: default")
+    expect(body).toContain("# interactiveModel: openai/gpt-5.5#xhigh")
+    expect(body).toContain("# appRunCommand: pnpm dev")
+    expect(body).toContain("# agents:")
+    expect(body).toContain("#   implementer:")
+    expect(body).toContain("#   design-polisher:")
+    expect(body).toContain("#   api-reviewer:")
+    expect(config.defaults).toEqual({})
+    expect(config.agents).toEqual({})
+    for (const agent of builtInAgents) {
+      expect(await readFile(join(dir, "agents", `${agent.name}.md`), "utf8")).toContain("#")
+    }
+    expect(config.pipelines.default?.steps).toEqual([
+      { agent: "implementer", reports: "none" },
+      "human-review",
+      "patterns",
+      "security",
+      "design",
+      { agent: "tests", reports: "none" },
+      { agent: "adversarial", reports: "all" },
+    ])
+    expect(config.permissions).toEqual({ allow: [], deny: [] })
+    expect(config.attachments).toEqual([])
+  })
+
+  test("writes default config without overwriting unless forced", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-config-write-"))
+    dirs.push(dir)
+    const path = join(dir, "config.yaml")
+
+    expect(await writeDefaultArcherConfig(path)).toEqual({ path, created: true })
+    expect(await readFile(path, "utf8")).toContain("version: 1")
+    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+
+    await writeFile(path, "version: 1\nattachments:\n  - custom.md\n")
+    await writeFile(join(dir, "agents", "implementer.md"), "# Custom Implementer\n")
+    expect(await writeDefaultArcherConfig(path)).toEqual({ path, created: false })
+    expect(await readFile(path, "utf8")).toContain("custom.md")
+    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Custom Implementer")
+
+    expect(await writeDefaultArcherConfig(path, true)).toEqual({ path, created: true })
+    expect(await readFile(path, "utf8")).not.toContain("custom.md")
+    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+  })
+
+  test("writes project default config under .archer", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-project-config-"))
+    dirs.push(dir)
+    const path = join(dir, ".archer", "config.yaml")
+
+    expect(await writeDefaultProjectConfig(dir)).toEqual({ path, created: true })
+    expect(await writeDefaultProjectConfig(dir)).toEqual({ path, created: false })
+    expect(await readFile(path, "utf8")).toContain("pipelines:")
+    expect(await readFile(join(dir, ".archer", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
   })
 })

--- a/test/env.ts
+++ b/test/env.ts
@@ -1,0 +1,10 @@
+import { mkdirSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+// Isolate every test run from the developer's real ~/.archer so tests never
+// read or write the user's actual config, runs, or agent prompts. ARCHER_HOME
+// points at the directory that holds `.archer` (the same convention as a repo
+// root), so the global config resolves to <tmp>/.archer/config.yaml.
+process.env.ARCHER_HOME ??= join(tmpdir(), `archer-test-home-${process.pid}`)
+mkdirSync(process.env.ARCHER_HOME, { recursive: true })


### PR DESCRIPTION
## Summary

Reconciles #1 with the `archer config` TUI that landed on `main` via #2, so both config entry points coexist:

- **`archer config`** — interactive TUI editor for global and project config (from #2, untouched)
- **`archer init`** — non-interactive: writes a commented starter config + copies built-in agent prompts (ported from #1, adapted to main's architecture)

### What was reconciled

#1 and #2 both reimplemented the same global-config infrastructure (loading, merging, `ARCHER_HOME`, global agent prompts) with different APIs. This PR ports #1's `init` command on top of #2's already-merged architecture, reusing its `globalConfigPath()`, `globalAgentsDir()`, `loadMergedArcherConfig()`, and `ARCHER_HOME` model (points at the directory that holds `.archer`, like a repo root) instead of duplicating them.

### What landed

- `archer init [--global] [--force] [--dir <path>] [--quiet]` — writes a commented YAML template that documents every key, plus copies every built-in agent prompt to `agents/*.md` so they can be customized in place
- `make install` runs `archer init --global --quiet` so a fresh install ships with a ready-to-edit `~/.archer/config.yaml`
- `parseArcherConfig` now tolerates `defaults: null` (a bare key with only comments underneath), which the commented template produces
- Test runs are isolated from the developer's real `~/.archer` via a `bunfig.toml` preload (`test/env.ts`) — previously only the `global config` describe block managed `ARCHER_HOME`, leaving other tests exposed to the user's real config
- README documents both `archer config` and `archer init`, with the prompt precedence chain (project > global > built-in)

### What was intentionally dropped from #1

#1 restructured `loadArcherConfig`/`mergeArcherConfigs`/`parseArcherConfig`/`validateAgents` with a `configDir` parameter and an array-based merge. None of that is needed: #2's `loadGlobalArcherConfig()` already parses the global config with `targetDir = archerRoot()`, which resolves agent-prompt validation to `~/.archer/agents/` correctly. Keeping #2's design avoids churning the config module and the TUI that depends on it.

## Tests
- `bun run typecheck`
- `bun test` (98 pass)