### PR TITLE
feat(pipeline): parallel step groups and multi-model fan-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,19 @@ pipelines:
       - agent: adversarial
         name: final-check          # step name (report file, commit prefix, --only/--skip)
         reports: [implementer, security]
+  audit:
+    steps:
+      - implementer
+      - parallel:                  # runs its steps concurrently; every one is forced read-only
+          - patterns
+          - security
+          - agent: clean-code
+            models:                # fans this one step out across models, one read-only run per model
+              - anthropic/claude-opus-4-7
+              - openai/gpt-5.5#xhigh
+      - agent: adversarial
+        name: triage
+        reports: all               # every parallel/fan-out report from above, in one attachment set
 
 permissions:                       # additive only; a config allow can never undo a deny
   allow:
@@ -244,6 +257,7 @@ The rules:
 - **Conventions over wiring**: every agent step gets the PRD, the cumulative diff against the base branch (except the first step; opt out with `diff: false`), and the previous step's report (`reports: previous|all|none|[names]`). Its report lands at `reports/<step>.md` and its commit is `archer(<step>): …`.
 - **Aliases**: the built-in agents answer to their short names in steps — `patterns`, `security`, `design`, `tests`, `adversarial` — as well as their full names.
 - **Read-only agents**: set `agents.<name>.readOnly: true` to enforce audit-only behavior. Archer disables the agent's write/edit/bash tools, denies edit/bash/task permissions, and saves the phase report from the assistant response if the agent cannot write it directly.
+- **Parallel steps and model fan-out**: wrap steps in `parallel: [...]` to run them concurrently, and/or give one step a `models: [...]` list (instead of `model:`) to run it once per model. Both are always forced read-only, regardless of the underlying agent's own `readOnly` setting, so concurrent runs can never step on each other's changes to the tree — there's no per-step way to opt out. A `models:` step's variants get disambiguated names (`<step>__<model-slug>`) and reports; `reports: previous` after a parallel block attaches every member's report, and `reports: [<step-name>]` on a fanned-out step's un-suffixed name attaches every one of its model variants. `parallel:` can't nest and can't contain `human-review`.
 - **Project pipelines shadow built-ins**: defining `pipelines.default` replaces the built-in default.
 - **`--no-human-review`** (and non-TTY runs) drop every `human-review` gate from the pipeline.
 - **Resume is frozen**: the resolved pipeline is persisted in the run's `metadata.json`; `--resume` replays it even if the config changed since.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # archer
 
