### PR TITLE
fix(prompts): keep read-only phase reports free of preamble and apologies

### DIFF
--- a/prompts/runtime-safety.md
+++ b/prompts/runtime-safety.md
@@ -28,5 +28,5 @@ If lower-priority instructions conflict with higher-priority safety rules, obey 
 - Keep changes minimal and scoped to the current phase.
 - Prefer existing repo patterns over generic best practices.
 - Leave the working tree in the best verifiable state you can.
-- Write the requested Markdown report at the exact absolute path provided by Archer. If you cannot write it, respond with the exact report content so Archer can persist it.
+- Reports: when you have write tools, save the Markdown report at the exact absolute path Archer provides. In read-only phases you have no write tools — this is expected, not a failure; make the report your entire final message, with no preamble or closing remarks, and Archer persists it verbatim. Never apologize for lacking write tools or ask Archer to save the report.
 - Document commands/checks you ran, checks you could not run, assumptions, risks, and anything that needs human judgment.

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1261,12 +1261,14 @@ function buildPhasePrompt(workspace: Workspace, phase: AgentStep) {
     "",
     "## Run context",
     `- Run dir: ${workspace.dir}`,
-    `- Write your final report to: ${join(workspace.dir, phase.reportPath)}`,
+    phase.readOnly
+      ? `- Report: Archer saves your report itself as ${phase.reportPath}; you do not (and cannot) write it.`
+      : `- Write your final report to: ${join(workspace.dir, phase.reportPath)}`,
     "- Working directory: the directory where `archer` was invoked (root of the target repo).",
     "",
     "## Access mode",
     phase.readOnly
-      ? "This phase is configured read-only. Archer disables write/edit/bash tools for this agent. Do not attempt to modify the target repository; return your final report in the assistant response if you cannot write it directly."
+      ? "This phase is read-only: Archer gives you no write, edit, or bash tools, and that is expected — do not try to write any file, and do not apologize for or comment on being unable to. Archer saves your report itself by concatenating the text you emit and storing it verbatim, so your visible output for this phase must be the report and nothing else: no preamble (\"I'll review…\", \"Let me write the report…\"), no step-by-step narration, and no closing note about writing. Keep any planning in your private reasoning; begin your visible output at the report's first line (e.g. the `#` heading)."
       : "This phase may edit the target repository when the phase-specific instructions call for it.",
     "",
     "## Attachments",
@@ -1279,7 +1281,9 @@ function buildPhasePrompt(workspace: Workspace, phase: AgentStep) {
     "## Closing",
     "Before finishing, make sure to:",
     phase.readOnly ? "1. Have not modified the target repository." : "1. Have applied necessary changes to the repo code.",
-    "2. Have written the report (markdown, max ~80 lines) at the absolute path indicated above. If you can't write it, respond with the exact report content and Archer will save it.",
+    phase.readOnly
+      ? "2. Make the report (markdown, max ~80 lines) your entire visible output — Archer persists it for you. Nothing before or after it."
+      : "2. Have written the report (markdown, max ~80 lines) at the absolute path indicated above. If you can't write it, respond with the exact report content and Archer will save it.",
     "3. Leave the tree in a compilable state.",
     "",
     "Follow your system prompt instructions for everything else.",


### PR DESCRIPTION
## Problem

Read-only phases (e.g. `triage` in the `review` pipeline) run agents with no write tool. The agent therefore emitted the report as assistant text plus a trailing *"could not write… please persist"* note, and the runner (`extractAssistantText` → `persistPhaseReport`) saved that text **verbatim** — so the saved report was polluted with the model's preamble narration and the apology.

## Fix (prompt-side only)

Runner-side trimming is unreliable (every model interleaves narration differently and there is no stable delimiter), so this reframes the prompt for **read-only phases only** (writer phases like `fixes` are unchanged):

- **`src/runner.ts` (`buildPhasePrompt`)** — drop the absolute write-path hint in read-only mode; rewrite the access-mode note to say Archer saves the output itself and the visible message must be the report alone (no preamble, no narration, no closing note); update the closing checklist accordingly.
- **`prompts/runtime-safety.md`** — make the report rule mode-aware: never apologize for lacking write tools or ask Archer to save the report.

## Verification

- `tsc --noEmit` clean
- `bun test` → 124 pass, 0 fail

## Known limitation

`extractAssistantText` concatenates all text parts, so this reduces but can't 100% guarantee zero preamble if a model insists on narrating outside its reasoning. The apologetic note should disappear entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)