### PR TITLE
feat(resume): recover a dirty working tree from an interrupted phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,10 @@ archer --prompt-file prd.md --app-run-command "pnpm dev"
 archer --prompt-file prd.md --emulator Pixel_8 --app-run-command "flutter run -d emulator-5554"
 
 # resume a failed run (phases that already wrote their report are skipped,
-# and the dashboard restores their real duration, cost, and session)
+# and the dashboard restores their real duration, cost, and session).
+# If a phase was interrupted before its commit and left the working tree dirty,
+# an interactive resume asks whether to commit those changes as that phase and
+# continue with the following ones.
 archer --resume 20260519-103045-x7q2
 
 # browse run history in the dashboard TUI: a selectable list (newest first,
@@ -223,6 +226,7 @@ The rules:
 - **Project pipelines shadow built-ins**: defining `pipelines.default` replaces the built-in default.
 - **`--no-human-review`** (and non-TTY runs) drop every `human-review` gate from the pipeline.
 - **Resume is frozen**: the resolved pipeline is persisted in the run's `metadata.json`; `--resume` replays it even if the config changed since.
+- **Dirty-tree recovery**: a phase interrupted before its commit (Ctrl+C, a failed commit step, a killed process) leaves uncommitted work in the tree, which normally blocks `--resume`. In an interactive terminal, resume offers to commit that work as the interrupted phase (`archer(<phase>): …`), mark it done, and continue with the following phases. Decline (or a non-TTY resume) keeps the old "commit/stash first" behavior.
 - **Permissions are additive**: `permissions.deny` extends the hard denylist, `permissions.allow` extends the allowlist, deny always wins, and there is deliberately no way for a repo to grant itself `--yolo`.
 
 ## Global configuration

--- a/src/git.ts
+++ b/src/git.ts
@@ -40,7 +40,7 @@ async function execFile(command: string, args: string[], options: ExecOptions): 
   return { stdout, stderr, exitCode }
 }
 