-Sequential [OpenCode](https://opencode.ai) agent pipeline for implementing features on software repos. It works with Flutter, web, backend, CLI, and mixed projects by detecting the repo's existing stack and conventions. Takes a PRD, runs agents in chain, and leaves one commit per step.
+Archer is a higher-level orchestration harness for [OpenCode](https://opencode.ai) that turns a PRD into a structured, reviewable implementation workflow. It coordinates specialized agents across implementation, human review, pattern alignment, security, design polish, tests, and adversarial review; adapts to the target repo's stack and conventions; and leaves one commit per phase.
+
+Rather than being only a sequential agent chain, Archer owns the operational layer around OpenCode: repo context attachment, runtime guard rails, permission gates, phase reports, diff tracking, and human-in-the-loop checkpoints.
 
 Pipelines are data, not code: archer ships a built-in `default` pipeline, and a project can define its own — any number of steps, its own agents, its own models, with `human-review` gates anywhere — in `.archer/config.yaml`.
 
@@ -12,7 +14,7 @@ Archer is written in Bun + TypeScript and uses `@opencode-ai/sdk` to control Ope
 PRD ──► implementer ──► human-review ──► patterns ──► security ──► design ──► tests ──► adversarial
          │                                │            │            │          │         │
          └────────────────────────────────┴────────────┴────────────┴──────────┴─────────┘
-                                                              commit per step
+                                                              commit per phase
 ```
 
 | Step | Agent | Model | What it does |

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from "node:url"
 
 import type { AgentConfig, Config } from "@opencode-ai/sdk/v2"
 import { bashPolicy, noAdditions } from "./bash-policy"
-import { builtInAgents } from "./pipeline"
+import { builtInAgents, readOnlyAgentSuffix } from "./pipeline"
 import type { AgentSpec, PermissionAdditions } from "./types"
 import { globalAgentsDir } from "./workspace"
 
@@ -20,7 +20,11 @@ export function opencodeConfig(
 ): Config {
   const agent: Record<string, AgentConfig> = {}
   for (const spec of agents) {
-    agent[spec.name] = agentConfig(spec.description, spec.temperature, spec.readOnly, loadAgentPrompt(spec.name, targetDir), runDir, targetDir, false, permissions)
+    // Synthesized forced-read-only variants (name suffixed "__ro", see
+    // synthesizeReadOnlyAgents in pipeline.ts) have no prompt file of their
+    // own; they share the base agent's prompt under its real name.
+    const promptName = spec.name.endsWith(readOnlyAgentSuffix) ? spec.name.slice(0, -readOnlyAgentSuffix.length) : spec.name
+    agent[spec.name] = agentConfig(spec.description, spec.temperature, spec.readOnly, loadAgentPrompt(promptName, targetDir), runDir, targetDir, false, permissions)
   }
 
   return {

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -14,7 +14,7 @@ import {
   type ConfigAgent,
 } from "./config"
 import { listModels, type ModelChoice } from "./model-catalog"
-import { humanReviewStep, type PipelineSpec, type StepSpec } from "./pipeline"
+import { humanReviewStep, isParallelSpec, type AgentStepSpec, type ParallelStepSpec, type PipelineSpec, type StepSpec } from "./pipeline"
 import {
   joinLines,
   padBetween,
@@ -512,7 +512,7 @@ export class ConfigEditor {
   private editStepModel(pipelineName: string, index: number) {
     const steps = this.tab().config?.pipelines[pipelineName]?.steps
     const spec = steps?.[index]
-    if (!steps || spec === undefined || agentOf(spec) === humanReviewStep) return
+    if (!steps || spec === undefined || isParallelSpec(spec) || agentOf(spec) === humanReviewStep) return
     const obj = asStepObject(spec)
     this.openModelPicker(`${pipelineName}[${index + 1}].model`, obj.model, (value) => {
       const next = { ...obj }
@@ -528,7 +528,7 @@ export class ConfigEditor {
     if (meta?.t !== "step") return
     const steps = this.tab().config?.pipelines[meta.pipeline]?.steps
     const spec = steps?.[meta.index]
-    if (!steps || spec === undefined || agentOf(spec) === humanReviewStep) return
+    if (!steps || spec === undefined || isParallelSpec(spec) || agentOf(spec) === humanReviewStep) return
     const obj = asStepObject(spec)
     this.openInput(`${meta.pipeline}[${meta.index + 1}].maxAttempts`, obj.maxAttempts === undefined ? "" : String(obj.maxAttempts), "positive integer, empty to clear", {
       validate: (value) => (value.trim() === "" || isPositiveInt(value) ? undefined : "must be a positive integer"),
@@ -570,8 +570,8 @@ export class ConfigEditor {
     if (meta?.t !== "step") return
     const steps = this.tab().config?.pipelines[meta.pipeline]?.steps
     if (!steps) return
-    const agentSteps = steps.filter((step) => agentOf(step) !== humanReviewStep).length
-    if (agentSteps <= 1 && agentOf(steps[meta.index]!) !== humanReviewStep) {
+    const agentSteps = steps.filter((step) => !isHumanReviewStep(step)).length
+    if (agentSteps <= 1 && !isHumanReviewStep(steps[meta.index]!)) {
       this.message("Can't delete", "A pipeline needs at least one agent step.")
       return
     }
@@ -1020,7 +1020,21 @@ function pipelineRow(name: string, spec: PipelineSpec, open: boolean): Row {
   }
 }
 
+// Parallel blocks aren't authorable here yet (no visual editor for `parallel:`
+// steps) - render a non-editable summary row instead of crashing on them.
 function stepRow(pipeline: string, index: number, spec: StepSpec): Row {
+  if (isParallelSpec(spec)) {
+    const label = `parallel (${spec.parallel.length} step${spec.parallel.length === 1 ? "" : "s"})`
+    return {
+      meta: { t: "step", pipeline, index },
+      chunks: (selected) => [
+        selected ? fg(theme.accent)("    ▸ ") : raw("      "),
+        fg(theme.faint)(`${index + 1}. `),
+        selected ? bold(fg(theme.text)(label)) : fg(theme.dim)(label),
+      ],
+    }
+  }
+
   const agent = agentOf(spec)
   const model = typeof spec === "string" ? undefined : spec.model
   const human = agent === humanReviewStep
@@ -1046,15 +1060,20 @@ function setDefault(defaults: ArcherDefaults, key: keyof ArcherDefaults, value: 
   else record[key] = value
 }
 
-function agentOf(spec: StepSpec): string {
+function isHumanReviewStep(spec: StepSpec): boolean {
+  return !isParallelSpec(spec) && agentOf(spec) === humanReviewStep
+}
+
+/** Only meaningful for non-parallel steps; callers must guard with isParallelSpec first. */
+function agentOf(spec: Exclude<StepSpec, ParallelStepSpec>): string {
   return typeof spec === "string" ? spec : spec.agent
 }
 
-function asStepObject(spec: StepSpec): Exclude<StepSpec, string> {
+function asStepObject(spec: Exclude<StepSpec, ParallelStepSpec>): AgentStepSpec {
   return typeof spec === "string" ? { agent: spec } : { ...spec }
 }
 
-function collapseStep(spec: Exclude<StepSpec, string>): StepSpec {
+function collapseStep(spec: AgentStepSpec): StepSpec {
   return Object.keys(spec).length === 1 ? spec.agent : spec
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,9 @@ import {
   defaultGptModel,
   defaultGptVariant,
   humanReviewStep,
+  readOnlyAgentSuffix,
   splitModelVariant,
+  type AgentStepSpec,
   type PipelineSpec,
   type StepSpec,
 } from "./pipeline"
@@ -303,6 +305,7 @@ function validateAgents(v: Validator, raw: unknown, targetDir: string): Record<s
     const path = `agents.${name}`
     if (name === humanReviewStep) v.fail(path, `"${humanReviewStep}" is a reserved step keyword, not an agent`)
     if (agentAliases[name]) v.fail(path, `"${name}" is an alias of the built-in agent "${agentAliases[name]}"; use that name to override it`)
+    if (name.endsWith(readOnlyAgentSuffix)) v.fail(path, `agent names can't end in "${readOnlyAgentSuffix}"; that suffix is reserved for archer's forced-read-only variants`)
 
     const entry = v.record(value, path)
     v.knownKeys(entry, path, ["description", "model", "temperature", "readOnly"])
@@ -345,20 +348,41 @@ function validatePipelines(v: Validator, raw: unknown): Record<string, PipelineS
   return pipelines
 }
 
-function validateStep(v: Validator, raw: unknown, path: string): StepSpec {
+function validateStep(v: Validator, raw: unknown, path: string, context: { insideParallel?: boolean } = {}): StepSpec {
   if (typeof raw === "string") {
     if (!raw.trim()) v.fail(path, "step name can't be empty")
+    if (context.insideParallel && raw.trim() === humanReviewStep) v.fail(path, `"${humanReviewStep}" can't run inside a parallel block`)
     return raw
   }
 
   const record = v.record(raw, path)
-  v.knownKeys(record, path, ["agent", "name", "model", "maxAttempts", "reports", "diff"])
+
+  if ("parallel" in record) {
+    if (context.insideParallel) v.fail(path, "parallel blocks can't be nested")
+    v.knownKeys(record, path, ["parallel"])
+    if (!Array.isArray(record.parallel) || record.parallel.length === 0) v.fail(`${path}.parallel`, "must be a non-empty list of steps")
+    const members = (record.parallel as unknown[]).map((step, index) => validateStep(v, step, `${path}.parallel[${index}]`, { insideParallel: true }))
+    return { parallel: members as (string | AgentStepSpec)[] }
+  }
+
+  v.knownKeys(record, path, ["agent", "name", "model", "models", "maxAttempts", "reports", "diff"])
 
   const agent = v.nonEmptyString(record.agent, `${path}.agent`)
+  if (context.insideParallel && agent === humanReviewStep) v.fail(path, `"${humanReviewStep}" can't run inside a parallel block`)
+  if (record.model !== undefined && record.models !== undefined) v.fail(path, `set either "model" or "models", not both`)
+
+  let models: string[] | undefined
+  if (record.models !== undefined) {
+    models = v.stringArray(record.models, `${path}.models`)
+    if (models.length < 2) v.fail(`${path}.models`, `must have at least 2 entries; use "model" for a single model`)
+    models.forEach((model, index) => v.model(model, `${path}.models[${index}]`))
+  }
+
   return {
     agent,
     ...(record.name !== undefined ? { name: v.nonEmptyString(record.name, `${path}.name`) } : {}),
     ...(record.model !== undefined ? { model: v.model(record.model, `${path}.model`) } : {}),
+    ...(models !== undefined ? { models } : {}),
     ...(record.maxAttempts !== undefined ? { maxAttempts: v.positiveInt(record.maxAttempts, `${path}.maxAttempts`) } : {}),
     ...(record.reports !== undefined ? { reports: validateReports(v, record.reports, `${path}.reports`) } : {}),
     ...(record.diff !== undefined ? { diff: v.boolean(record.diff, `${path}.diff`) } : {}),
@@ -469,16 +493,21 @@ export function defaultConfigTemplate(): ArcherConfig {
 }
 
 function templatePipeline(spec: PipelineSpec, globalModel: string): PipelineSpec {
-  const steps = spec.steps.map<StepSpec>((raw) => {
-    const step = typeof raw === "string" ? { agent: raw } : { ...raw }
-    if (step.agent === humanReviewStep) return step.agent
-    const agent = builtInAgents.find((candidate) => candidate.name === (agentAliases[step.agent] ?? step.agent))
-    const preferred = agent?.defaultModel
-    const withModel = preferred && preferred !== globalModel ? { ...step, model: preferred } : step
-    // Collapse a bare { agent } back to its string shorthand for clean YAML.
-    return Object.keys(withModel).length === 1 ? withModel.agent : withModel
-  })
+  const steps = spec.steps.map<StepSpec>((raw) => templateStep(raw, globalModel))
   return { ...(spec.description ? { description: spec.description } : {}), steps }
+}
+
+function templateStep(raw: StepSpec, globalModel: string): StepSpec {
+  if (typeof raw === "object" && raw !== null && "parallel" in raw) {
+    return { parallel: raw.parallel.map((inner) => templateStep(inner, globalModel) as string | AgentStepSpec) }
+  }
+  const step = typeof raw === "string" ? { agent: raw } : { ...raw }
+  if (step.agent === humanReviewStep) return step.agent
+  const agent = builtInAgents.find((candidate) => candidate.name === (agentAliases[step.agent] ?? step.agent))
+  const preferred = agent?.defaultModel
+  const withModel = preferred && preferred !== globalModel ? { ...step, model: preferred } : step
+  // Collapse a bare { agent } back to its string shorthand for clean YAML.
+  return Object.keys(withModel).length === 1 ? withModel.agent : withModel
 }
 
 class Validator {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -65,23 +65,33 @@ export const agentAliases: Record<string, string> = {
  * (or alias), plus the reserved "human-review" keyword. Strings are shorthand
  * for `{ agent: <string> }`.
  */
-export type StepSpec =
-  | string
-  | {
-      agent: string
-      name?: string
-      model?: string
-      maxAttempts?: number
-      /** Which previous step reports to attach: the nearest one (default), all of them, none, or an explicit list of step names. */
-      reports?: "previous" | "all" | "none" | string[]
-      /** Attach the cumulative diff against the base branch. Defaults to true except for the first agent step. */
-      diff?: boolean
-    }
+export type AgentStepSpec = {
+  agent: string
+  name?: string
+  model?: string
+  /** Fans this step out into one concurrent, forced-read-only invocation per model. Mutually exclusive with `model`. */
+  models?: string[]
+  maxAttempts?: number
+  /** Which previous step reports to attach: the nearest group (default), all of them, none, or an explicit list of step names. */
+  reports?: "previous" | "all" | "none" | string[]
+  /** Attach the cumulative diff against the base branch. Defaults to true except for the first agent step. */
+  diff?: boolean
+}
+
+/** A group of steps that run concurrently, forced read-only. No nesting, no human-review members. */
+export type ParallelStepSpec = {
+  parallel: (string | AgentStepSpec)[]
+}
+
+export type StepSpec = string | AgentStepSpec | ParallelStepSpec
 
 export type PipelineSpec = {
   description?: string
   steps: StepSpec[]
 }
+
+/** Suffix reserved for archer's synthesized forced-read-only agent variants; project agents can't use it. */
+export const readOnlyAgentSuffix = "__ro"
 
 export const builtInPipelines: Record<string, PipelineSpec> = {
   default: {
@@ -121,6 +131,13 @@ export type ResolvePipelineInput = {
  * step names and report paths, applies the model precedence chain
  * (step > agent > defaults.model > built-in preference > gpt default), and
  * wires each step's inputs (prd + previous reports + diff) by convention.
+ *
+ * Steps inside the same `parallel:` block, or produced by fanning one step
+ * out across `models:`, share a `groupId` and are always forced read-only —
+ * the runner batches same-groupId steps to run concurrently, and since none
+ * of them can touch the working tree, they can't step on each other. Their
+ * `inputFiles` are resolved against the steps that finished before their
+ * group started, never against groupmates running concurrently with them.
  */
 export function resolvePipeline(input: ResolvePipelineInput): Pipeline {
   const steps: Step[] = []
@@ -128,7 +145,7 @@ export function resolvePipeline(input: ResolvePipelineInput): Pipeline {
   const names = new Set<string>()
   let humanCount = 0
 
-  const claimName = (name: string, position: number) => {
+  const claimName = (name: string, position: string) => {
     if (name === humanReviewStep || name.startsWith(`${humanReviewStep}-`)) {
       throw new Error(`pipeline "${input.name}": step ${position} can't use the reserved name "${name}"`)
     }
@@ -139,7 +156,33 @@ export function resolvePipeline(input: ResolvePipelineInput): Pipeline {
   }
 
   for (const [index, raw] of input.spec.steps.entries()) {
-    const position = index + 1
+    const position = String(index + 1)
+    const groupId = `g${index + 1}`
+
+    if (isParallelSpec(raw)) {
+      if (raw.parallel.length === 0) {
+        throw new Error(`pipeline "${input.name}": step ${position} is an empty parallel block`)
+      }
+      for (const inner of raw.parallel) {
+        if (typeof inner === "object" && inner !== null && "parallel" in inner) {
+          throw new Error(`pipeline "${input.name}": step ${position} can't nest a parallel block inside another`)
+        }
+      }
+      const members = raw.parallel.flatMap((inner, innerIndex) =>
+        resolveAgentStepSpec(inner, {
+          input,
+          position: `${position}.${innerIndex + 1}`,
+          groupId,
+          forcedReadOnly: true,
+          priorSteps: agentSteps,
+          claimName,
+        }),
+      )
+      steps.push(...members)
+      agentSteps.push(...members)
+      continue
+    }
+
     const spec = typeof raw === "string" ? { agent: raw } : raw
 
     if (spec.agent === humanReviewStep) {
@@ -151,31 +194,16 @@ export function resolvePipeline(input: ResolvePipelineInput): Pipeline {
       continue
     }
 
-    const agent = findAgent(spec.agent, input.agents)
-    if (!agent) {
-      const known = [...input.agents.map((candidate) => candidate.name), ...Object.keys(agentAliases), humanReviewStep]
-      throw new Error(`pipeline "${input.name}": step ${position} references unknown agent "${spec.agent}" (known: ${known.join(", ")})`)
-    }
-
-    const name = spec.name ?? spec.agent
-    claimName(name, position)
-
-    const { model, variant } = splitModelVariant(spec.model ?? agent.model ?? input.defaultModel ?? agent.defaultModel ?? fallbackModel)
-    const step: AgentStep = {
-      type: "agent",
-      name,
-      agentName: agent.name,
-      description: agent.description,
-      model,
-      ...(variant ? { variant } : {}),
-      inputFiles: ["prd.md", ...reportInputs(input.name, name, spec.reports ?? "previous", agentSteps)],
-      inputDiff: spec.diff ?? agentSteps.length > 0,
-      reportPath: `reports/${name}.md`,
-      ...(agent.readOnly ? { readOnly: true } : {}),
-      ...(spec.maxAttempts !== undefined ? { maxAttempts: spec.maxAttempts } : {}),
-    }
-    steps.push(step)
-    agentSteps.push(step)
+    const members = resolveAgentStepSpec(spec, {
+      input,
+      position,
+      groupId,
+      forcedReadOnly: Boolean(spec.models && spec.models.length > 0),
+      priorSteps: agentSteps,
+      claimName,
+    })
+    steps.push(...members)
+    agentSteps.push(...members)
   }
 
   if (agentSteps.length === 0) {
@@ -183,6 +211,73 @@ export function resolvePipeline(input: ResolvePipelineInput): Pipeline {
   }
 
   return { name: input.name, ...(input.spec.description ? { description: input.spec.description } : {}), steps }
+}
+
+export function isParallelSpec(raw: StepSpec): raw is ParallelStepSpec {
+  return typeof raw === "object" && raw !== null && "parallel" in raw
+}
+
+type ResolveStepContext = {
+  input: ResolvePipelineInput
+  /** Human-readable position for error messages; may be dotted (e.g. "3.2") inside a parallel block. */
+  position: string
+  groupId: string
+  /** True when every variant of this step must be forced read-only (inside a parallel block, or fanned out across models). */
+  forcedReadOnly: boolean
+  /** Steps that finished resolving before this step's group started; never includes groupmates. */
+  priorSteps: readonly AgentStep[]
+  claimName: (name: string, position: string) => void
+}
+
+/** Resolves one step spec into one or more AgentSteps: more than one only when `models:` fans it out. */
+function resolveAgentStepSpec(raw: string | AgentStepSpec, ctx: ResolveStepContext): AgentStep[] {
+  const spec = typeof raw === "string" ? { agent: raw } : raw
+
+  if (spec.agent === humanReviewStep) {
+    throw new Error(`pipeline "${ctx.input.name}": step ${ctx.position} can't use "human-review" inside a parallel block`)
+  }
+
+  const agent = findAgent(spec.agent, ctx.input.agents)
+  if (!agent) {
+    const known = [...ctx.input.agents.map((candidate) => candidate.name), ...Object.keys(agentAliases), humanReviewStep]
+    throw new Error(`pipeline "${ctx.input.name}": step ${ctx.position} references unknown agent "${spec.agent}" (known: ${known.join(", ")})`)
+  }
+
+  const baseName = spec.name ?? spec.agent
+  if (spec.models !== undefined && spec.model !== undefined) {
+    throw new Error(`pipeline "${ctx.input.name}": step ${ctx.position} ("${baseName}") can't set both "model" and "models"`)
+  }
+  if (spec.models !== undefined && spec.models.length < 2) {
+    throw new Error(`pipeline "${ctx.input.name}": step ${ctx.position} ("${baseName}")'s "models" needs at least 2 entries; use "model" for a single one`)
+  }
+
+  const models = spec.models
+  const forced = ctx.forcedReadOnly || Boolean(models)
+  const variants = models ?? [spec.model ?? agent.model ?? ctx.input.defaultModel ?? agent.defaultModel ?? fallbackModel]
+  const agentName = forced && !agent.readOnly ? `${agent.name}${readOnlyAgentSuffix}` : agent.name
+
+  return variants.map((modelValue, variantIndex) => {
+    const name = models ? `${baseName}__${slugifyModel(modelValue)}` : baseName
+    ctx.claimName(name, models ? `${ctx.position}[${variantIndex + 1}]` : ctx.position)
+
+    const { model, variant } = splitModelVariant(modelValue)
+    const step: AgentStep = {
+      type: "agent",
+      name,
+      stepName: baseName,
+      groupId: ctx.groupId,
+      agentName,
+      description: agent.description,
+      model,
+      ...(variant ? { variant } : {}),
+      inputFiles: ["prd.md", ...reportInputs(ctx.input.name, name, spec.reports ?? "previous", ctx.priorSteps)],
+      inputDiff: spec.diff ?? ctx.priorSteps.length > 0,
+      reportPath: `reports/${name}.md`,
+      ...(forced || agent.readOnly ? { readOnly: true } : {}),
+      ...(spec.maxAttempts !== undefined ? { maxAttempts: spec.maxAttempts } : {}),
+    }
+    return step
+  })
 }
 
 function findAgent(ref: string, agents: readonly AgentSpec[]): AgentSpec | undefined {
@@ -193,27 +288,59 @@ function findAgent(ref: string, agents: readonly AgentSpec[]): AgentSpec | undef
 function reportInputs(pipelineName: string, stepName: string, mode: "previous" | "all" | "none" | string[], previous: readonly AgentStep[]): string[] {
   if (mode === "none") return []
   if (mode === "previous") {
-    const last = previous[previous.length - 1]
-    return last ? [last.reportPath] : []
+    const lastGroupId = previous[previous.length - 1]?.groupId
+    if (lastGroupId === undefined) return []
+    return previous.filter((step) => step.groupId === lastGroupId).map((step) => step.reportPath)
   }
   if (mode === "all") return previous.map((step) => step.reportPath)
 
-  return mode.map((name) => {
-    const step = previous.find((candidate) => candidate.name === name)
-    if (!step) {
+  // A name can match every model variant of a fanned-out step (by its shared
+  // stepName) as well as one specific variant (by its full disambiguated name).
+  return mode.flatMap((name) => {
+    const matches = previous.filter((candidate) => candidate.name === name || candidate.stepName === name)
+    if (matches.length === 0) {
       throw new Error(`pipeline "${pipelineName}": step "${stepName}" wants the report of "${name}", which is not an earlier agent step`)
     }
-    return step.reportPath
+    return matches.map((step) => step.reportPath)
   })
 }
 
-/** Step names valid for --only/--skip in this pipeline. */
+/** Turns a `provider/model#variant` string into a filesystem/identifier-safe slug, used to disambiguate a step fanned out across `models:`. */
+export function slugifyModel(value: string): string {
+  return value.replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "")
+}
+
+/**
+ * Builds the forced-read-only agent variants a resolved pipeline references:
+ * steps whose `agentName` was suffixed by `resolvePipeline` because their
+ * base agent isn't already read-only. Register these alongside the normal
+ * agent registry so the OpenCode server config has a matching entry for each.
+ */
+export function synthesizeReadOnlyAgents(pipeline: Pipeline, baseAgents: readonly AgentSpec[]): AgentSpec[] {
+  const synthesized = new Map<string, AgentSpec>()
+  for (const step of pipeline.steps) {
+    if (step.type !== "agent" || !step.agentName.endsWith(readOnlyAgentSuffix)) continue
+    if (synthesized.has(step.agentName)) continue
+    const baseName = step.agentName.slice(0, -readOnlyAgentSuffix.length)
+    const base = baseAgents.find((agent) => agent.name === baseName)
+    if (!base) {
+      throw new Error(`pipeline "${pipeline.name}": step "${step.name}" needs forced-read-only agent "${step.agentName}", but base agent "${baseName}" is not defined`)
+    }
+    synthesized.set(step.agentName, { ...base, name: step.agentName, readOnly: true })
+  }
+  return [...synthesized.values()]
+}
+
+/** Step names valid for --only/--skip in this pipeline: each step's full name plus, for fanned-out steps, their shared logical name. */
 export function stepNames(pipeline: Pipeline): string[] {
   return pipeline.steps.map((step) => step.name)
 }
 
 export function validateStepFilters(pipeline: Pipeline, filters: { onlySteps: string[]; skipSteps: string[] }) {
   const valid = new Set(stepNames(pipeline))
+  for (const step of pipeline.steps) {
+    if (step.type === "agent") valid.add(step.stepName)
+  }
   for (const [flag, names] of [
     ["--only", filters.onlySteps],
     ["--skip", filters.skipSteps],

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -1,7 +1,17 @@
 import { log } from "./log"
-import type { Step } from "./types"
 
-export type ProgressPhase = Pick<Step, "name" | "description">
+export type ProgressPhase = {
+  name: string
+  description: string
+  /** Shared by every member of a concurrent group (a `parallel:` block, or a step fanned out across `models:`); absent on human gates. */
+  groupId?: string
+  /** Pre-fan-out logical name; equals `name` unless this step was produced by a `models:` fan-out. Absent on human gates. */
+  stepName?: string
+  /** The model this step is configured to run, so a fanned-out member can be labelled by its model before it starts. */
+  plannedModel?: string
+  /** The variant paired with `plannedModel`, when the model shorthand carried one. */
+  plannedVariant?: string
+}
 
 export type ProgressTokens = {
   input: number

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -13,7 +13,7 @@ import { log } from "./log"
 import { openRunMetadata, recordProgress, type RunMetadataStore } from "./metadata"
 import { startOpencode } from "./opencode"
 import { startPermissionGate, type PermissionGate } from "./permissions"
-import { splitModelVariant, validateStepFilters } from "./pipeline"
+import { splitModelVariant, synthesizeReadOnlyAgents, validateStepFilters } from "./pipeline"
 import {
   createProgressUI,
   noopProgress,
@@ -29,11 +29,11 @@ import {
   type RunOutcome,
 } from "./progress"
 import { discoverProjectContextFiles } from "./project-context"
-import type { AgentSpec, AgentStep, Pipeline, RunOptions } from "./types"
+import type { AgentSpec, AgentStep, Pipeline, RunOptions, Step } from "./types"
 import { addTokens, emptyTokens, tokensFromValue } from "./usage"
 import { cleanupWorkspace, createWorkspace, resumeWorkspace, type Workspace, writeSummary } from "./workspace"
 
-type ActiveSession = {
+export type ActiveSession = {
   client: OpencodeClient
   sessionID: string
   directory: string
@@ -70,10 +70,10 @@ export function shouldRetryAttempt(error: unknown, signal: AbortSignal, attempt:
   return !signal.aborted && !isUserAbortError(error) && attempt < maxAttempts
 }
 
-class RunShutdown {
+export class RunShutdown {
   private readonly controller = new AbortController()
-  private activeSession: ActiveSession | undefined
-  private abortingSession: Promise<void> | undefined
+  private readonly activeSessions = new Map<string, ActiveSession>()
+  private abortingSessions: Promise<void> | undefined
   private requests = 0
   private forceTimer: ReturnType<typeof setTimeout> | undefined
 
@@ -92,7 +92,7 @@ class RunShutdown {
       process.exit(130)
     }
 
-    log.warn(`${source} received; aborting active OpenCode session and shutting down`)
+    log.warn(`${source} received; aborting active OpenCode session(s) and shutting down`)
     this.controller.abort(new UserAbortError(`${source} received`))
     this.forceTimer = setTimeout(() => {
       log.warn("Shutdown cleanup timed out; forcing exit")
@@ -112,35 +112,92 @@ class RunShutdown {
   }
 
   setActiveSession(session: ActiveSession) {
-    this.activeSession = session
+    this.activeSessions.set(session.phaseName, session)
   }
 
-  clearActiveSession(sessionID: string) {
-    if (this.activeSession?.sessionID === sessionID) this.activeSession = undefined
+  clearActiveSession(phaseName: string, sessionID: string) {
+    if (this.activeSessions.get(phaseName)?.sessionID === sessionID) this.activeSessions.delete(phaseName)
   }
 
-  async abortActiveSession(progress?: ProgressUI) {
-    if (this.abortingSession) return this.abortingSession
-    const session = this.activeSession
-    if (!session) return
+  async abortActiveSessions(progress?: ProgressUI) {
+    if (this.abortingSessions) return this.abortingSessions
+    const sessions = [...this.activeSessions.values()]
+    if (sessions.length === 0) return
 
-    this.abortingSession = (async () => {
-      progress?.phaseActivity(session.phaseName, "aborting active OpenCode session")
-      try {
-        const response = await session.client.session.abort({ sessionID: session.sessionID, directory: session.directory })
-        if (response.error) log.warn(`couldn't abort OpenCode session ${session.sessionID}: ${formatSdkError(response.error)}`)
-      } catch (error) {
-        log.warn(`couldn't abort OpenCode session ${session.sessionID}: ${formatSdkError(error)}`)
-      }
+    this.abortingSessions = (async () => {
+      await Promise.allSettled(
+        sessions.map(async (session) => {
+          progress?.phaseActivity(session.phaseName, "aborting active OpenCode session")
+          try {
+            const response = await session.client.session.abort({ sessionID: session.sessionID, directory: session.directory })
+            if (response.error) log.warn(`couldn't abort OpenCode session ${session.sessionID}: ${formatSdkError(response.error)}`)
+          } catch (error) {
+            log.warn(`couldn't abort OpenCode session ${session.sessionID}: ${formatSdkError(error)}`)
+          }
+        }),
+      )
     })().finally(() => {
-      this.abortingSession = undefined
+      this.abortingSessions = undefined
     })
 
-    return this.abortingSession
+    return this.abortingSessions
   }
 
   dispose() {
     if (this.forceTimer) clearTimeout(this.forceTimer)
+  }
+}
+
+/**
+ * Groups the flat step list into batches the runner executes together: a
+ * human gate is always its own batch, and consecutive agent steps sharing a
+ * groupId (a `parallel:` block, or one step fanned out across `models:`) form
+ * one batch that runs concurrently. Validation guarantees group members are
+ * always contiguous, so a linear scan suffices.
+ */
+export function planBatches(steps: readonly Step[]): Step[][] {
+  const batches: Step[][] = []
+  for (const step of steps) {
+    const last = batches[batches.length - 1]
+    const lastFirst = last?.[0]
+    if (step.type === "agent" && lastFirst?.type === "agent" && lastFirst.groupId === step.groupId) {
+      last.push(step)
+    } else {
+      batches.push([step])
+    }
+  }
+  return batches
+}
+
+/** Every group member runs to completion before the pipeline fails; this aggregates their failures into one error. */
+export class PhaseGroupError extends Error {
+  readonly failures: { name: string; error: unknown }[]
+
+  constructor(failures: { name: string; error: unknown }[]) {
+    super(failures.map((failure) => `[${failure.name}] ${formatSdkError(failure.error)}`).join("; "))
+    this.name = "PhaseGroupError"
+    this.failures = failures
+  }
+}
+
+type GitLock = <T>(job: () => Promise<T>) => Promise<T>
+
+/**
+ * Serializes git operations across concurrently-running phases in the same
+ * group: their agent sessions run fully in parallel, but git.ts's mutating
+ * calls (`git add`, `git commit`, `git reset --hard`) would otherwise race on
+ * `.git/index.lock`. Forced-read-only group members never actually change the
+ * tree, so this only ever arbitrates housekeeping, not real content conflicts.
+ */
+export function createGitLock(): GitLock {
+  let tail: Promise<unknown> = Promise.resolve()
+  return function withGitLock<T>(job: () => Promise<T>): Promise<T> {
+    const run = tail.then(job, job)
+    tail = run.then(
+      () => undefined,
+      () => undefined,
+    )
+    return run
   }
 }
 
@@ -187,7 +244,11 @@ export async function run(options: RunOptions) {
     // (and thus --only/--skip names and required agents) come from there.
     const pipeline = metadata.pipeline
     validateStepFilters(pipeline, options)
-    ensureAgentsAvailable(pipeline, options.agents)
+    // Parallel/multi-model steps are forced read-only and point at a synthesized
+    // "<agent>__ro" variant when their base agent isn't already read-only;
+    // register those variants alongside the normal registry for this run.
+    const agents = [...options.agents, ...synthesizeReadOnlyAgents(pipeline, options.agents)]
+    ensureAgentsAvailable(pipeline, agents)
     // A run interrupted before its phase commit leaves the tree dirty; on resume
     // offer to commit that work as the interrupted phase and continue. Runs here,
     // before the TUI grabs the terminal, so the readline prompt stays visible.
@@ -218,7 +279,7 @@ export async function run(options: RunOptions) {
     const abortBoot = () => boot.abort(shutdown.signal.reason)
     shutdown.signal.addEventListener("abort", abortBoot, { once: true })
     try {
-      opencode = await startOpencode(opencodeConfig(workspace.dir, options.targetDir, options.agents, options.permissions), boot.signal)
+      opencode = await startOpencode(opencodeConfig(workspace.dir, options.targetDir, agents, options.permissions), boot.signal)
     } finally {
       shutdown.signal.removeEventListener("abort", abortBoot)
     }
@@ -235,21 +296,50 @@ export async function run(options: RunOptions) {
     })
 
     const resuming = Boolean(options.resumeRunID)
-    for (const step of pipeline.steps) {
+    const gitLock = createGitLock()
+    // Narrow once, outside any closure: opencode/metadata are `let`s assigned
+    // above, and TS won't retain that narrowing inside the batch's nested
+    // arrow functions, but a `const` alias captured here stays narrowed.
+    const client = opencode.client
+    const runMetadata = metadata
+
+    for (const batch of planBatches(pipeline.steps)) {
       shutdown.throwIfRequested()
-      if (shouldSkip(step.name, options)) {
-        progress.phaseSkipped(step.name)
-        log.warn(`[${step.name}] skipped by flag`)
+      const [first] = batch
+
+      if (batch.length === 1 && first?.type === "human") {
+        if (shouldSkip(first, options)) {
+          progress.phaseSkipped(first.name)
+          log.warn(`[${first.name}] skipped by flag`)
+          continue
+        }
+        await runHumanReviewGate(workspace, options, opencode.url, progress, permissions, first.name)
         continue
       }
-      if (step.type === "human") {
-        await runHumanReviewGate(workspace, options, opencode.url, progress, permissions, step.name)
-        continue
-      }
-      const restored = resuming && (await restorePhaseFromPreviousRun(workspace, metadata, step, progress))
-      if (!restored) {
-        await runPhase(opencode.client, workspace, step, options, extraFiles, projectContextFiles, progress, shutdown)
-      }
+
+      const agentBatch = batch as AgentStep[]
+      const results = await Promise.allSettled(
+        agentBatch.map(async (step) => {
+          if (shouldSkip(step, options)) {
+            progress.phaseSkipped(step.name)
+            log.warn(`[${step.name}] skipped by flag`)
+            return
+          }
+          const restored = resuming && (await restorePhaseFromPreviousRun(workspace, runMetadata, step, progress))
+          if (!restored) {
+            await runPhase(client, workspace, step, options, extraFiles, projectContextFiles, progress, shutdown, gitLock)
+          }
+        }),
+      )
+
+      // Every batch member runs to completion (Promise.allSettled, not
+      // fail-fast) since forced-read-only siblings can't corrupt each other's
+      // work; a user abort takes priority and propagates unwrapped so the
+      // existing isUserAbortError handling below keeps working.
+      const userAbort = results.find((result): result is PromiseRejectedResult => result.status === "rejected" && isUserAbortError(result.reason))
+      if (userAbort) throw userAbort.reason
+      const failures = results.flatMap((result, index) => (result.status === "rejected" ? [{ name: agentBatch[index]!.name, error: result.reason }] : []))
+      if (failures.length > 0) throw new PhaseGroupError(failures)
     }
 
     progress.message("writing run summary")
@@ -263,7 +353,7 @@ export async function run(options: RunOptions) {
     throw error
   } finally {
     removeSignalHandlers()
-    if (shutdown.aborted) await shutdown.abortActiveSession(progress)
+    if (shutdown.aborted) await shutdown.abortActiveSessions(progress)
     await permissions?.stop()
     await metadata?.flush().catch((error) => log.warn(`couldn't flush run metadata: ${String(error)}`))
     progress.stop()
@@ -428,17 +518,18 @@ async function runPhase(
   projectContextFiles: string[],
   progress: ProgressUI,
   shutdown: RunShutdown,
+  gitLock: GitLock,
 ) {
   progress.phaseStarted(phase.name, phase.description)
   log.section(`${phase.name} - ${phase.description}`)
 
   try {
     const prepared = await preparePhaseRun(workspace, phase, options, extraFiles, projectContextFiles)
-    const baseline = await createCleanRepoSnapshot(options.targetDir)
-    const assistantText = await runPhaseWithRetries(client, workspace, phase, options.targetDir, prepared, baseline, progress, shutdown)
+    const baseline = await gitLock(() => createCleanRepoSnapshot(options.targetDir))
+    const assistantText = await runPhaseWithRetries(client, workspace, phase, options.targetDir, prepared, baseline, progress, shutdown, gitLock)
 
     const reportAbs = await persistPhaseReport(workspace, phase, assistantText)
-    await commitPhase(phase, reportAbs, options.targetDir)
+    await gitLock(() => commitPhase(phase, reportAbs, options.targetDir))
     progress.phaseCompleted(phase.name, "report saved and commit checked")
   } catch (error) {
     progress.phaseFailed(phase.name, formatSdkError(error))
@@ -498,6 +589,7 @@ async function runPhaseWithRetries(
   baseline: RepoSnapshot | undefined,
   progress: ProgressUI,
   shutdown: RunShutdown,
+  gitLock: GitLock,
 ) {
   if (!baseline && prepared.maxAttempts > 1) {
     throw new Error(`[${phase.name}] can't retry with dirty working tree; use --max-attempts 1 or clean the repo`)
@@ -521,12 +613,12 @@ async function runPhaseWithRetries(
       if (!(error instanceof LoggedAttemptError)) {
         await writeAttemptLog(workspace, phase, attempt, { error: formatSdkError(error) })
       }
-      if (shouldRetryAttempt(error, shutdown.signal, attempt, prepared.maxAttempts)) await restorePhaseBaseline(phase, baseline, targetDir, error)
+      if (shouldRetryAttempt(error, shutdown.signal, attempt, prepared.maxAttempts)) await gitLock(() => restorePhaseBaseline(phase, baseline, targetDir, error))
     }
   }
 
   if (lastError) {
-    await restorePhaseBaseline(phase, baseline, targetDir, lastError)
+    await gitLock(() => restorePhaseBaseline(phase, baseline, targetDir, lastError))
     throw lastError
   }
 
@@ -676,8 +768,8 @@ async function promptPhase(
     }
     throw error
   } finally {
-    if (input.shutdown.aborted) await input.shutdown.abortActiveSession(input.progress)
-    input.shutdown.clearActiveSession(session.data.id)
+    if (input.shutdown.aborted) await input.shutdown.abortActiveSessions(input.progress)
+    input.shutdown.clearActiveSession(input.phase.name, session.data.id)
     await watcher.stop()
   }
 }
@@ -1311,9 +1403,13 @@ function formatModel(model: ModelSelection) {
   return model.variant ? `${base}#${model.variant}` : base
 }
 
-export function shouldSkip(name: string, options: Pick<RunOptions, "onlySteps" | "skipSteps">) {
-  if (options.onlySteps.length > 0) return !options.onlySteps.includes(name)
-  return options.skipSteps.includes(name)
+// A fanned-out step (name "clean-code__anthropic-claude-opus-4-7") matches
+// --only/--skip by its full name or by its shared stepName ("clean-code"),
+// so a filter can target one variant or every variant of a fanned-out step.
+export function shouldSkip(step: Step, options: Pick<RunOptions, "onlySteps" | "skipSteps">) {
+  const names = step.type === "agent" ? [step.name, step.stepName] : [step.name]
+  if (options.onlySteps.length > 0) return !names.some((name) => options.onlySteps.includes(name))
+  return names.some((name) => options.skipSteps.includes(name))
 }
 
 // A resumed run can outlive its config: the frozen pipeline may reference a

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -160,7 +160,7 @@ export function planBatches(steps: readonly Step[]): Step[][] {
   for (const step of steps) {
     const last = batches[batches.length - 1]
     const lastFirst = last?.[0]
-    if (step.type === "agent" && lastFirst?.type === "agent" && lastFirst.groupId === step.groupId) {
+    if (step.type === "agent" && lastFirst?.type === "agent" && step.groupId !== undefined && lastFirst.groupId === step.groupId) {
       last.push(step)
     } else {
       batches.push([step])

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1424,7 +1424,18 @@ function ensureAgentsAvailable(pipeline: Pipeline, agents: readonly AgentSpec[])
 }
 
 function progressPhases(pipeline: Pipeline): ProgressPhase[] {
-  return pipeline.steps.map((step) => ({ name: step.name, description: step.description }))
+  return pipeline.steps.map((step) =>
+    step.type === "agent"
+      ? {
+          name: step.name,
+          description: step.description,
+          groupId: step.groupId,
+          stepName: step.stepName,
+          plannedModel: step.model,
+          ...(step.variant ? { plannedVariant: step.variant } : {}),
+        }
+      : { name: step.name, description: step.description },
+  )
 }
 
 class LoggedAttemptError extends Error {}

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -82,6 +82,10 @@ function kindStyle(kind: ActivityKind): { icon: string; color: string } {
 
 const pipelineWidth = 32
 const feedLimit = 100
+// Concurrently-running phases (a parallel block, or a step fanned out across
+// models) each get their own live-detail pane, up to this many at once; extra
+// running phases beyond this are folded into the last pane's title.
+const maxPanes = 4
 
 const permissionChoices: ReadonlyArray<{ reply: PermissionReply; label: string; color: PaletteColor }> = [
   { reply: "once", label: "allow once", color: "green" },
@@ -167,7 +171,12 @@ export class TuiProgress implements ProgressUI {
   private runID = ""
   private targetDir = ""
   private serverUrl = ""
+  // Fallback focus for single-phase rendering: the phase that most recently
+  // had activity, kept updated by every progress callback exactly as before.
   private activePhase = ""
+  // Explicit user focus among concurrently-running phases (Tab / pane click);
+  // unlike activePhase, this only ever changes on direct user action.
+  private focusedPhaseName = ""
   private lastActivityAt = Date.now()
   private readonly startedAt = Date.now()
   private readonly phases: PhaseState[]
@@ -178,6 +187,12 @@ export class TuiProgress implements ProgressUI {
   private readonly pipelineText: TextRenderable
   private readonly stepBox: BoxRenderable
   private readonly stepText: TextRenderable
+  // Extra live-detail panes for additional concurrently-running phases beyond
+  // the first (which reuses stepBox); hidden whenever at most one phase runs.
+  private readonly extraPanes: { box: BoxRenderable; text: TextRenderable }[] = []
+  // Slot index -> phase name currently assigned there, rebuilt every render
+  // so pane clicks resolve against exactly what's on screen.
+  private paneAssignment: (string | undefined)[] = []
   private readonly todosBox: BoxRenderable
   private readonly todosText: TextRenderable
   private readonly feedBox: BoxRenderable
@@ -250,6 +265,15 @@ export class TuiProgress implements ProgressUI {
     }
     if (this.permissionQueue.length > 0) {
       this.handlePermissionKey(key)
+      return
+    }
+    // Plain Tab cycles focus among concurrently-running phases; a no-op when
+    // at most one is running. Checked after the permission modal, which
+    // already claims plain Tab for cycling its own choices.
+    if (key.name === "tab" && !key.ctrl && !key.meta && !key.option) {
+      key.preventDefault()
+      key.stopPropagation()
+      this.cycleFocusedPhase()
       return
     }
     if (key.name !== "o" || key.ctrl || key.meta || key.option) return
@@ -347,11 +371,12 @@ export class TuiProgress implements ProgressUI {
       gap: 0,
     })
 
-    const openFromStep = (event: { preventDefault(): void; stopPropagation(): void }) => {
+    const paneClickHandler = (index: number) => (event: { preventDefault(): void; stopPropagation(): void }) => {
       event.preventDefault()
       event.stopPropagation()
-      this.openActiveSessionWindow("click")
+      this.focusPaneAndOpen(index)
     }
+    const openFromStep = paneClickHandler(0)
 
     const step = this.panel({
       id: "archer-step",
@@ -365,8 +390,31 @@ export class TuiProgress implements ProgressUI {
     })
     step.text.onMouseDown = openFromStep
 
+    // Extra panes for additional concurrently-running phases (a parallel
+    // block, or a step fanned out across models); hidden until more than one
+    // phase is running at once. Pane 0 is the step panel above.
+    for (let index = 1; index < maxPanes; index++) {
+      const openFromThisPane = paneClickHandler(index)
+      const pane = this.panel({
+        id: `archer-step-${index}`,
+        width: "100%",
+        height: 3,
+        borderColor: theme.borderDim,
+        backgroundColor: theme.bg,
+        title: " ",
+        titleAlignment: "left",
+        visible: false,
+        onMouseDown: openFromThisPane,
+      })
+      pane.text.onMouseDown = openFromThisPane
+      this.extraPanes.push(pane)
+      this.paletteTargets.push({ box: pane.box, background: "bg", border: "borderDim" })
+    }
+
     // Todos live in their own panel below the step meta; its border is the
-    // divider between session usage above and the todo list itself.
+    // divider between session usage above and the todo list itself. Only
+    // shown when exactly one phase is running - concurrent phases fold their
+    // todos into their own compact pane instead.
     const todos = this.panel({
       id: "archer-todos",
       width: "100%",
@@ -428,6 +476,7 @@ export class TuiProgress implements ProgressUI {
 
     body.add(pipeline.box)
     right.add(step.box)
+    for (const pane of this.extraPanes) right.add(pane.box)
     right.add(todos.box)
     right.add(feed.box)
     body.add(right)
@@ -875,13 +924,33 @@ export class TuiProgress implements ProgressUI {
   private openActiveSessionWindow(source: "click" | "key") {
     const active = this.finished
       ? this.phases[this.finished.selected]
-      : (this.findPhase(this.activePhase) ?? this.phases.find((phase) => phase.status === "running"))
+      : (this.findPhase(this.focusedPhaseName) ?? this.findPhase(this.activePhase) ?? this.phases.find((phase) => phase.status === "running"))
     if (!active) {
       this.addEvent("archer", "system", "no active opencode session to open yet")
       this.render()
       return
     }
     this.openSessionWindowForPhase(active.name, source)
+  }
+
+  // Clicking a specific pane both focuses it (so [o]/Tab agree with what was
+  // clicked) and opens its session immediately, matching the single-pane
+  // click-to-open behavior this replaces.
+  private focusPaneAndOpen(index: number) {
+    const name = this.paneAssignment[index]
+    if (name) this.focusedPhaseName = name
+    this.openActiveSessionWindow("click")
+  }
+
+  // Cycles explicit focus among currently-running phases; a no-op with zero
+  // or one running phase (nothing to choose between).
+  private cycleFocusedPhase() {
+    const running = this.phases.filter((phase) => phase.status === "running")
+    if (running.length === 0) return
+    const currentIndex = running.findIndex((phase) => phase.name === this.focusedPhaseName)
+    const next = running[(currentIndex + 1) % running.length]!
+    this.focusedPhaseName = next.name
+    this.render()
   }
 
   private openSessionWindowForPhase(name: string, source: "click" | "key") {
@@ -954,39 +1023,31 @@ export class TuiProgress implements ProgressUI {
   private render() {
     if (this.renderer.isDestroyed) return
     const now = Date.now()
-    // While running, the right column follows the live phase; on the finish
-    // screen it follows the browsed selection instead.
-    const focus = this.finished
-      ? this.phases[this.finished.selected]
-      : (this.findPhase(this.activePhase) ?? this.phases.find((phase) => phase.status === "running"))
     const innerWidth = Math.max(40, this.renderer.width - 6)
     const rightWidth = Math.max(40, this.renderer.width - pipelineWidth - 9)
-
     // Body rows left after the dir line (1), header (3), and footer (3); the
-    // step and todos panels grow with their content but never starve the logs.
+    // step/pane panels grow with their content but never starve the logs.
     const bodyHeight = Math.max(8, this.renderer.height - 7)
-    const stepLines = this.finished ? this.finishedPhaseContent(focus, now, rightWidth) : this.stepContent(focus, now, rightWidth)
-    this.stepBox.title = this.finished ? " phase " : " current step "
-    this.stepBox.height = stepLines.length + 2
 
-    const todoRows =
-      focus && focus.todos.length > 0
-        ? todoLines(focus.todos, Math.max(3, Math.floor(bodyHeight * 0.6) - stepLines.length - 4), rightWidth)
-        : []
-    this.todosBox.visible = todoRows.length > 0
-    if (focus && todoRows.length > 0) {
-      const completed = focus.todos.filter((todo) => todo.status === "completed").length
-      this.todosBox.height = todoRows.length + 2
-      this.todosBox.title = ` todos ${completed}/${focus.todos.length} `
-      this.todosText.content = joinLines(todoRows)
-    }
-    const todosHeight = this.todosBox.visible ? todoRows.length + 2 : 0
+    // A finished run always browses one phase at a time (its live-run
+    // concurrency is over); a live run with more than one phase running at
+    // once shows each in its own pane instead of following a single focus.
+    const running = this.finished ? [] : this.runningPhasesByFocus()
+    const focus = this.finished ? this.phases[this.finished.selected] : (this.findPhase(this.activePhase) ?? running[0])
 
-    const feedRows = Math.max(3, bodyHeight - stepLines.length - todosHeight - 4)
+    const multi = running.length > 1
+    const usedHeight = multi ? this.renderPanes(running, now, rightWidth, bodyHeight) : this.renderSinglePane(focus, now, rightWidth, bodyHeight)
+
+    // usedHeight already counts every pane's own border, so the feed box only
+    // needs its own 2 rows subtracted. Single mode keeps a floor of 3 (its
+    // content is small and bounded, so there's always room); multi mode
+    // can't assume that - several full-height panes can legitimately leave
+    // nothing over, so it floors at 0 instead of asking for lines the feed
+    // box has no room to show (which would bleed into its own border).
+    const feedRows = Math.max(multi ? 0 : 3, bodyHeight - usedHeight - 2)
     this.dirText.content = this.dirContent(innerWidth)
     this.headerText.content = this.headerContent(now, innerWidth)
     this.pipelineText.content = this.pipelineContent(now)
-    this.stepText.content = joinLines(stepLines)
     if (this.finished) {
       this.reportPageRows = feedRows
       // Content first: it computes the scroll indicator the title shows.
@@ -999,6 +1060,78 @@ export class TuiProgress implements ProgressUI {
     this.footerText.content = this.footerContent(now, innerWidth)
     this.renderPermissionModal()
     this.renderer.requestRender()
+  }
+
+  // Running phases ordered for pane assignment: the explicitly-focused one
+  // (if still running) first so it's always visible even under overflow,
+  // then the rest oldest-first so pane assignment stays stable frame to frame.
+  private runningPhasesByFocus(): PhaseState[] {
+    const running = this.phases.filter((phase) => phase.status === "running").sort((a, b) => (a.startedAt ?? 0) - (b.startedAt ?? 0))
+    const focusedIndex = running.findIndex((phase) => phase.name === this.focusedPhaseName)
+    if (focusedIndex <= 0) return running
+    return [running[focusedIndex]!, ...running.slice(0, focusedIndex), ...running.slice(focusedIndex + 1)]
+  }
+
+  // Single-phase mode: identical to archer's original one-pane layout (step
+  // panel plus a separate todos panel), used whenever at most one phase is
+  // running - i.e. every ordinary sequential pipeline, unchanged.
+  private renderSinglePane(focus: PhaseState | undefined, now: number, width: number, bodyHeight: number): number {
+    for (const pane of this.extraPanes) pane.box.visible = false
+    this.paneAssignment = [focus?.name]
+
+    const stepLines = this.finished ? this.finishedPhaseContent(focus, now, width) : this.stepContent(focus, now, width)
+    this.stepBox.title = this.finished ? " phase " : " current step "
+    this.stepBox.height = stepLines.length + 2
+    this.stepText.content = joinLines(stepLines)
+
+    const todoRows =
+      focus && focus.todos.length > 0
+        ? todoLines(focus.todos, Math.max(3, Math.floor(bodyHeight * 0.6) - stepLines.length - 4), width)
+        : []
+    this.todosBox.visible = todoRows.length > 0
+    if (focus && todoRows.length > 0) {
+      const completed = focus.todos.filter((todo) => todo.status === "completed").length
+      this.todosBox.height = todoRows.length + 2
+      this.todosBox.title = ` todos ${completed}/${focus.todos.length} `
+      this.todosText.content = joinLines(todoRows)
+    }
+    return stepLines.length + 2 + (this.todosBox.visible ? todoRows.length + 2 : 0)
+  }
+
+  // Multi-phase mode: one compact pane per concurrently-running phase (step
+  // content plus a condensed todo summary), up to maxPanes; the separate
+  // todos panel is hidden since each pane already carries its own.
+  private renderPanes(running: PhaseState[], now: number, width: number, bodyHeight: number): number {
+    this.todosBox.visible = false
+    const { visibleCount, overflow, perPaneBudget } = paneLayout(running.length, bodyHeight, maxPanes)
+    const visible = running.slice(0, visibleCount)
+    const focusedName = this.focusedPhaseName || visible[0]!.name
+    this.paneAssignment = []
+
+    let usedHeight = 0
+    visible.forEach((phase, index) => {
+      const pane = index === 0 ? { box: this.stepBox, text: this.stepText } : this.extraPanes[index - 1]!
+      const stepLines = this.stepContent(phase, now, width).slice(0, perPaneBudget)
+      const todoCap = Math.max(0, Math.min(2, perPaneBudget - stepLines.length))
+      const lines = todoCap > 0 && phase.todos.length > 0 ? [...stepLines, ...todoLines(phase.todos, todoCap, width)] : stepLines
+
+      const focused = phase.name === focusedName
+      const overflowSuffix = overflow > 0 && index === visible.length - 1 ? ` · +${overflow} more running` : ""
+      pane.box.visible = true
+      pane.box.title = ` ${focused ? "▸ " : "  "}${phase.name}${overflowSuffix} `
+      pane.box.height = lines.length + 2
+      pane.text.content = joinLines(lines)
+      this.paneAssignment[index] = phase.name
+      usedHeight += lines.length + 2
+    })
+
+    for (let index = visible.length; index < maxPanes; index++) {
+      const pane = index === 0 ? this.stepBox : this.extraPanes[index - 1]!.box
+      pane.visible = false
+      this.paneAssignment[index] = undefined
+    }
+
+    return usedHeight
   }
 
   // Header owns the session-wide totals in a single row: clock, elapsed time,
@@ -1216,6 +1349,12 @@ export class TuiProgress implements ProgressUI {
   }
 
   private feedLines(width: number, visible: number): StyledText[] {
+    // No room at all (several full-height panes left nothing over): render
+    // nothing rather than a placeholder line that would bleed into the
+    // feed box's own border.
+    if (visible <= 0) return []
+    // Array.slice(-0) is slice(0) - the whole array, not empty - already
+    // ruled out above, but keep the guard explicit for any future caller.
     const events = this.feed.slice(-visible).reverse()
     if (events.length === 0) return [t`${fg(theme.dim)("no activity yet…")}`]
 
@@ -1284,6 +1423,9 @@ export class TuiProgress implements ProgressUI {
       fg(theme.yellow)("ctrl+c"),
       fg(theme.dim)(" abort"),
     ]
+    if (this.phases.filter((phase) => phase.status === "running").length > 1) {
+      left.push(fg(theme.dim)(" · ["), fg(theme.accent)("tab"), fg(theme.dim)("] focus"))
+    }
     if (this.autoAccept) {
       left.push(fg(theme.dim)(" · "), fg(theme.accent)("shift+tab"))
       left.push(autoAcceptStatusChunk(this.autoAccept.mode))
@@ -1379,6 +1521,26 @@ function todoRow(todo: ProgressTodo, width: number): StyledText {
     default:
       return new StyledText([fg(theme.dim)("  ○ "), fg(theme.text)(text)])
   }
+}
+
+/**
+ * How many concurrently-running phases get their own pane, and how much
+ * content-line budget each one gets, for a given body height. Pure and
+ * exported so the height math that caused real overflow/corruption bugs
+ * during development can be unit tested without spinning up OpenTUI.
+ */
+export function paneLayout(runningCount: number, bodyHeight: number, cap: number): { visibleCount: number; overflow: number; perPaneBudget: number } {
+  // A pane needs at least 3 content lines plus its border (5 rows) to be
+  // worth showing; a terminal too short for `cap` panes at that floor folds
+  // the rest into overflow instead of overflowing the terminal itself.
+  const minPaneHeight = 5
+  const fitCount = Math.max(1, Math.floor(bodyHeight / minPaneHeight))
+  const visibleCount = Math.max(1, Math.min(cap, fitCount, runningCount))
+  const overflow = Math.max(0, runningCount - visibleCount)
+  // An equal share of the body per pane (minus its own border); callers trim
+  // content to this budget rather than letting it overflow the terminal.
+  const perPaneBudget = Math.max(3, Math.floor(bodyHeight / visibleCount) - 2)
+  return { visibleCount, overflow, perPaneBudget }
 }
 
 function runningFraction(phase: PhaseState) {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -857,6 +857,10 @@ export class TuiProgress implements ProgressUI {
       fg: theme.text,
       width: "100%",
       height: "100%",
+      // Every panel manages its own wrapping/truncation to a known width; a
+      // stray over-long line must clip at the panel edge, never wrap onto a
+      // second row (which would desync the pipeline's click row mapping).
+      wrapMode: "none",
     })
     box.add(text)
     return { box, text }
@@ -1052,7 +1056,7 @@ export class TuiProgress implements ProgressUI {
       this.reportPageRows = feedRows
       // Content first: it computes the scroll indicator the title shows.
       this.feedText.content = joinLines(this.reportPanelLines(focus, rightWidth, feedRows))
-      this.feedBox.title = ` report · ${focus?.name ?? "—"}${this.reportPosition ? ` · ${this.reportPosition}` : ""} `
+      this.feedBox.title = ` report · ${focus ? phaseDisplayName(focus) : "—"}${this.reportPosition ? ` · ${this.reportPosition}` : ""} `
     } else {
       this.feedBox.title = " logs "
       this.feedText.content = joinLines(this.feedLines(rightWidth, feedRows))
@@ -1118,7 +1122,7 @@ export class TuiProgress implements ProgressUI {
       const focused = phase.name === focusedName
       const overflowSuffix = overflow > 0 && index === visible.length - 1 ? ` · +${overflow} more running` : ""
       pane.box.visible = true
-      pane.box.title = ` ${focused ? "▸ " : "  "}${phase.name}${overflowSuffix} `
+      pane.box.title = ` ${focused ? "▸ " : "  "}${phaseDisplayName(phase)}${overflowSuffix} `
       pane.box.height = lines.length + 2
       pane.text.content = joinLines(lines)
       this.paneAssignment[index] = phase.name
@@ -1174,8 +1178,11 @@ export class TuiProgress implements ProgressUI {
     return Math.min(1, done / total)
   }
 
-  // The pipeline owns run progress: the overall bar plus one row per phase
-  // (status, elapsed, and final cost once a phase ends).
+  // The pipeline owns run progress: the overall bar plus the phase list. A
+  // sequential step is one flat row (unchanged); a concurrent group (a
+  // `parallel:` block, or a step fanned out across `models:`) renders as an
+  // indented sub-tree under a group header, so the nesting is visible instead
+  // of a flat list of `step__model` names all sitting at the same level.
   private pipelineContent(now: number) {
     const width = pipelineWidth - 4
     const done = this.phases.filter((phase) => phase.status === "completed" || phase.status === "skipped").length
@@ -1191,24 +1198,121 @@ export class TuiProgress implements ProgressUI {
       ]),
       plain(""),
     ]
+    // Rebuilt in lockstep with `out`: one entry per rendered line so a click
+    // resolves against exactly what is on screen. Group headers point at their
+    // first member so a click still opens (or, on the finish screen, browses)
+    // something sensible.
     const rows: (string | undefined)[] = [undefined, undefined]
-    for (const [index, phase] of this.phases.entries()) {
-      const selected = this.finished?.selected === index
-      const name =
-        selected || phase.status === "running"
-          ? bold(fg(theme.text)(phase.name))
-          : phase.status === "pending"
-            ? fg(theme.dim)(phase.name)
-            : phase.status === "skipped"
-              ? fg(theme.faint)(phase.name)
-              : fg(theme.text)(phase.name)
-      const left: TextChunk[] = [statusIcon(phase.status, now), raw(" "), name]
-      // The selection marker only exists on the finish screen, where the
-      // pipeline doubles as the phase browser.
-      if (this.finished) left.unshift(selected ? fg(theme.accent)("▸ ") : raw("  "))
-      rows.push(phase.name)
-      out.push(padBetween(left, phaseMetaChunks(phase, now), width))
+    const emit = (left: TextChunk[], right: TextChunk[], rowPhase: string | undefined) => {
+      out.push(padBetween(left, right, width))
+      rows.push(rowPhase)
     }
+    // The selection marker (▸) only exists on the finish screen, where the
+    // pipeline doubles as the phase browser; emitLine draws it at column 0,
+    // before the tree prefix, so it stays aligned across every depth.
+    const isSelected = (phase: PhaseState) => this.finished !== undefined && this.phases[this.finished.selected] === phase
+
+    // One rendered line, sized so it never wraps: the marker, tree prefix and
+    // status icon are fixed, the right-aligned meta is preserved whole, and
+    // the label (name or model) is truncated to whatever budget is left
+    // between them. Deep nesting eats into the name, never into the layout —
+    // which keeps `rows` one-to-one with the visible lines (clicks resolve).
+    const emitLine = (args: {
+      rowPhase: string | undefined
+      selectedPhase?: PhaseState
+      lasts: boolean[]
+      icon: TextChunk
+      labelText: string
+      labelStatus: PhaseStatus
+      color?: (text: string) => TextChunk
+      suffix?: TextChunk[]
+      right: TextChunk[]
+    }) => {
+      const selected = args.selectedPhase !== undefined && isSelected(args.selectedPhase)
+      const left: TextChunk[] = []
+      if (this.finished) left.push(selected ? fg(theme.accent)("▸ ") : raw("  "))
+      const prefix = treePrefix(args.lasts)
+      if (prefix) left.push(fg(theme.faint)(prefix))
+      left.push(args.icon, raw(" "))
+      const suffix = args.suffix ?? []
+      // -1 reserves the single-column gap padBetween keeps before the meta.
+      // Floored at 1 (not higher) so a very deep row shrinks its name to fit
+      // rather than forcing extra columns that would push the meta off-panel.
+      const budget = Math.max(1, width - plainLen(left) - plainLen(suffix) - plainLen(args.right) - 1)
+      const label = truncate(args.labelText, budget)
+      left.push(args.color ? args.color(label) : phaseNameChunk(label, args.labelStatus, selected))
+      left.push(...suffix)
+      emit(left, args.right, args.rowPhase)
+    }
+
+    // A leaf row: a single phase (sequential step, human gate, or one member
+    // of a concurrent group) labelled by `labelText`.
+    const emitRow = (phase: PhaseState, lasts: boolean[], labelText: string, right: TextChunk[]) =>
+      emitLine({ rowPhase: phase.name, selectedPhase: phase, lasts, icon: statusIcon(phase.status, now), labelText, labelStatus: phase.status, right })
+
+    // A fanned-out member, labelled by its model with the variant (if any) as
+    // a faint suffix.
+    const emitModelRow = (phase: PhaseState, lasts: boolean[]) =>
+      emitLine({
+        rowPhase: phase.name,
+        selectedPhase: phase,
+        lasts,
+        icon: statusIcon(phase.status, now),
+        labelText: modelLabel(phase),
+        labelStatus: phase.status,
+        suffix: phase.plannedVariant ? [fg(theme.faint)(`#${phase.plannedVariant}`)] : undefined,
+        right: phaseMetaChunks(phase, now),
+      })
+
+    // A group / sub-group header: the aggregate status icon, a label, and an
+    // `×N` count, carrying the group's aggregate elapsed/cost. `count` is the
+    // number of visible branches — distinct steps under a `parallel:` header,
+    // models under a fan-out header — not always the raw member total.
+    const emitHeader = (members: PhaseState[], labelText: string, kind: "step" | "parallel", count: number, lasts: boolean[]) => {
+      const status = groupStatus(members)
+      emitLine({
+        rowPhase: members[0]!.name,
+        lasts,
+        icon: statusIcon(status, now),
+        labelText,
+        labelStatus: status,
+        color: kind === "parallel" ? (text) => fg(theme.teal)(text) : undefined,
+        suffix: [fg(theme.faint)(` ×${count}`)],
+        right: groupMetaChunks(members, now),
+      })
+    }
+
+    for (const group of groupPhases(this.phases)) {
+      if (group.length === 1) {
+        const phase = group[0]!
+        emitRow(phase, [], phase.name, phaseMetaChunks(phase, now))
+        continue
+      }
+
+      const stepGroups = chunkByStepName(group)
+      if (stepGroups.length === 1) {
+        // A single step fanned out across models: the header names the step,
+        // each member names just its model.
+        emitHeader(group, stepLabel(group[0]!), "step", group.length, [])
+        group.forEach((phase, index) => emitModelRow(phase, [index === group.length - 1]))
+        continue
+      }
+
+      // A `parallel:` block of distinct steps; the header counts the steps,
+      // and any step that is itself fanned out across models nests one level
+      // deeper under its own ×N sub-header.
+      emitHeader(group, "parallel", "parallel", stepGroups.length, [])
+      stepGroups.forEach((members, stepIndex) => {
+        const lastStep = stepIndex === stepGroups.length - 1
+        if (members.length === 1) {
+          emitRow(members[0]!, [lastStep], stepLabel(members[0]!), phaseMetaChunks(members[0]!, now))
+          return
+        }
+        emitHeader(members, stepLabel(members[0]!), "step", members.length, [lastStep])
+        members.forEach((phase, index) => emitModelRow(phase, [lastStep, index === members.length - 1]))
+      })
+    }
+
     this.pipelineRowPhases = rows
     return joinLines(out)
   }
@@ -1220,10 +1324,11 @@ export class TuiProgress implements ProgressUI {
     if (!active) return [t`${fg(theme.dim)("waiting for the first phase to start…")}`]
 
     const out: StyledText[] = []
+    const title = phaseDisplayName(active)
     const head: TextChunk[] =
       active.status === "running"
-        ? [fg(theme.accent)(`${spinnerFrame(now)} `), bold(fg(theme.text)(active.name))]
-        : [statusIcon(active.status, now), raw(" "), bold(fg(theme.text)(active.name))]
+        ? [fg(theme.accent)(`${spinnerFrame(now)} `), bold(fg(theme.text)(title))]
+        : [statusIcon(active.status, now), raw(" "), bold(fg(theme.text)(title))]
     // Live activity sits to the right of the name; truncation reserves room
     // for the name, the separators, and a possible quiet indicator.
     if (active.now.message) {
@@ -1231,7 +1336,7 @@ export class TuiProgress implements ProgressUI {
       head.push(
         fg(theme.faint)("  ·  "),
         fg(style.color)(`${style.icon} `),
-        fg(theme.text)(truncate(active.now.message, Math.max(10, width - active.name.length - 28))),
+        fg(theme.text)(truncate(active.now.message, Math.max(10, width - title.length - 28))),
       )
     } else {
       head.push(fg(theme.faint)("  ·  "), fg(theme.dim)("waiting for opencode events…"))
@@ -1280,14 +1385,15 @@ export class TuiProgress implements ProgressUI {
     if (!phase) return [t`${fg(theme.dim)("no phases to show")}`]
     const out: StyledText[] = []
 
-    const head: TextChunk[] = [statusIcon(phase.status, now), raw(" "), bold(fg(theme.text)(phase.name))]
+    const title = phaseDisplayName(phase)
+    const head: TextChunk[] = [statusIcon(phase.status, now), raw(" "), bold(fg(theme.text)(title))]
     if (phase.description) {
-      head.push(fg(theme.faint)("  ·  "), fg(theme.dim)(truncate(phase.description, Math.max(10, width - phase.name.length - 8))))
+      head.push(fg(theme.faint)("  ·  "), fg(theme.dim)(truncate(phase.description, Math.max(10, width - title.length - 8))))
     }
     out.push(new StyledText(head))
 
     const meta: TextChunk[] = []
-    const elapsed = phase.restoredDurationMs ?? (phase.startedAt !== undefined ? (phase.endedAt ?? now) - phase.startedAt : undefined)
+    const elapsed = phaseElapsed(phase, now)
     if (elapsed !== undefined) meta.push(fg(theme.faint)("took "), fg(theme.dim)(formatElapsed(elapsed)))
     const model = phase.lastStepModel || phase.model
     if (model) {
@@ -1363,7 +1469,8 @@ export class TuiProgress implements ProgressUI {
       // Newest-first list: blank the phase label when the older neighbour
       // repeats it, so each phase shows once at the start of its group.
       const older = events[index + 1]
-      const phaseLabel = older && older.phase === entry.phase ? raw(" ".repeat(12)) : fg(theme.dim)(entry.phase.padEnd(12).slice(0, 12))
+      const label = this.feedLabel(entry.phase)
+      const phaseLabel = older && older.phase === entry.phase ? raw(" ".repeat(12)) : fg(theme.dim)(label.padEnd(12).slice(0, 12))
       return new StyledText([
         fg(theme.faint)(formatTime(entry.time)),
         raw(" "),
@@ -1374,6 +1481,16 @@ export class TuiProgress implements ProgressUI {
         fg(entry.kind === "error" ? theme.red : theme.text)(truncate(entry.message, Math.max(20, width - 26))),
       ])
     })
+  }
+
+  // Feed rows are cross-phase and only 12 columns wide, so a fanned-out
+  // member reads by its model alone (`opus-4-7`) rather than its `step__slug`
+  // id; every other phase keeps its own name. "archer" and unknown phases pass
+  // through untouched.
+  private feedLabel(name: string): string {
+    const phase = this.findPhase(name)
+    if (phase && phase.stepName && phase.stepName !== phase.name) return modelLabel(phase)
+    return name
   }
 
   private footerContent(now: number, width: number) {
@@ -1483,13 +1600,114 @@ function phaseMetaChunks(phase: PhaseState, now: number): TextChunk[] {
   if (phase.status === "pending") return []
   if (phase.status === "skipped" && phase.restoredDurationMs === undefined) return [fg(theme.faint)("skipped")]
   const parts: TextChunk[] = []
-  const elapsed = phase.restoredDurationMs ?? (phase.startedAt !== undefined ? (phase.endedAt ?? now) - phase.startedAt : undefined)
+  const elapsed = phaseElapsed(phase, now)
   if (elapsed !== undefined) {
     parts.push(fg(phase.status === "failed" ? theme.red : theme.dim)(formatElapsed(elapsed)))
   }
   // Live cost belongs to the current-step panel; a phase's final cost lands here once it ends.
   if (phase.usageReported && phase.status !== "running") parts.push(fg(theme.faint)(` ${formatMoney(phase.cost)}`))
   return parts
+}
+
+function phaseElapsed(phase: PhaseState, now: number): number | undefined {
+  return phase.restoredDurationMs ?? (phase.startedAt !== undefined ? (phase.endedAt ?? now) - phase.startedAt : undefined)
+}
+
+// Consecutive phases sharing a defined groupId form one concurrent group; a
+// human gate (no groupId) or a plain sequential step is a group of one.
+function groupPhases(phases: readonly PhaseState[]): PhaseState[][] {
+  const groups: PhaseState[][] = []
+  for (const phase of phases) {
+    const last = groups[groups.length - 1]
+    if (phase.groupId && last && last[0]!.groupId === phase.groupId) last.push(phase)
+    else groups.push([phase])
+  }
+  return groups
+}
+
+// Splits a group into its distinct logical steps: a pure `models:` fan-out is
+// one step (every member shares a stepName), a `parallel:` block is several.
+function chunkByStepName(group: readonly PhaseState[]): PhaseState[][] {
+  const chunks: PhaseState[][] = []
+  for (const phase of group) {
+    const last = chunks[chunks.length - 1]
+    if (last && stepLabel(last[0]!) === stepLabel(phase)) last.push(phase)
+    else chunks.push([phase])
+  }
+  return chunks
+}
+
+// Column count of a chunk list. The pipeline tree uses only single-cell
+// glyphs (icons, box-drawing, ASCII), so a codepoint count is the cell width.
+function plainLen(chunks: readonly TextChunk[]): number {
+  let count = 0
+  for (const chunk of chunks) for (const _ of chunk.text) count++
+  return count
+}
+
+// Box-drawing prefix for a tree row: one entry per ancestor level, true when
+// that ancestor was its parent's last child (so its vertical line stops).
+function treePrefix(lasts: readonly boolean[]): string {
+  if (lasts.length === 0) return ""
+  let prefix = ""
+  for (let i = 0; i < lasts.length - 1; i++) prefix += lasts[i] ? "  " : "│ "
+  return `${prefix}${lasts[lasts.length - 1] ? "└ " : "├ "}`
+}
+
+// A concurrent group's aggregate status: running while any member is (or has
+// started but none have), then failed/skipped/completed once all have ended.
+function groupStatus(members: readonly PhaseState[]): PhaseStatus {
+  const allEnded = members.every((m) => m.status === "completed" || m.status === "skipped" || m.status === "failed")
+  if (!allEnded) return members.some((m) => m.status === "running" || m.startedAt !== undefined) ? "running" : "pending"
+  if (members.some((m) => m.status === "failed")) return "failed"
+  if (members.every((m) => m.status === "skipped")) return "skipped"
+  return "completed"
+}
+
+// Aggregate meta for a group header: wall-clock is the longest member (they
+// run concurrently), cost is their sum.
+function groupMetaChunks(members: readonly PhaseState[], now: number): TextChunk[] {
+  const status = groupStatus(members)
+  if (status === "pending") return []
+  const parts: TextChunk[] = []
+  const elapsed = members.map((m) => phaseElapsed(m, now)).filter((value): value is number => value !== undefined)
+  if (elapsed.length > 0) parts.push(fg(status === "failed" ? theme.red : theme.dim)(formatElapsed(Math.max(...elapsed))))
+  if (members.some((m) => m.usageReported) && status !== "running") {
+    parts.push(fg(theme.faint)(` ${formatMoney(members.reduce((sum, m) => sum + m.cost, 0))}`))
+  }
+  return parts
+}
+
+// The status-driven colouring a pipeline name (or model label) takes: bold
+// while running or selected, dimmed while pending, faint once skipped.
+function phaseNameChunk(text: string, status: PhaseStatus, selected: boolean): TextChunk {
+  if (selected || status === "running") return bold(fg(theme.text)(text))
+  if (status === "pending") return fg(theme.dim)(text)
+  if (status === "skipped") return fg(theme.faint)(text)
+  return fg(theme.text)(text)
+}
+
+// The logical (pre-fan-out) name of a phase; equals its own name for a plain
+// sequential step or a human gate.
+function stepLabel(phase: PhaseState): string {
+  return phase.stepName ?? phase.name
+}
+
+// A compact model label for a fanned-out member: provider prefix dropped, and
+// the redundant `claude-` vendor token trimmed, so `security__…opus-4-7`
+// reads as just `opus-4-7`. Falls back to the live/planned model once known.
+function modelLabel(phase: PhaseState): string {
+  const full = phase.lastStepModel || phase.model || phase.plannedModel || ""
+  if (!full) return stepLabel(phase)
+  const id = full.includes("/") ? full.slice(full.lastIndexOf("/") + 1) : full
+  return id.replace(/^claude-/, "")
+}
+
+// A phase's name for use outside the pipeline tree (pane titles, the feed):
+// a fanned-out member reads as `step · model` instead of its `step__slug` id.
+function phaseDisplayName(phase: PhaseState): string {
+  if (phase.stepName && phase.stepName !== phase.name) return `${phase.stepName} · ${modelLabel(phase)}`
+  return phase.name
 }
 
 // One row per todo, windowed around the first unfinished item when the list

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,10 +63,14 @@ export type AgentStep = {
   inputFiles: readonly string[]
   inputDiff: boolean
   reportPath: string
-  /** True when the underlying agent is configured as read-only. */
+  /** True when the underlying agent is configured as read-only, or forced read-only for parallel/multi-model execution. */
   readOnly?: boolean
   /** Per-step override; falls back to --max-attempts when absent. */
   maxAttempts?: number
+  /** Shared by every step produced from the same top-level pipeline entry; the runner batches same-groupId steps to run concurrently. */
+  groupId: string
+  /** Pre-fan-out logical name; equals `name` unless this step was produced by a `models:` fan-out. */
+  stepName: string
 }
 
 export type HumanStep = {

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -67,6 +67,32 @@ describe("opencode config", () => {
     }
   })
 
+  test("a synthesized forced-read-only agent (__ro suffix) loads the base agent's prompt, not its own", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "archer-ro-variant-"))
+    try {
+      await mkdir(join(dir, ".archer", "agents"), { recursive: true })
+      await writeFile(join(dir, ".archer", "agents", "clean-code.md"), "# Clean Code\n\nLook for unnecessary complexity.")
+
+      // Only "clean-code" has a prompt file on disk; "clean-code__ro" is
+      // synthesized by synthesizeReadOnlyAgents and must not need its own.
+      const config = opencodeConfig("/tmp/archer-run", dir, [
+        { name: "clean-code", description: "Clean code review", builtIn: false },
+        { name: "clean-code__ro", description: "Clean code review", readOnly: true, builtIn: false },
+      ])
+
+      const forced = config.agent?.["clean-code__ro"]
+      expect(forced?.prompt).toContain("# Clean Code")
+      expect(forced?.prompt).toContain("Look for unnecessary complexity.")
+      expect(forced?.tools?.write).toBe(false)
+      expect(forced?.tools?.edit).toBe(false)
+      expect(forced?.tools?.bash).toBe(false)
+      // The base agent's own config is untouched: still writable.
+      expect(config.agent?.["clean-code"]?.tools?.write).toBe(true)
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
   test("read-only agents cannot write, edit, or run shell commands", async () => {
     const dir = await mkdtemp(join(tmpdir(), "archer-readonly-agent-"))
     try {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -16,10 +16,11 @@ import {
   parseArcherConfig,
   selectPipelineSpec,
   serializeArcherConfig,
+  writeArcherConfig,
   writeDefaultArcherConfig,
   writeDefaultProjectConfig,
 } from "../src/config"
-import { builtInAgents, defaultGptModel, defaultGptVariant, defaultOpusModel } from "../src/pipeline"
+import { builtInAgents, defaultGptModel, defaultGptVariant, defaultOpusModel, isParallelSpec } from "../src/pipeline"
 
 const dirs: string[] = []
 
@@ -139,6 +140,113 @@ describe("config loading", () => {
   })
 })
 
+describe("parallel steps and model fan-out", () => {
+  test("parses a parallel block with a models fan-out member", async () => {
+    const dir = await projectDir(undefined, ["clean-code"])
+    const config = parse(
+      [
+        "pipelines:",
+        "  audit:",
+        "    steps:",
+        "      - implementer",
+        "      - parallel:",
+        "          - patterns",
+        "          - security",
+        "          - agent: clean-code",
+        "            models:",
+        "              - anthropic/claude-opus-4-7",
+        "              - openai/gpt-5.5#xhigh",
+        "      - agent: adversarial",
+        "        name: triage",
+        "        reports: all",
+      ].join("\n"),
+      dir,
+    )
+
+    expect(config.pipelines.audit?.steps).toEqual([
+      "implementer",
+      {
+        parallel: [
+          "patterns",
+          "security",
+          { agent: "clean-code", models: ["anthropic/claude-opus-4-7", "openai/gpt-5.5#xhigh"] },
+        ],
+      },
+      { agent: "adversarial", name: "triage", reports: "all" },
+    ])
+  })
+
+  test("rejects nested parallel blocks", () => {
+    expect(() =>
+      parse("pipelines:\n  p:\n    steps:\n      - implementer\n      - parallel:\n          - parallel:\n              - patterns"),
+    ).toThrow("nested")
+  })
+
+  test("rejects human-review inside a parallel block, string and object form", () => {
+    expect(() => parse("pipelines:\n  p:\n    steps:\n      - implementer\n      - parallel:\n          - patterns\n          - human-review")).toThrow(
+      "can't run inside a parallel block",
+    )
+    expect(() =>
+      parse("pipelines:\n  p:\n    steps:\n      - implementer\n      - parallel:\n          - patterns\n          - agent: human-review"),
+    ).toThrow("can't run inside a parallel block")
+  })
+
+  test("rejects an empty parallel block", () => {
+    expect(() => parse("pipelines:\n  p:\n    steps:\n      - implementer\n      - parallel: []")).toThrow("must be a non-empty list of steps")
+  })
+
+  test("rejects models with fewer than 2 entries", () => {
+    expect(() =>
+      parse("pipelines:\n  p:\n    steps:\n      - agent: implementer\n        models:\n          - anthropic/claude-opus-4-7"),
+    ).toThrow("at least 2 entries")
+  })
+
+  test("rejects setting both model and models", () => {
+    expect(() =>
+      parse(
+        [
+          "pipelines:",
+          "  p:",
+          "    steps:",
+          "      - agent: implementer",
+          "        model: anthropic/claude-opus-4-7",
+          "        models:",
+          "          - anthropic/claude-opus-4-7",
+          "          - openai/gpt-5.5#xhigh",
+        ].join("\n"),
+      ),
+    ).toThrow('set either "model" or "models"')
+  })
+
+  test("rejects agent names ending in the reserved read-only suffix", () => {
+    expect(() => parse("agents:\n  clean-code__ro:\n    model: anthropic/claude-opus-4-7")).toThrow('reserved for archer\'s forced-read-only variants')
+  })
+
+  test("a config with parallel/models round-trips through serialize + reparse", async () => {
+    const dir = await projectDir(undefined, ["clean-code"])
+    const config = parse(
+      [
+        "pipelines:",
+        "  audit:",
+        "    steps:",
+        "      - implementer",
+        "      - parallel:",
+        "          - patterns",
+        "          - agent: clean-code",
+        "            models:",
+        "              - anthropic/claude-opus-4-7",
+        "              - openai/gpt-5.5#xhigh",
+      ].join("\n"),
+      dir,
+    )
+
+    const path = join(dir, ".archer", "config.yaml")
+    await writeArcherConfig(path, config, dir)
+    const reparsed = parse(await readFile(path, "utf8"), dir)
+    expect(reparsed.pipelines).toEqual(config.pipelines)
+  })
+})
+
 describe("agent registry", () => {
   test("merges built-in overrides and appends project agents", async () => {
     const dir = await projectDir(undefined, ["api-reviewer"])
@@ -251,7 +359,7 @@ describe("serialization", () => {
     const template = defaultConfigTemplate()
     expect(template.defaults.model).toBe(`${defaultGptModel}#${defaultGptVariant}`)
     const steps = template.pipelines.default!.steps
-    expect(steps.find((step) => typeof step !== "string" && step.agent === "design")).toEqual({ agent: "design", model: defaultOpusModel })
+    expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && step.agent === "design")).toEqual({ agent: "design", model: defaultOpusModel })
     const reparsed = parse(serializeArcherConfig(template))
     expect(reparsed.defaults).toEqual(template.defaults)
     expect(reparsed.pipelines).toEqual(template.pipelines)

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -34,6 +34,8 @@ const quick: Pipeline = {
       inputFiles: ["prd.md"],
       inputDiff: false,
       reportPath: "reports/implementer.md",
+      groupId: "g1",
+      stepName: "implementer",
     },
   ],
 }

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -4,8 +4,10 @@ import {
   builtInAgents,
   defaultPipeline,
   resolvePipeline,
+  slugifyModel,
   splitModelVariant,
   stepNames,
+  synthesizeReadOnlyAgents,
   validateStepFilters,
   type PipelineSpec,
 } from "../src/pipeline"
@@ -186,5 +188,163 @@ describe("step filters", () => {
 
     const headless = { ...pipeline, steps: pipeline.steps.filter((step) => step.type !== "human") }
     expect(() => validateStepFilters(headless, { onlySteps: [], skipSteps: ["human-review"] })).not.toThrow()
+  })
+
+  test("accepts a fanned-out step's shared stepName alongside its full disambiguated name", () => {
+    const pipeline = resolve({
+      steps: ["implementer", { agent: "adversarial", name: "clean-code", models: ["anthropic/claude-opus-4-7", "openai/gpt-5.5#xhigh"] }],
+    })
+    expect(() => validateStepFilters(pipeline, { onlySteps: ["clean-code"], skipSteps: [] })).not.toThrow()
+    expect(() => validateStepFilters(pipeline, { onlySteps: ["clean-code__anthropic-claude-opus-4-7"], skipSteps: [] })).not.toThrow()
+  })
+})
+
+describe("parallel groups", () => {
+  test("resolves a parallel block into steps sharing one groupId, forced read-only with a synthesized agent name", () => {
+    const [, patterns, security] = agentSteps({ steps: ["implementer", { parallel: ["patterns", "security"] }] })
+
+    expect(patterns?.groupId).toBeDefined()
+    expect(patterns?.groupId).toBe(security?.groupId)
+    expect(patterns?.readOnly).toBe(true)
+    expect(security?.readOnly).toBe(true)
+    // pattern-auditor/security-auditor aren't read-only by default, so parallel execution synthesizes a "__ro" variant
+    expect(patterns?.agentName).toBe("pattern-auditor__ro")
+    expect(security?.agentName).toBe("security-auditor__ro")
+  })
+
+  test("doesn't double-suffix an agent that's already configured read-only", () => {
+    const agents = builtInAgents.map((agent) => (agent.name === "security-auditor" ? { ...agent, readOnly: true } : agent))
+    const [security] = resolvePipeline({ name: "test", spec: { steps: [{ parallel: ["security"] }] }, agents }).steps as AgentStep[]
+    expect(security?.agentName).toBe("security-auditor")
+    expect(security?.readOnly).toBe(true)
+  })
+
+  test("a step inside a parallel block never sees its own siblings' reports, only earlier groups'", () => {
+    const [, patterns, security] = agentSteps({ steps: ["implementer", { parallel: ["patterns", "security"] }] })
+    expect(patterns?.inputFiles).toEqual(["prd.md", "reports/implementer.md"])
+    expect(security?.inputFiles).toEqual(["prd.md", "reports/implementer.md"])
+  })
+
+  test("reports: previous after a group expands to every member of that group", () => {
+    const steps = agentSteps({
+      steps: ["implementer", { parallel: ["patterns", "security"] }, { agent: "adversarial", name: "triage" }],
+    })
+    const triage = steps.find((step) => step.name === "triage")
+    expect(triage?.inputFiles).toEqual(["prd.md", "reports/patterns.md", "reports/security.md"])
+  })
+
+  test("reports: all includes every member of every earlier group", () => {
+    const steps = agentSteps({
+      steps: ["implementer", { parallel: ["patterns", "security"] }, { agent: "adversarial", name: "triage", reports: "all" }],
+    })
+    const triage = steps.find((step) => step.name === "triage")
+    expect(triage?.inputFiles).toEqual(["prd.md", "reports/implementer.md", "reports/patterns.md", "reports/security.md"])
+  })
+
+  test("empty parallel block is rejected", () => {
+    expect(() => resolve({ steps: ["implementer", { parallel: [] }] })).toThrow("empty parallel block")
+  })
+
+  test("nested parallel blocks are rejected", () => {
+    // Nesting isn't representable in StepSpec's types; simulate config-loaded data that bypassed validation.
+    const nested = { parallel: ["patterns"] } as unknown as string
+    expect(() => resolve({ steps: ["implementer", { parallel: [nested, "security"] }] })).toThrow("nest a parallel block")
+  })
+
+  test("human-review can't run inside a parallel block", () => {
+    expect(() => resolve({ steps: ["implementer", { parallel: ["patterns", "human-review"] }] })).toThrow("inside a parallel block")
+    expect(() => resolve({ steps: ["implementer", { parallel: ["patterns", { agent: "human-review" }] }] })).toThrow("inside a parallel block")
+  })
+})
+
+describe("model fan-out", () => {
+  test("slugifies provider/model#variant into a filesystem-safe suffix", () => {
+    expect(slugifyModel("anthropic/claude-opus-4-7")).toBe("anthropic-claude-opus-4-7")
+    expect(slugifyModel("openai/gpt-5.5#xhigh")).toBe("openai-gpt-5-5-xhigh")
+  })
+
+  test("fans a step out across models, one forced-read-only invocation per model, sharing groupId/stepName", () => {
+    const [clean1, clean2] = agentSteps({
+      steps: [{ agent: "implementer", name: "clean-code", models: ["anthropic/claude-opus-4-7", "openai/gpt-5.5#xhigh"] }],
+    })
+
+    expect(clean1?.stepName).toBe("clean-code")
+    expect(clean2?.stepName).toBe("clean-code")
+    expect(clean1?.groupId).toBe(clean2?.groupId)
+    expect(clean1?.name).toBe("clean-code__anthropic-claude-opus-4-7")
+    expect(clean2?.name).toBe("clean-code__openai-gpt-5-5-xhigh")
+    expect(clean1).toMatchObject({ model: "anthropic/claude-opus-4-7" })
+    expect(clean2).toMatchObject({ model: "openai/gpt-5.5", variant: "xhigh" })
+    expect(clean1?.reportPath).toBe("reports/clean-code__anthropic-claude-opus-4-7.md")
+    expect(clean1?.readOnly).toBe(true)
+    expect(clean2?.readOnly).toBe(true)
+    expect(clean1?.agentName).toBe("implementer__ro")
+  })
+
+  test("reports: [stepName] on a fanned-out step expands to every model variant", () => {
+    const steps = agentSteps({
+      steps: [
+        { agent: "implementer", name: "clean-code", models: ["anthropic/claude-opus-4-7", "openai/gpt-5.5#xhigh"] },
+        { agent: "adversarial", name: "triage", reports: ["clean-code"] },
+      ],
+    })
+    const triage = steps.find((step) => step.name === "triage")
+    expect(triage?.inputFiles).toEqual(["prd.md", "reports/clean-code__anthropic-claude-opus-4-7.md", "reports/clean-code__openai-gpt-5-5-xhigh.md"])
+  })
+
+  test("a fanned-out step can also be targeted by one specific variant's full name", () => {
+    const steps = agentSteps({
+      steps: [
+        { agent: "implementer", name: "clean-code", models: ["anthropic/claude-opus-4-7", "openai/gpt-5.5#xhigh"] },
+        { agent: "adversarial", name: "triage", reports: ["clean-code__anthropic-claude-opus-4-7"] },
+      ],
+    })
+    const triage = steps.find((step) => step.name === "triage")
+    expect(triage?.inputFiles).toEqual(["prd.md", "reports/clean-code__anthropic-claude-opus-4-7.md"])
+  })
+
+  test("models needs at least 2 entries", () => {
+    expect(() => resolve({ steps: [{ agent: "implementer", models: ["anthropic/claude-opus-4-7"] }] })).toThrow("at least 2 entries")
+  })
+
+  test("can't set both model and models", () => {
+    expect(() =>
+      resolve({
+        steps: [{ agent: "implementer", model: "anthropic/claude-opus-4-7", models: ["anthropic/claude-opus-4-7", "openai/gpt-5.5#xhigh"] }],
+      }),
+    ).toThrow('both "model" and "models"')
+  })
+
+  test("models inside a parallel block compose: fan-out members join the block's shared group", () => {
+    const steps = agentSteps({
+      steps: [
+        "implementer",
+        {
+          parallel: ["patterns", { agent: "implementer", name: "clean-code", models: ["anthropic/claude-opus-4-7", "openai/gpt-5.5#xhigh"] }],
+        },
+      ],
+    })
+    expect(steps.length).toBe(4) // implementer + patterns + 2 clean-code variants
+    const groupIds = new Set(steps.slice(1).map((step) => step.groupId))
+    expect(groupIds.size).toBe(1)
+  })
+})
+
+describe("synthesizeReadOnlyAgents", () => {
+  test("builds one forced-read-only agent spec per distinct base agent referenced, deduped", () => {
+    const pipeline = resolve({
+      steps: [
+        "implementer",
+        { parallel: ["patterns", "security"] },
+        { agent: "implementer", name: "clean-code", models: ["anthropic/claude-opus-4-7", "openai/gpt-5.5#xhigh"] },
+      ],
+    })
+    const synthesized = synthesizeReadOnlyAgents(pipeline, builtInAgents)
+    expect(synthesized.map((agent) => agent.name).sort()).toEqual(["implementer__ro", "pattern-auditor__ro", "security-auditor__ro"])
+    expect(synthesized.every((agent) => agent.readOnly)).toBe(true)
+  })
+
+  test("returns nothing when no step needed a synthesized variant", () => {
+    expect(synthesizeReadOnlyAgents(defaultPipeline(), builtInAgents)).toEqual([])
   })
 })

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -6,18 +6,22 @@ import { join } from "node:path"
 import { openRunMetadata, type RunMetadataStore } from "../src/metadata"
 import { noopProgress, type ProgressPhaseSnapshot } from "../src/progress"
 import {
+  RunShutdown,
   UserAbortError,
   commitRecoveredPhase,
+  createGitLock,
   describeSessionActivity,
   isIgnorableRejection,
   newActivityState,
   parseModel,
+  planBatches,
   restorePhaseFromPreviousRun,
   selectInterruptedPhase,
   shouldRetryAttempt,
   shouldSkip,
+  type ActiveSession,
 } from "../src/runner"
-import type { AgentStep, Pipeline } from "../src/types"
+import type { AgentStep, HumanStep, Pipeline, Step } from "../src/types"
 import type { Workspace } from "../src/workspace"
 
 const recoveryDirs: string[] = []
@@ -50,6 +54,21 @@ async function dirtyRepo(): Promise<string> {
   return dir
 }
 
+function agentStep(name: string): AgentStep {
+  return {
+    type: "agent",
+    name,
+    agentName: name,
+    description: name,
+    model: "openai/gpt-5.5",
+    inputFiles: [],
+    inputDiff: false,
+    reportPath: `reports/${name}.md`,
+    groupId: `g-${name}`,
+    stepName: name,
+  }
+}
+
 function messageUpdated(info: Record<string, unknown>) {
   return { type: "message.updated", properties: { sessionID: "ses_1", info } }
 }
@@ -78,10 +97,17 @@ describe("runner helpers", () => {
   })
 
   test("applies only and skip phase filters", () => {
-    expect(shouldSkip("security", { onlySteps: ["implementer"], skipSteps: [] })).toBe(true)
-    expect(shouldSkip("implementer", { onlySteps: ["implementer"], skipSteps: ["implementer"] })).toBe(false)
-    expect(shouldSkip("design", { onlySteps: [], skipSteps: ["design"] })).toBe(true)
-    expect(shouldSkip("tests", { onlySteps: [], skipSteps: [] })).toBe(false)
+    expect(shouldSkip(agentStep("security"), { onlySteps: ["implementer"], skipSteps: [] })).toBe(true)
+    expect(shouldSkip(agentStep("implementer"), { onlySteps: ["implementer"], skipSteps: ["implementer"] })).toBe(false)
+    expect(shouldSkip(agentStep("design"), { onlySteps: [], skipSteps: ["design"] })).toBe(true)
+    expect(shouldSkip(agentStep("tests"), { onlySteps: [], skipSteps: [] })).toBe(false)
+  })
+
+  test("only/skip also match a fanned-out step's shared stepName", () => {
+    const variant = { ...agentStep("clean-code__anthropic-claude-opus-4-7"), stepName: "clean-code" }
+    expect(shouldSkip(variant, { onlySteps: ["clean-code"], skipSteps: [] })).toBe(false)
+    expect(shouldSkip(variant, { onlySteps: ["some-other-step"], skipSteps: [] })).toBe(true)
+    expect(shouldSkip(variant, { onlySteps: [], skipSteps: ["clean-code"] })).toBe(true)
   })
 
   test("turns assistant message updates into live cumulative usage", () => {
@@ -203,9 +229,117 @@ describe("runner helpers", () => {
   })
 })
 
+describe("planBatches", () => {
+  const human = (name: string): HumanStep => ({ type: "human", name, description: name })
+
+  test("sequential steps and human gates are each their own batch", () => {
+    const steps: Step[] = [agentStep("implementer"), human("human-review"), agentStep("tests")]
+    expect(planBatches(steps)).toEqual([[steps[0]], [steps[1]], [steps[2]]])
+  })
+
+  test("consecutive agent steps sharing a groupId batch together", () => {
+    const patterns = { ...agentStep("patterns"), groupId: "g2" }
+    const security = { ...agentStep("security"), groupId: "g2" }
+    const steps: Step[] = [agentStep("implementer"), patterns, security, agentStep("triage")]
+    expect(planBatches(steps)).toEqual([[steps[0]], [patterns, security], [steps[3]]])
+  })
+
+  test("a groupId doesn't merge across a human gate between them", () => {
+    const before = { ...agentStep("a"), groupId: "shared" }
+    const after = { ...agentStep("b"), groupId: "shared" }
+    const steps: Step[] = [before, human("human-review"), after]
+    expect(planBatches(steps)).toEqual([[before], [human("human-review")], [after]])
+  })
+})
+
+describe("RunShutdown multi-session tracking", () => {
+  function fakeSession(phaseName: string, sessionID: string, aborted: string[]): ActiveSession {
+    return {
+      sessionID,
+      directory: "/tmp/target",
+      phaseName,
+      client: {
+        session: {
+          abort: async ({ sessionID }: { sessionID: string; directory: string }) => {
+            aborted.push(sessionID)
+            return { error: undefined }
+          },
+        },
+      } as unknown as ActiveSession["client"],
+    }
+  }
+
+  test("tracks one active session per phase independently", () => {
+    const shutdown = new RunShutdown()
+    const aborted: string[] = []
+    shutdown.setActiveSession(fakeSession("patterns", "ses_1", aborted))
+    shutdown.setActiveSession(fakeSession("security", "ses_2", aborted))
+
+    // Clearing one phase's session doesn't touch the other's.
+    shutdown.clearActiveSession("patterns", "ses_1")
+    shutdown.clearActiveSession("security", "ses_wrong-id")
+    return shutdown.abortActiveSessions().then(() => {
+      expect(aborted).toEqual(["ses_2"])
+    })
+  })
+
+  test("abortActiveSessions aborts every currently-tracked session", async () => {
+    const shutdown = new RunShutdown()
+    const aborted: string[] = []
+    shutdown.setActiveSession(fakeSession("patterns", "ses_1", aborted))
+    shutdown.setActiveSession(fakeSession("security", "ses_2", aborted))
+    shutdown.setActiveSession(fakeSession("clean-code", "ses_3", aborted))
+
+    await shutdown.abortActiveSessions()
+    expect(aborted.sort()).toEqual(["ses_1", "ses_2", "ses_3"])
+  })
+
+  test("concurrent callers share the same in-flight abort", async () => {
+    const shutdown = new RunShutdown()
+    const aborted: string[] = []
+    shutdown.setActiveSession(fakeSession("patterns", "ses_1", aborted))
+
+    const [a, b] = await Promise.all([shutdown.abortActiveSessions(), shutdown.abortActiveSessions()])
+    expect(a).toBe(b)
+    expect(aborted).toEqual(["ses_1"])
+  })
+})
+
+describe("createGitLock", () => {
+  test("serializes concurrent jobs in enqueue order, regardless of individual duration", async () => {
+    const gitLock = createGitLock()
+    const order: number[] = []
+    const job = (id: number, delayMs: number) =>
+      gitLock(async () => {
+        await new Promise((resolve) => setTimeout(resolve, delayMs))
+        order.push(id)
+      })
+
+    // Job 1 is slowest but enqueued first; it must still finish before 2 and 3 start.
+    await Promise.all([job(1, 30), job(2, 10), job(3, 0)])
+    expect(order).toEqual([1, 2, 3])
+  })
+
+  test("a rejected job doesn't break the chain for jobs queued after it", async () => {
+    const gitLock = createGitLock()
+    const order: string[] = []
+
+    const first = gitLock(async () => {
+      order.push("first")
+      throw new Error("boom")
+    })
+    const second = gitLock(async () => {
+      order.push("second")
+    })
+
+    await expect(first).rejects.toThrow("boom")
+    await second
+    expect(order).toEqual(["first", "second"])
+  })
+})
+
 describe("dirty-tree recovery", () => {
-  const agent = (name: string): AgentStep =>
-    ({ type: "agent", name, agentName: name, description: name, model: "openai/gpt-5.5", inputFiles: [], inputDiff: false, reportPath: `reports/${name}.md` })
+  const agent = agentStep
   const pipeline: Pipeline = {
     name: "p",
     steps: [agent("implementer"), { type: "human", name: "review", description: "review" }, agent("patterns"), agent("tests")],

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -250,6 +250,15 @@ describe("planBatches", () => {
     const steps: Step[] = [before, human("human-review"), after]
     expect(planBatches(steps)).toEqual([[before], [human("human-review")], [after]])
   })
+
+  test("consecutive agent steps with an undefined groupId never batch together", () => {
+    // Legacy metadata.json from before groupId existed (schemaVersion 1-2)
+    // loads steps missing the field entirely; guard against undefined === undefined.
+    const a = { ...agentStep("a"), groupId: undefined } as unknown as AgentStep
+    const b = { ...agentStep("b"), groupId: undefined } as unknown as AgentStep
+    const steps: Step[] = [a, b]
+    expect(planBatches(steps)).toEqual([[a], [b]])
+  })
 })
 
 describe("RunShutdown multi-session tracking", () => {


### PR DESCRIPTION
## Summary
- Adds `parallel: [...]` blocks to pipeline config: member steps run concurrently, forced read-only unconditionally (no per-step opt-out) so they can't corrupt each other's changes to the shared working tree.
- Adds `models: [...]` on any step (inside or outside a parallel block) to fan it out into one concurrent, forced-read-only invocation per model.
- Report threading is group-aware: `reports: previous` after a group/fan-out attaches every member's report, `reports: all`/`[name]` expand fanned-out steps to all their model variants.
- TUI shows a live pane per concurrently-running phase (up to 4, with overflow folded into the last pane's title); ordinary sequential pipelines render identically to before.
- Fixes two latent bugs surfaced while building this: `templatePipeline()` silently dropping `parallel:` blocks, and `config-tui.ts` crashing on non-agent step specs.

## Test plan
- [x] `bun run typecheck` and `bun test` (166 tests, including new coverage for group/fan-out resolution, sibling report isolation, synthesized read-only agents, config validation, and the concurrent-batch/git-lock runner logic)
- [x] End-to-end resolution check against a real scratch git repo (YAML config → `resolvePipeline` → synthesized `__ro` agents → OpenCode agent config)
- [x] Visual verification of the new TUI multi-pane layout via `@opentui/core/testing`'s headless renderer (roomy + small terminal sizes, plus the unchanged single-phase path)
- [ ] A live `archer` run against real model APIs (not possible in the sandboxed dev environment - no provider credentials)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>