-export async function ensureRepoReady(cwd: string, options: { includeDirty?: boolean; maxAttempts?: number; baseRef?: string } = {}) {
+export async function ensureRepoReady(cwd: string, options: { includeDirty?: boolean; maxAttempts?: number; baseRef?: string; allowDirty?: boolean } = {}) {
   const rootResult = await execFile("git", ["rev-parse", "--show-toplevel"], { cwd, allowFailure: true })
   if (rootResult.exitCode !== 0) {
     throw new Error("archer must be run at the root of a git repo")
@@ -62,12 +62,11 @@ export async function ensureRepoReady(cwd: string, options: { includeDirty?: boo
 
   const status = await execFile("git", ["status", "--porcelain"], { cwd })
   if (status.stdout.trim() !== "") {
+    // A resumed run defers the dirty-tree decision to the recovery step, which
+    // can offer to commit an interrupted phase's leftover changes and continue.
+    if (options.allowDirty) return
     if (!options.includeDirty) {
-      // On resume the target dir comes from the run's metadata, not the user's
-      // cwd — name the repo and the files or the error is impossible to act on.
-      throw new Error(
-        `working tree at ${cwd} is not clean; do commit/stash or use --include-dirty to include those changes\n${dirtyFilesPreview(status.stdout)}`,
-      )
+      throw dirtyTreeError(cwd, status.stdout)
     }
     if ((options.maxAttempts ?? 1) > 1) {
       throw new Error("--include-dirty can't be combined with --max-attempts > 1; use --max-attempts 1")
@@ -76,9 +75,23 @@ export async function ensureRepoReady(cwd: string, options: { includeDirty?: boo
   }
 }
 
+export async function statusPorcelain(cwd: string): Promise<string> {
+  const status = await execFile("git", ["status", "--porcelain"], { cwd })
+  return status.stdout
+}
+
+// On resume the target dir comes from the run's metadata, not the user's cwd —
+// name the repo and the files or the error is impossible to act on.
+export function dirtyTreeError(cwd: string, porcelain: string, options: { resuming?: boolean } = {}) {
+  const hint = options.resuming
+    ? "resume in an interactive terminal to commit these changes as the interrupted phase and continue, or commit/stash them manually"
+    : "do commit/stash or use --include-dirty to include those changes"
+  return new Error(`working tree at ${cwd} is not clean; ${hint}\n${dirtyFilesPreview(porcelain)}`)
+}
+
 const maxDirtyPreview = 5
 
-function dirtyFilesPreview(porcelain: string) {
+export function dirtyFilesPreview(porcelain: string) {
   const lines = porcelain.split("\n").filter(Boolean)
   const shown = lines.slice(0, maxDirtyPreview).map((line) => `  ${line}`)
   if (lines.length > shown.length) shown.push(`  … and ${lines.length - shown.length} more`)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,11 +1,13 @@
 import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
+import { stdin, stdout } from "node:process"
+import { createInterface } from "node:readline/promises"
 
 import type { AssistantMessage, FilePartInput, OpencodeClient, Part } from "@opencode-ai/sdk/v2"
 
 import { opencodeConfig } from "./agents"
 import { fileParts } from "./attachments"
-import { addAllAndCommit, createCleanRepoSnapshot, ensureRepoReady, restoreRepoSnapshot, type RepoSnapshot, writeDiff } from "./git"
+import { addAllAndCommit, createCleanRepoSnapshot, dirtyFilesPreview, dirtyTreeError, ensureRepoReady, restoreRepoSnapshot, type RepoSnapshot, statusPorcelain, writeDiff } from "./git"
 import { runHumanReviewGate } from "./human"
 import { log } from "./log"
 import { openRunMetadata, recordProgress, type RunMetadataStore } from "./metadata"
@@ -139,7 +141,12 @@ function installShutdownSignals(shutdown: RunShutdown) {
 }
 
 export async function run(options: RunOptions) {
-  await ensureRepoReady(options.targetDir, { includeDirty: options.includeDirty, maxAttempts: options.maxAttempts, baseRef: options.baseRef })
+  await ensureRepoReady(options.targetDir, {
+    includeDirty: options.includeDirty,
+    maxAttempts: options.maxAttempts,
+    baseRef: options.baseRef,
+    allowDirty: Boolean(options.resumeRunID),
+  })
 
   const workspace = options.resumeRunID
     ? await resumeWorkspace(options.resumeRunID)
@@ -162,6 +169,10 @@ export async function run(options: RunOptions) {
     const pipeline = metadata.pipeline
     validateStepFilters(pipeline, options)
     ensureAgentsAvailable(pipeline, options.agents)
+    // A run interrupted before its phase commit leaves the tree dirty; on resume
+    // offer to commit that work as the interrupted phase and continue. Runs here,
+    // before the TUI grabs the terminal, so the readline prompt stays visible.
+    await maybeRecoverDirtyTree(workspace, metadata, options)
     progress = recordProgress(
       await createProgressUI(progressPhases(pipeline), options.tui, () => shutdown.request("Ctrl+C"), autoAccept),
       metadata,
@@ -271,20 +282,118 @@ export async function restorePhaseFromPreviousRun(
   phase: AgentStep,
   progress: ProgressUI,
 ): Promise<boolean> {
-  const reportAbs = join(workspace.dir, phase.reportPath)
-  if (!(await exists(reportAbs))) return false
-
-  const snapshot = metadata.snapshot(phase.name)
-  if (snapshot?.status === "failed") {
-    await rm(reportAbs, { force: true })
-    log.info(`[${phase.name}] failed in the previous run; retrying`)
+  if (await phaseNeedsRun(workspace, metadata, phase)) {
+    // A failed phase can leave its report behind; drop it so persistPhaseReport
+    // writes a fresh one on the rerun instead of keeping the stale one.
+    const reportAbs = join(workspace.dir, phase.reportPath)
+    if (await exists(reportAbs)) {
+      await rm(reportAbs, { force: true })
+      log.info(`[${phase.name}] failed in the previous run; retrying`)
+    }
     return false
   }
 
+  const snapshot = metadata.snapshot(phase.name)
   if (snapshot) progress.phaseRestored(phase.name, snapshot)
   else progress.phaseCompleted(phase.name, "already completed in previous run")
   log.info(`[${phase.name}] report exists; skipping on resume`)
   return true
+}
+
+// A phase still needs to run on resume when its report is missing (it never
+// finished) or the metadata marks it failed (its report, if any, is stale).
+async function phaseNeedsRun(workspace: Workspace, metadata: RunMetadataStore, phase: AgentStep): Promise<boolean> {
+  if (!(await exists(join(workspace.dir, phase.reportPath)))) return true
+  return metadata.snapshot(phase.name)?.status === "failed"
+}
+
+// The agent phase a resume would run next: the first one still needing a run,
+// skipping human gates. The dirty tree belongs to whichever phase was
+// interrupted before its commit, which is exactly that phase.
+export async function selectInterruptedPhase(
+  workspace: Workspace,
+  metadata: RunMetadataStore,
+  pipeline: Pipeline,
+): Promise<AgentStep | undefined> {
+  for (const step of pipeline.steps) {
+    if (step.type !== "agent") continue
+    if (await phaseNeedsRun(workspace, metadata, step)) return step
+  }
+  return undefined
+}
+
+// On resume with a dirty tree, offer to commit the interrupted phase's leftover
+// work and continue. Runs before the TUI starts so the prompt owns the terminal.
+async function maybeRecoverDirtyTree(workspace: Workspace, metadata: RunMetadataStore, options: RunOptions) {
+  if (!options.resumeRunID) return
+  const porcelain = await statusPorcelain(options.targetDir)
+  if (porcelain.trim() === "") return
+
+  const dirty = () => dirtyTreeError(options.targetDir, porcelain, { resuming: true })
+  const phase = await selectInterruptedPhase(workspace, metadata, metadata.pipeline)
+  // No pending agent phase means the changes don't belong to an interrupted
+  // phase (stray edits); leave them for the user rather than guess.
+  if (!phase) throw dirty()
+  if (!(stdin.isTTY && stdout.isTTY)) throw dirty()
+  if (!(await confirmRecovery(phase.name, porcelain))) throw dirty()
+
+  await commitRecoveredPhase(workspace, metadata, phase, options.targetDir)
+}
+
+async function confirmRecovery(phaseName: string, porcelain: string): Promise<boolean> {
+  stdout.write(`Resume found uncommitted changes from interrupted phase "${phaseName}":\n${dirtyFilesPreview(porcelain)}\n`)
+  const rl = createInterface({ input: stdin, output: stdout })
+  const controller = new AbortController()
+  let interrupted = false
+  // Raw-mode readline swallows the process SIGINT and emits this event instead;
+  // without it Ctrl+C at the prompt would hang.
+  rl.on("SIGINT", () => {
+    interrupted = true
+    controller.abort()
+  })
+  try {
+    const answer = (await rl.question(`commit changes as '${phaseName}' and continue? [y/N] > `, { signal: controller.signal })).trim().toLowerCase()
+    return answer === "y" || answer === "yes"
+  } catch (error) {
+    if (interrupted) throw new UserAbortError("Ctrl+C received")
+    throw error
+  } finally {
+    rl.close()
+  }
+}
+
+// Treats the dirty tree as the interrupted phase's output: writes a recovery
+// report if the phase never wrote one, commits everything as that phase, and
+// marks it completed so the resume loop skips it and runs the rest.
+export async function commitRecoveredPhase(
+  workspace: Workspace,
+  metadata: RunMetadataStore,
+  phase: AgentStep,
+  targetDir: string,
+) {
+  const reportAbs = join(workspace.dir, phase.reportPath)
+  if (!(await exists(reportAbs))) {
+    await mkdir(dirname(reportAbs), { recursive: true })
+    await writeFile(reportAbs, recoveryReport(phase.name))
+  }
+
+  const committed = await addAllAndCommit(`archer(${phase.name}): ${await summaryFromReport(reportAbs)}`, targetDir)
+  if (committed) log.info(`[${phase.name}] recovered uncommitted changes into a commit; continuing from the next phase`)
+  else log.warn(`[${phase.name}] nothing to commit during recovery`)
+
+  metadata.phaseEnded(phase.name, "completed")
+  await metadata.flush()
+}
+
+function recoveryReport(phaseName: string) {
+  return [
+    "# Recovered uncommitted changes",
+    "",
+    `Phase "${phaseName}" was interrupted before archer committed its work. The`,
+    "uncommitted changes left in the working tree were committed as this phase during a",
+    "manual resume recovery, and the pipeline continued from the next phase.",
+    "",
+  ].join("\n")
 }
 
 async function runPhase(

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -1,6 +1,9 @@
-import { describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
-import { findSuspiciousStagedFiles } from "../src/git"
+import { ensureRepoReady, findSuspiciousStagedFiles } from "../src/git"
 
 describe("findSuspiciousStagedFiles", () => {
   test("flags common secret filenames", () => {
@@ -48,5 +51,39 @@ describe("findSuspiciousStagedFiles", () => {
   test("decodes C-quoted porcelain paths before matching", () => {
     const porcelain = ['A  "secret dir/.env"', 'A  "caf\\303\\251/.env"'].join("\n")
     expect(findSuspiciousStagedFiles(porcelain)).toEqual(["secret dir/.env", "cafÃ©/.env"])
+  })
+})
+
+describe("ensureRepoReady", () => {
+  const dirs: string[] = []
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  async function git(args: string[], cwd: string) {
+    const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe", env: process.env })
+    if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")}: ${await new Response(proc.stderr).text()}`)
+  }
+
+  async function dirtyRepo(): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "archer-ensure-repo-"))
+    dirs.push(dir)
+    await git(["init", "-q"], dir)
+    await writeFile(join(dir, "dirty.txt"), "uncommitted\n")
+    // git reports the physical path; ensureRepoReady resolves symlinks too, but
+    // mkdtemp on macOS hands back a /var → /private/var symlink, so compare from there.
+    const proc = Bun.spawn(["git", "-C", dir, "rev-parse", "--show-toplevel"], { stdout: "pipe", stderr: "pipe" })
+    await proc.exited
+    return (await new Response(proc.stdout).text()).trim()
+  }
+
+  test("throws on a dirty tree without allowDirty", async () => {
+    const dir = await dirtyRepo()
+    await expect(ensureRepoReady(dir)).rejects.toThrow(/not clean/)
+  })
+
+  test("allowDirty defers the dirty-tree decision so resume can recover", async () => {
+    const dir = await dirtyRepo()
+    await expect(ensureRepoReady(dir, { allowDirty: true })).resolves.toBeUndefined()
   })
 })

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,21 +1,53 @@
-import { describe, expect, test } from "bun:test"
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { afterAll, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import type { RunMetadataStore } from "../src/metadata"
+import { openRunMetadata, type RunMetadataStore } from "../src/metadata"
 import { noopProgress, type ProgressPhaseSnapshot } from "../src/progress"
 import {
   UserAbortError,
+  commitRecoveredPhase,
   describeSessionActivity,
   newActivityState,
   parseModel,
   restorePhaseFromPreviousRun,
+  selectInterruptedPhase,
   shouldRetryAttempt,
   shouldSkip,
 } from "../src/runner"
-import type { AgentStep } from "../src/types"
+import type { AgentStep, Pipeline } from "../src/types"
 import type { Workspace } from "../src/workspace"
+
+const recoveryDirs: string[] = []
+
+afterAll(async () => {
+  await Promise.all(recoveryDirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function git(args: string[], cwd: string) {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" },
+  })
+  const [out, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+  if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`)
+  return out
+}
+
+async function dirtyRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "archer-recover-repo-"))
+  recoveryDirs.push(dir)
+  await git(["init", "-q"], dir)
+  await writeFile(join(dir, "keep.txt"), "base\n")
+  await git(["add", "-A"], dir)
+  await git(["commit", "-qm", "base"], dir)
+  // leave an uncommitted change behind, as an interrupted phase would
+  await writeFile(join(dir, "feature.txt"), "work in progress\n")
+  return dir
+}
 
 function messageUpdated(info: Record<string, unknown>) {
   return { type: "message.updated", properties: { sessionID: "ses_1", info } }
@@ -152,5 +184,73 @@ describe("runner helpers", () => {
     expect(shouldRetryAttempt(new Error("aborted fetch"), controller.signal, 1, 2)).toBe(false)
     expect(shouldRetryAttempt(new UserAbortError(), new AbortController().signal, 1, 2)).toBe(false)
     expect(shouldRetryAttempt(new Error("exhausted"), new AbortController().signal, 2, 2)).toBe(false)
+  })
+})
+
+describe("dirty-tree recovery", () => {
+  const agent = (name: string): AgentStep =>
+    ({ type: "agent", name, agentName: name, description: name, model: "openai/gpt-5.5", inputFiles: [], inputDiff: false, reportPath: `reports/${name}.md` })
+  const pipeline: Pipeline = {
+    name: "p",
+    steps: [agent("implementer"), { type: "human", name: "review", description: "review" }, agent("patterns"), agent("tests")],
+  }
+  const fakeMetadata = (statuses: Record<string, ProgressPhaseSnapshot | undefined>): RunMetadataStore =>
+    ({ snapshot: (name: string) => statuses[name] }) as unknown as RunMetadataStore
+
+  async function workspaceWithReports(reports: string[]): Promise<Workspace> {
+    const dir = await mkdtemp(join(tmpdir(), "archer-recover-ws-"))
+    recoveryDirs.push(dir)
+    await mkdir(join(dir, "reports"), { recursive: true })
+    for (const name of reports) await writeFile(join(dir, "reports", `${name}.md`), `# ${name}`)
+    return { dir, runID: "20260101-000000-test" }
+  }
+
+  test("selects the first agent phase a resume would re-run, skipping human gates", async () => {
+    // implementer done, patterns failed (stale report), tests never ran.
+    const ws = await workspaceWithReports(["implementer", "patterns"])
+    const metadata = fakeMetadata({ implementer: { status: "completed" }, patterns: { status: "failed" } })
+    const phase = await selectInterruptedPhase(ws, metadata, pipeline)
+    expect(phase?.name).toBe("patterns")
+  })
+
+  test("falls back to the first phase missing its report", async () => {
+    const ws = await workspaceWithReports(["implementer"])
+    const metadata = fakeMetadata({ implementer: { status: "completed" } })
+    const phase = await selectInterruptedPhase(ws, metadata, pipeline)
+    expect(phase?.name).toBe("patterns")
+  })
+
+  test("returns undefined when every agent phase is already done", async () => {
+    const ws = await workspaceWithReports(["implementer", "patterns", "tests"])
+    const metadata = fakeMetadata({ implementer: { status: "completed" }, patterns: { status: "completed" }, tests: { status: "completed" } })
+    expect(await selectInterruptedPhase(ws, metadata, pipeline)).toBeUndefined()
+  })
+
+  test("commits the dirty tree as the phase, writes a recovery report, and marks it completed", async () => {
+    const repo = await dirtyRepo()
+    const ws = await workspaceWithReports([])
+    const metadata = await openRunMetadata(ws, repo, pipeline)
+
+    await commitRecoveredPhase(ws, metadata, agent("implementer"), repo)
+
+    // working tree is clean and the leftover work is in a new archer commit
+    expect((await git(["status", "--porcelain"], repo)).trim()).toBe("")
+    expect(await git(["log", "-1", "--pretty=%s"], repo)).toContain("archer(implementer):")
+    expect((await git(["show", "--name-only", "--pretty=", "HEAD"], repo)).trim()).toBe("feature.txt")
+
+    // a recovery report was written and the phase is marked completed
+    expect(await readFile(join(ws.dir, "reports", "implementer.md"), "utf8")).toContain("Recovered uncommitted changes")
+    expect(metadata.snapshot("implementer")?.status).toBe("completed")
+  })
+
+  test("keeps an existing report instead of overwriting it", async () => {
+    const repo = await dirtyRepo()
+    const ws = await workspaceWithReports(["implementer"])
+    const metadata = await openRunMetadata(ws, repo, pipeline)
+
+    await commitRecoveredPhase(ws, metadata, agent("implementer"), repo)
+
+    expect(await readFile(join(ws.dir, "reports", "implementer.md"), "utf8")).toBe("# implementer")
+    expect(await git(["log", "-1", "--pretty=%s"], repo)).toContain("archer(implementer): implementer")
   })
 })


### PR DESCRIPTION
A phase interrupted before its commit (Ctrl+C, a failed commit step, a killed process) leaves uncommitted work in the tree, which blocked --resume with "working tree is not clean".

On resume in an interactive terminal, archer now detects the dirty tree, identifies the interrupted phase (the first agent phase the resume would re-run, skipping human gates), and asks whether to commit that work as the phase and continue. Accepting commits everything as archer(<phase>):, writes a recovery report if missing, marks the phase completed, and the resume loop skips it and runs the rest. Declining (or a non-TTY resume) keeps the old commit/stash-first behavior.