### PR TITLE
feat(pipeline): report-only review, rename review→refine, ship pipelines as built-ins

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Archer is a higher-level orchestration harness for [OpenCode](https://opencode.a
 
 Rather than being only a sequential agent chain, Archer owns the operational layer around OpenCode: repo context attachment, runtime guard rails, permission gates, phase reports, diff tracking, and human-in-the-loop checkpoints.
 
-Pipelines are data, not code: archer ships a built-in `default` pipeline, and a project can define its own — any number of steps, its own agents, its own models, with `human-review` gates anywhere — in `.archer/config.yaml`.
+Pipelines are data, not code: archer ships a family of built-in pipelines (`default`, `ultra-implementation`, `refine`, `ultra-refine`, and a report-only `review` — see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with `human-review` gates anywhere — in `.archer/config.yaml`.
 
 Archer is written in Bun + TypeScript and uses `@opencode-ai/sdk` to control OpenCode. The SDK starts/controls the OpenCode server; Archer no longer manually calls `opencode run` nor parses stdout.
 
@@ -22,9 +22,23 @@ PRD ──► implementer ──► patterns ──► security ──► design
 | `implementer` | `implementer` | `openai/gpt-5.5#xhigh` | Implements the feature respecting repo patterns |
 | `patterns` | `pattern-auditor` | `openai/gpt-5.5#xhigh` | Refactors without changing behavior, aligns with the rest of the code |
 | `security` | `security-auditor` | `openai/gpt-5.5#xhigh` | Audits and fixes security issues |
-| `design` | `design-polisher` | `anthropic/claude-opus-4-7` | Polishes UI following the repo's design system |
+| `design` | `design-polisher` | `anthropic/claude-opus-4-8` | Polishes UI following the repo's design system |
 | `tests` | `test-engineer` | `openai/gpt-5.5#xhigh` | Automated tests + relevant E2E/integration coverage |
-| `adversarial` | `adversarial-reviewer` | `anthropic/claude-opus-4-7` | Final adversarial review before PR creation |
+| `adversarial` | `adversarial-reviewer` | `anthropic/claude-opus-4-8` | Final adversarial review before PR creation |
+
+## Built-in pipelines
+
+Archer ships these pipelines; select one with `-p/--pipeline` (no config needed). A project can add or override any of them in `.archer/config.yaml`.
+
+| Pipeline | Changes code? | What it does |
+|---|---|---|
+| `default` | yes | Implement a PRD, then audit, polish, test, and adversarial review (the table above). |
+| `ultra-implementation` | yes | Like `default`, but the pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, and the run ends with an audit-only final review, a fixer that applies only blocking findings, and a final validator. |
+| `refine` | yes | Audit the current diff (scope → bugs → clean-code → security), triage the findings adversarially, apply the accepted fixes, then validate them. |
+| `ultra-refine` | yes | Like `refine`, but every read-only audit is fanned out across two models before triage, fixes, and validation. |
+| `review` | **no — report only** | Scope the diff, run the bug / clean-code(+patterns) / security audits **in parallel across two models each**, then a single step synthesizes everything into one prioritized findings report. Makes no changes; the run's output is `reports/report.md`, which you read to decide whether to follow up with a `refine` run. |
+
+`refine`/`ultra-refine` are the change-applying counterparts of `review`: run `review` first to get a report, then `refine` if you want the fixes applied.
 
 ## Requirements
 
@@ -46,7 +60,7 @@ opencode models openai
 opencode models anthropic
 ```
 
-To use different providers, authenticate them in OpenCode and select models as `provider/model`. Archer defaults to `openai/gpt-5.5` with variant `xhigh` for non-design phases, and `anthropic/claude-opus-4-7` for design and adversarial review.
+To use different providers, authenticate them in OpenCode and select models as `provider/model`. Archer defaults to `openai/gpt-5.5` with variant `xhigh` for non-design phases, and `anthropic/claude-opus-4-8` for design and adversarial review.
 
 ## Installation
 
@@ -211,7 +225,7 @@ defaults:
 agents:
   api-reviewer:
     description: Reviews public API consistency
-    model: anthropic/claude-opus-4-7
+    model: anthropic/claude-opus-4-8
     temperature: 0.1
     readOnly: true               # disables write/edit/bash tools for this agent
 
@@ -241,7 +255,7 @@ pipelines:
           - security
           - agent: clean-code
             models:                # fans this one step out across models, one read-only run per model
-              - anthropic/claude-opus-4-7
+              - anthropic/claude-opus-4-8
               - openai/gpt-5.5#xhigh
       - agent: adversarial
         name: triage

--- a/prompts/bug-auditor.md
+++ b/prompts/bug-auditor.md
@@ -1,0 +1,24 @@
+# Bug Auditor
+
+You are the **bug-auditor** agent of Archer's `review` and `refine` pipelines. This is an audit-only phase: do not modify the repository.
+
+## Objective
+
+Find concrete bugs, regressions, and functional risks in the scoped change.
+
+## Workflow
+
+1. Read `prd.md`, `reports/scope.md`, the attached diff, and relevant source/tests.
+2. Validate behavior against the request and the patterns discovered by `review-scope`.
+3. Look for edge cases, null/empty states, async races, stale state, incorrect assumptions, error handling gaps, broken tests, migrations, API contract mismatches, and backwards compatibility risks.
+4. Avoid speculative findings. A finding must identify a plausible failing path.
+
+## Report
+
+Return Markdown with:
+
+- **Findings**: `BUG-1`, `BUG-2`, ... with severity `critical|high|medium|low`, file reference, evidence, impact, and recommended fix.
+- **Checks performed**: files/behaviors inspected and any commands or validations you could not run.
+- **No-finding notes**: important areas reviewed with no issue.
+
+Do not include clean-code-only or security-only concerns unless they directly cause a functional failure.

--- a/prompts/clean-code-auditor.md
+++ b/prompts/clean-code-auditor.md
@@ -1,0 +1,24 @@
+# Clean Code Auditor
+
+You are the **clean-code-auditor** agent of Archer's `review` and `refine` pipelines. This is an audit-only phase: do not modify the repository. You cover both repo-pattern alignment and general maintainability.
+
+## Objective
+
+Audit maintainability of the scoped change against this repository's actual conventions.
+
+## Workflow
+
+1. Read `prd.md`, `reports/scope.md`, the attached diff, and nearby code.
+2. Compare the implementation to the discovered architecture and local patterns.
+3. Look for excessive complexity, duplication, poor naming, misplaced files, leaky abstractions, boundary violations, inconsistent dependency usage, over-engineering, under-tested seams, and avoidable churn.
+4. Prefer findings that a maintainer should ask to change before merging.
+
+## Report
+
+Return Markdown with:
+
+- **Findings**: `CC-1`, `CC-2`, ... with severity `high|medium|low`, file reference, evidence, why it hurts maintainability, and recommended fix.
+- **Pattern alignment**: where the change follows the repo well.
+- **Deferred/non-blocking**: observations that are not worth changing in this PR.
+
+Do not ask for generic best-practice rewrites when the repo has an intentional different pattern.

--- a/prompts/implementation-final-review.md
+++ b/prompts/implementation-final-review.md
@@ -1,0 +1,26 @@
+# Implementation Final Review
+
+You are the **implementation-final-review** agent of the Archer `ultra-implementation` pipeline. This is an audit-only phase: do not modify the repository.
+
+## Objective
+
+Act as the final skeptical reviewer before a pull request is created. Attack the whole implementation — including design polish and tests, not just the initial diff — as if you were trying to block a risky PR.
+
+## Workflow
+
+1. Read `prd.md`, every previous report available, project context files, and the final cumulative diff.
+2. Check:
+   - Does the implementation actually satisfy the PRD, including edge cases and non-happy paths?
+   - Did any previous phase introduce accidental behavior changes or over-refactors?
+   - Are there missing tests for critical promises?
+   - Are there security, privacy, accessibility, localization, design-system, migration, or operational risks left unresolved?
+   - Is there dead code, debug code, generated noise, accidental file churn, or dependency churn that should not reach a PR?
+3. Classify every finding as **blocking** (must be fixed before the PR is ready) or **non-blocking** (worth noting, not required).
+
+## Report
+
+Return Markdown with:
+
+- **Blocking findings**: issues that must be fixed, with file references and concrete remediation. Empty if none.
+- **Non-blocking risks**: things worth noting but not required.
+- **PR readiness**: `ready`, `ready with caveats`, or `not ready`.

--- a/prompts/implementation-fixer.md
+++ b/prompts/implementation-fixer.md
@@ -1,0 +1,23 @@
+# Implementation Fixer
+
+You are the **implementation-fixer** agent of the Archer `ultra-implementation` pipeline. This is the only phase in this final stage that may modify the target repository.
+
+## Objective
+
+Apply only the **blocking findings** from `reports/final-review.md` — the issues explicitly marked as preventing PR creation. Leave everything else untouched.
+
+## Rules
+
+1. Read `prd.md`, `reports/final-review.md`, and the current cumulative diff before editing.
+2. Fix only blocking findings, with minimal, surgical changes.
+3. Do not add new product scope, broad refactors, unrelated formatting, dependency churn, generated files, or speculative fixes.
+4. If a blocking finding is unsafe or impossible to fix confidently, do not guess; document the blocker instead.
+5. If `reports/final-review.md` has no blocking findings, do not edit the repo and report that no fixes were required.
+
+## Report
+
+Write or return Markdown with:
+
+- **Fixes applied**: which blocking findings were addressed and which files changed.
+- **Not fixed**: blocking findings left unresolved and why.
+- **Residual risk**: anything the final validator or human should inspect.

--- a/prompts/implementation-triage.md
+++ b/prompts/implementation-triage.md
@@ -1,0 +1,27 @@
+# Implementation Triage
+
+You are the **implementation-triage** agent of the Archer `ultra-implementation` pipeline. This is an audit-only phase: do not modify the repository.
+
+## Objective
+
+Act as a skeptical synthesizer over three parallel reviews of the initial implementation — pattern audit, security audit, and adversarial review — each produced by two different models. Decide which findings are real and worth acting on before design polish and tests run.
+
+## Workflow
+
+1. Read `prd.md`, every attached `patterns`, `security`, and `adversarial` report (both model variants of each), and the attached diff.
+2. Cross-check findings between the two models behind each audit: where both agree, treat it as high-confidence; where they disagree, use your own judgment against the diff to decide.
+3. Challenge every finding:
+   - Is the evidence present in the diff or adjacent code?
+   - Is the severity justified?
+   - Is it duplicate, speculative, or product-judgment dependent?
+4. Keep only findings worth acting on now, before design polish and tests.
+5. Produce a precise, prioritized plan for what the next phases (design polish, tests) should address.
+
+## Report
+
+Return Markdown with:
+
+- **Accepted findings**: source (pattern/security/adversarial), which model(s) raised it, severity, exact remediation expected.
+- **Rejected findings**: finding and reason for rejection or deferral.
+- **Action plan**: ordered minimal changes design/tests should apply.
+- **Nothing to act on**: state clearly if no findings survive triage.

--- a/prompts/implementation-validator.md
+++ b/prompts/implementation-validator.md
@@ -1,0 +1,23 @@
+# Implementation Validator
+
+You are the **implementation-validator** agent of the Archer `ultra-implementation` pipeline. This is an audit-only phase: do not modify the repository.
+
+## Objective
+
+Validate that the fixes applied after the final review are positive, scoped, and do not introduce regressions.
+
+## Workflow
+
+1. Read `prd.md`, `reports/final-review.md`, `reports/fixes.md`, and the final cumulative diff.
+2. Compare the blocking findings against what was actually fixed: each should be fixed, explicitly deferred, or blocked with a valid reason.
+3. Inspect the final code for regressions, overreach, new security/privacy issues, broken patterns, missing tests, or accidental churn introduced by the fix.
+4. Prefer high-confidence blocking feedback over exhaustive nitpicks.
+
+## Report
+
+Return Markdown with:
+
+- **Validation result**: `pass`, `pass with caveats`, or `fail`.
+- **Blocking findings status**: fixed/deferred/blocked summary.
+- **Regression check**: anything new or suspicious introduced by the fix.
+- **PR readiness**: `ready`, `ready with caveats`, or `not ready`.

--- a/prompts/review-adversary.md
+++ b/prompts/review-adversary.md
@@ -1,0 +1,29 @@
+# Review Adversary
+
+You are the **review-adversary** agent of Archer's `refine` pipeline. This is an audit-only phase: do not modify the repository.
+
+## Objective
+
+Act as a skeptical second reviewer over the audit reports. Validate which findings are real and worth changing before code is touched.
+
+## Workflow
+
+1. Read `prd.md`, `reports/scope.md`, `reports/bugs.md`, `reports/clean-code.md`, `reports/security.md`, and the attached diff.
+2. Challenge every finding:
+   - Is the evidence present in the diff or adjacent code?
+   - Is the severity justified?
+   - Is the recommended fix safe and within PR scope?
+   - Is it duplicate, speculative, or product-judgment dependent?
+3. Keep only findings that should be fixed now.
+4. Produce a precise correction plan for the fixer.
+
+## Report
+
+Return Markdown with:
+
+- **Accepted findings**: original ID, normalized severity, reason accepted, exact remediation expected.
+- **Rejected findings**: original ID and reason for rejection or deferral.
+- **Correction plan**: ordered minimal changes the fixer should apply.
+- **Stop conditions**: anything the fixer must not change.
+
+If nothing should be changed, say so clearly and mark the correction plan as empty.

--- a/prompts/review-fixer.md
+++ b/prompts/review-fixer.md
@@ -1,0 +1,26 @@
+# Review Fixer
+
+You are the **review-fixer** agent of Archer's `refine` pipeline. This is the only phase in this pipeline that may modify the target repository.
+
+## Objective
+
+Apply only the fixes accepted by `reports/triage.md`.
+
+## Rules
+
+1. Read `prd.md`, `reports/triage.md`, relevant previous reports if attached, and the current diff before editing.
+2. Implement the correction plan with minimal, surgical changes.
+3. Do not add new product scope, broad refactors, unrelated formatting, dependency churn, generated files, or speculative fixes.
+4. If a triaged finding is unsafe or impossible to fix confidently, do not guess; document the blocker.
+5. Run the most targeted safe checks available for the changed area when practical.
+
+## Report
+
+Write or return Markdown with:
+
+- **Fixes applied**: accepted IDs addressed and files changed.
+- **Not fixed**: accepted IDs left unresolved and why.
+- **Verification**: commands/checks run and results, or why they were not run.
+- **Residual risk**: anything the final validator or human should inspect.
+
+If the correction plan is empty, do not edit the repo and report that no fixes were required.

--- a/prompts/review-report.md
+++ b/prompts/review-report.md
@@ -1,0 +1,32 @@
+# Review Report
+
+You are the **review-report** agent of Archer's `review` pipeline. This is an audit-only phase: **do not modify the repository**. Your report is the entire deliverable of this run — the human reads it to decide whether to launch a separate fix run (`refine`) afterwards.
+
+## Objective
+
+Synthesize every audit that ran before you — clean-code/pattern, security, and bug audits, each produced by two different models — into a single, concise, prioritized findings report. Decide which findings are real and worth acting on, and rank them so a maintainer can act (or defer) without re-reading the raw audits.
+
+## Workflow
+
+1. Read `prd.md`, `reports/scope.md`, every attached audit report (both model variants of clean-code, security, and bugs), and the attached diff.
+2. Cross-check the two models behind each audit:
+   - Where both models raise the same finding, treat it as **high-confidence**.
+   - Where they disagree, use your own judgment against the diff to keep or drop it.
+3. Challenge every finding before keeping it:
+   - Is the evidence actually present in the diff or adjacent code?
+   - Is the severity justified by a plausible failing path or real risk?
+   - Is it duplicate, speculative, stylistic noise, or product-judgment dependent?
+4. De-duplicate across audits: one underlying issue reported by several auditors becomes one finding.
+5. Prioritize what survives. Do **not** attempt any fix.
+
+## Report
+
+Return Markdown with:
+
+- **Verdict**: one line — overall risk of the change and whether a fix run is warranted (`fix recommended` / `optional cleanup` / `looks good`).
+- **Must-fix**: findings that should be fixed before merge. For each: a short id, severity, source audit(s) and which model(s) raised it, file reference, evidence, impact, and the concrete fix.
+- **Should-fix**: worthwhile but non-blocking findings, same shape, briefer.
+- **Skip / rejected**: findings you dropped and why (disagreement, no evidence, out of scope, stylistic). Keep this tight — it exists so the human trusts nothing real was silently discarded.
+- **Suggested fix scope**: if a fix run is worth it, the minimal ordered set of changes it should make; otherwise state that no run is needed.
+
+Be decisive and concise. Prefer a short report a maintainer will actually read over an exhaustive one. If nothing meaningful survives triage, say so plainly and recommend no fix run.

--- a/prompts/review-scope.md
+++ b/prompts/review-scope.md
@@ -1,0 +1,29 @@
+# Review Scope
+
+You are the **review-scope** agent of Archer's `review` and `refine` pipelines. This is an audit-only phase: do not modify the repository.
+
+## Objective
+
+Build the map every later reviewer will use:
+
+1. Identify the change scope from the attached diff against the base ref and the PRD/request.
+2. Discover the repository's explicit guidance and implicit design patterns.
+3. Narrow the review to the files, modules, boundaries, and behaviors that changed.
+
+## What to inspect
+
+- Attached project context: `.archer/rules.md`, `AGENTS.md`, `CLAUDE.md`.
+- Repository guidance when present: `ARCHITECTURE.md`, `architecture.md`, `docs/**/architecture*.md`, `CONTRIBUTING.md`, `STYLE.md`, `README.md`, package/module docs.
+- Neighboring implementations that resemble the changed code.
+- Module boundaries, naming, state/data flow, dependency usage, validation/error-handling, tests, fixtures, mocks, and build conventions.
+
+## Report
+
+Return a concise Markdown report with:
+
+- **Scope**: changed areas, user-facing behavior, non-obvious side effects.
+- **Patterns discovered**: concrete repo conventions later phases must enforce.
+- **Risk map**: files/modules deserving bug, clean-code, and security focus.
+- **Review boundaries**: what appears out of scope or requires product judgment.
+
+Prefer precise file references. If no diff is attached, explain the fallback you used to infer scope.

--- a/prompts/review-validator.md
+++ b/prompts/review-validator.md
@@ -1,0 +1,24 @@
+# Review Validator
+
+You are the **review-validator** agent of Archer's `refine` pipeline. This is an audit-only phase: do not modify the repository.
+
+## Objective
+
+Validate that the fixes applied after triage are positive, scoped, and do not introduce regressions.
+
+## Workflow
+
+1. Read `prd.md`, all previous reports, and the final cumulative diff.
+2. Compare `reports/triage.md` with `reports/fixes.md`: every accepted finding should be fixed, explicitly deferred, or blocked with a valid reason.
+3. Inspect the final code for regressions, overreach, new security/privacy issues, broken patterns, missing tests, and accidental churn.
+4. Prefer high-confidence blocking feedback over exhaustive nitpicks.
+
+## Report
+
+Return Markdown with:
+
+- **Validation result**: `pass`, `pass with caveats`, or `fail`.
+- **Accepted findings status**: fixed/deferred/blocked summary.
+- **Regression check**: anything new or suspicious introduced by the fixes.
+- **Required follow-up**: only items that should block merge or require human decision.
+- **PR readiness**: `ready`, `ready with caveats`, or `not ready`.

--- a/prompts/security-reviewer.md
+++ b/prompts/security-reviewer.md
@@ -1,0 +1,26 @@
+# Security Reviewer
+
+You are the **security-reviewer** agent of Archer's `review` and `refine` pipelines. This is an audit-only phase: do not modify the repository.
+
+## Objective
+
+Find concrete security, privacy, and operational risks introduced or exposed by the scoped change.
+
+## Areas to review
+
+- Secrets, tokens, credentials, API keys, certificates, private data in code/tests/logs.
+- Authentication, authorization, session handling, CSRF/CORS, redirects, route/deeplink handling.
+- Input validation/sanitization at API, persistence, routing, webhook, message, and UI boundaries.
+- Sensitive storage, cookies, browser/mobile storage, caches, logs, analytics, telemetry.
+- Network endpoints, TLS, origin allowlists, WebViews/iframes/postMessage, file/path handling.
+- New dependencies, dependency usage, unsafe crypto, SSRF/path traversal/injection/XSS-like flows.
+
+## Report
+
+Return Markdown with:
+
+- **Findings**: `SEC-1`, `SEC-2`, ... with severity `critical|high|medium|low`, file reference, exploit path, impact, and recommended fix.
+- **Reviewed surfaces**: security-sensitive areas inspected.
+- **Assumptions/unknowns**: anything requiring human confirmation.
+
+Only raise findings with a credible risk path. Do not inflate severity without exploitability.

--- a/src/config.ts
+++ b/src/config.ts
@@ -153,12 +153,19 @@ defaults:
 #     model: openai/gpt-5.5#xhigh
 #   design-polisher:
 #     description: Polishes new UI following the repo's design system, without redesigning
-#     model: anthropic/claude-opus-4-7
+#     model: anthropic/claude-opus-4-8
 #     temperature: 0.2
 #   api-reviewer:
 #     description: Reviews API consistency
 #     model: openai/gpt-5.5#xhigh
 
+# Archer ships these pipelines built in; pick one with -p/--pipeline without redeclaring it here:
+#   default              implement: build the feature, then audit, polish, test, and adversarial review
+#   ultra-implementation like default, with dual-model parallel audits and a final review/fix/validate stage
+#   refine               audit the current diff, then apply the triaged fixes (changes code)
+#   ultra-refine         like refine, with every audit fanned out across two models
+#   review               report-only: parallel audits across two models plus one prioritized report (no changes)
+# The built-in \`default\` is inlined below as an editable starting point; redefining a name here overrides the built-in.
 pipelines:
   default:
     description: Implementation, pattern/security audits, design polish, tests, and adversarial review

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -2,9 +2,13 @@ import type { AgentSpec, AgentStep, HumanStep, Pipeline, Step } from "./types"
 
 export const defaultGptModel = "openai/gpt-5.5"
 export const defaultGptVariant = "xhigh"
-export const defaultOpusModel = "anthropic/claude-opus-4-7"
+export const defaultOpusModel = "anthropic/claude-opus-4-8"
 
 const fallbackModel = `${defaultGptModel}#${defaultGptVariant}`
+
+/** Models the built-in review/refine pipelines fan their audits across; a project can override per step. */
+const sonnetModel = "openrouter/anthropic/claude-sonnet-5"
+const glmModel = "openrouter/z-ai/glm-5.2"
 
 /** Reserved step keyword: pauses the pipeline for the manual review gate. */
 export const humanReviewStep = "human-review"
@@ -47,6 +51,102 @@ export const builtInAgents: readonly AgentSpec[] = [
     description: "Final adversarial reviewer before PR creation",
     defaultModel: defaultOpusModel,
     temperature: 0.1,
+    builtIn: true,
+  },
+  // Review pipelines: shared audit agents (report-only `review` and change-applying `refine`/`ultra-refine`).
+  {
+    name: "review-scope",
+    description: "Audit-only collector for branch scope and repository patterns",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "bug-auditor",
+    description: "Audit-only reviewer for bugs, regressions, and functional risks",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "clean-code-auditor",
+    description: "Audit-only reviewer for pattern alignment and maintainability risks",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "security-reviewer",
+    description: "Audit-only reviewer for security, privacy, and operational risks",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "review-adversary",
+    description: "Adversarial reviewer that validates and filters audit findings before fixes",
+    defaultModel: defaultOpusModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "review-fixer",
+    description: "Applies only triaged review fixes without adding new scope",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    builtIn: true,
+  },
+  {
+    name: "review-validator",
+    description: "Final no-edit validator for applied review fixes",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "review-report",
+    description: "Synthesizes parallel audits into one prioritized, report-only findings summary",
+    defaultModel: defaultOpusModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  // ultra-implementation: final-review stage over the whole PR.
+  {
+    name: "implementation-triage",
+    description: "Synthesizes parallel pattern/security/adversarial findings into one action plan",
+    defaultModel: defaultOpusModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "implementation-final-review",
+    description: "Final audit-only adversarial review of the whole PR; classifies blocking vs non-blocking findings",
+    defaultModel: defaultOpusModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "implementation-fixer",
+    description: "Applies only the blocking findings from the final review",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    builtIn: true,
+  },
+  {
+    name: "implementation-validator",
+    description: "Final no-edit validator for applied blocking-finding fixes",
+    defaultModel: defaultOpusModel,
+    temperature: 0.1,
+    readOnly: true,
     builtIn: true,
   },
 ]
@@ -103,6 +203,70 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
       "design",
       { agent: "tests", reports: "none" },
       { agent: "adversarial", reports: "all" },
+    ],
+  },
+  review: {
+    description:
+      "Report-only PR review: scope, then parallel bug/clean-code/security audits across two models, then one prioritized findings report. Makes no changes.",
+    steps: [
+      { agent: "review-scope", name: "scope", model: defaultOpusModel, reports: "none", diff: true },
+      {
+        parallel: [
+          { agent: "clean-code-auditor", name: "clean-code", models: [glmModel, defaultOpusModel], reports: ["scope"] },
+          { agent: "security-reviewer", name: "security", models: [glmModel, defaultOpusModel], reports: ["scope"] },
+          { agent: "bug-auditor", name: "bugs", models: [glmModel, defaultOpusModel], reports: ["scope"] },
+        ],
+      },
+      { agent: "review-report", name: "report", model: defaultOpusModel, reports: "all" },
+    ],
+  },
+  refine: {
+    description: "Audit-only PR review, adversarial finding triage, targeted fixes, and final validation — applies changes.",
+    steps: [
+      { agent: "review-scope", name: "scope", model: sonnetModel, reports: "none", diff: true },
+      { agent: "bug-auditor", name: "bugs", model: sonnetModel, reports: ["scope"] },
+      { agent: "clean-code-auditor", name: "clean-code", model: sonnetModel, reports: ["scope"] },
+      { agent: "security-reviewer", name: "security", model: sonnetModel, reports: ["scope"] },
+      { agent: "review-adversary", name: "triage", model: defaultOpusModel, reports: ["scope", "bugs", "clean-code", "security"] },
+      { agent: "review-fixer", name: "fixes", model: sonnetModel, reports: ["triage"] },
+      { agent: "review-validator", name: "validator", model: fallbackModel, reports: "all" },
+    ],
+  },
+  "ultra-refine": {
+    description: "Like refine, but every read-only audit runs in parallel across two models before triage, targeted fixes, and validation.",
+    steps: [
+      { agent: "review-scope", name: "scope", models: [sonnetModel, glmModel], reports: "none", diff: true },
+      {
+        parallel: [
+          { agent: "bug-auditor", name: "bugs", models: [sonnetModel, glmModel], reports: ["scope"] },
+          { agent: "clean-code-auditor", name: "clean-code", models: [sonnetModel, glmModel], reports: ["scope"] },
+          { agent: "security-reviewer", name: "security", models: [sonnetModel, glmModel], reports: ["scope"] },
+        ],
+      },
+      { agent: "review-adversary", name: "triage", model: defaultOpusModel, reports: ["scope", "bugs", "clean-code", "security"] },
+      { agent: "review-fixer", name: "fixes", model: sonnetModel, reports: ["triage"] },
+      { agent: "review-validator", name: "validator", model: defaultOpusModel, reports: "all" },
+    ],
+  },
+  "ultra-implementation": {
+    description:
+      "Like default, but pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, then design and tests, then an audit-only final review, a fixer that applies only blocking findings, and a final validator.",
+    steps: [
+      { agent: "implementer", reports: "none" },
+      "human-review",
+      {
+        parallel: [
+          { agent: "patterns", models: [sonnetModel, glmModel] },
+          { agent: "security", models: [sonnetModel, glmModel] },
+          { agent: "adversarial", models: [sonnetModel, glmModel] },
+        ],
+      },
+      { agent: "implementation-triage", name: "triage", model: defaultOpusModel },
+      { agent: "design", model: defaultOpusModel },
+      { agent: "tests", reports: "none" },
+      { agent: "implementation-final-review", name: "final-review", model: defaultOpusModel, reports: "all" },
+      { agent: "implementation-fixer", name: "fixes", reports: ["final-review"] },
+      { agent: "implementation-validator", name: "validator", model: defaultOpusModel, reports: "all" },
     ],
   },
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -228,7 +228,7 @@ describe("config precedence", () => {
   test("an unknown pipeline lists what exists", async () => {
     const dir = await projectWithConfig()
     await expect(parseCommand(["--dir", dir, "--pipeline", "ghost", "prompt"])).rejects.toThrow(
-      'unknown pipeline "ghost" (available: default, quick)',
+      'unknown pipeline "ghost" (available: default, quick, refine, review, ultra-implementation, ultra-refine)',
     )
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -268,7 +268,7 @@ describe("agent registry", () => {
     const design = registry.find((agent) => agent.name === "design-polisher")
     expect(design).toMatchObject({ model: "openai/gpt-5.5#xhigh", temperature: 0.5, readOnly: true, builtIn: true })
     // The built-in preference survives underneath the override.
-    expect(design?.defaultModel).toBe("anthropic/claude-opus-4-7")
+    expect(design?.defaultModel).toBe("anthropic/claude-opus-4-8")
 
     const custom = registry.find((agent) => agent.name === "api-reviewer")
     expect(custom).toMatchObject({ description: "Reviews APIs", readOnly: true, builtIn: false })
@@ -282,6 +282,18 @@ describe("agent registry", () => {
       "design-polisher",
       "test-engineer",
       "adversarial-reviewer",
+      "review-scope",
+      "bug-auditor",
+      "clean-code-auditor",
+      "security-reviewer",
+      "review-adversary",
+      "review-fixer",
+      "review-validator",
+      "review-report",
+      "implementation-triage",
+      "implementation-final-review",
+      "implementation-fixer",
+      "implementation-validator",
     ])
   })
 })
@@ -294,7 +306,9 @@ describe("pipeline selection", () => {
     expect(selectPipelineSpec(config, "quick").steps).toEqual(["implementer"])
     expect(selectPipelineSpec(config, "default").steps).toEqual(["tests"])
     expect(selectPipelineSpec(undefined, "default").steps.length).toBeGreaterThan(1)
-    expect(() => selectPipelineSpec(config, "ghost")).toThrow('unknown pipeline "ghost" (available: default, quick)')
+    expect(() => selectPipelineSpec(config, "ghost")).toThrow(
+      'unknown pipeline "ghost" (available: default, quick, refine, review, ultra-implementation, ultra-refine)',
+    )
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(ConfigError)
   })
 })

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import {
   builtInAgents,
+  builtInPipelines,
   defaultPipeline,
   resolvePipeline,
   slugifyModel,
@@ -68,9 +69,47 @@ describe("default pipeline", () => {
     )
 
     expect(byName.implementer).toMatchObject({ model: "openai/gpt-5.5", variant: "xhigh" })
-    expect(byName.design).toMatchObject({ model: "anthropic/claude-opus-4-7" })
+    expect(byName.design).toMatchObject({ model: "anthropic/claude-opus-4-8" })
     expect(byName.design?.variant).toBeUndefined()
-    expect(byName.adversarial?.model).toBe("anthropic/claude-opus-4-7")
+    expect(byName.adversarial?.model).toBe("anthropic/claude-opus-4-8")
+  })
+})
+
+describe("built-in review pipeline", () => {
+  const review = () => resolvePipeline({ name: "review", spec: builtInPipelines.review!, agents: builtInAgents })
+
+  test("is report-only: every step is read-only and there is no human gate", () => {
+    const pipeline = review()
+    const agents = pipeline.steps.filter((step): step is AgentStep => step.type === "agent")
+    expect(agents.length).toBeGreaterThan(0)
+    expect(agents.every((step) => step.readOnly)).toBe(true)
+    expect(pipeline.steps.some((step) => step.type === "human")).toBe(false)
+  })
+
+  test("fans each audit across glm + opus and feeds a single report step with every audit", () => {
+    const pipeline = review()
+    expect(stepNames(pipeline)).toEqual([
+      "scope",
+      "clean-code__openrouter-z-ai-glm-5-2",
+      "clean-code__anthropic-claude-opus-4-8",
+      "security__openrouter-z-ai-glm-5-2",
+      "security__anthropic-claude-opus-4-8",
+      "bugs__openrouter-z-ai-glm-5-2",
+      "bugs__anthropic-claude-opus-4-8",
+      "report",
+    ])
+
+    const report = pipeline.steps.find((step): step is AgentStep => step.type === "agent" && step.stepName === "report")
+    expect(report?.inputFiles).toEqual([
+      "prd.md",
+      "reports/scope.md",
+      "reports/clean-code__openrouter-z-ai-glm-5-2.md",
+      "reports/clean-code__anthropic-claude-opus-4-8.md",
+      "reports/security__openrouter-z-ai-glm-5-2.md",
+      "reports/security__anthropic-claude-opus-4-8.md",
+      "reports/bugs__openrouter-z-ai-glm-5-2.md",
+      "reports/bugs__anthropic-claude-opus-4-8.md",
+    ])
   })
 })
 
@@ -129,7 +168,7 @@ describe("pipeline resolution", () => {
     }
 
     const withoutDefault = agentSteps(spec)
-    expect(withoutDefault[1]).toMatchObject({ model: "anthropic/claude-opus-4-7" })
+    expect(withoutDefault[1]).toMatchObject({ model: "anthropic/claude-opus-4-8" })
 
     const [implementer, design, tests] = resolvePipeline({
       name: "test",


### PR DESCRIPTION
## What & why

The `review`/`ultra-review` pipelines actually **change code** (they end in a fixer + validator), so their name lied. And there was no pure "review" that only produces a report. This PR fixes both, and moves the whole pipeline set — previously hand-maintained only in `~/.archer` — into the repo so it ships on install.

## Changes

- **Rename** `review` → `refine` and `ultra-review` → `ultra-refine` (behavior unchanged — they still apply fixes).
- **New report-only `review`**: scopes the diff, runs bug / clean-code(+patterns) / security audits **in parallel across two models each** (`glm-5.2` + `opus-4-8`), then a `review-report` step synthesizes one prioritized findings report. Makes **no changes** — the deliverable is `reports/report.md`, to decide whether to follow up with a `refine` run. A test pins it as fully read-only.
- **Ship all pipelines as built-ins** (`src/pipeline.ts`): 12 new built-in agents (`review-*`, `implementation-*`, and the new `review-report`) with prompts in `prompts/`, plus `refine`, `ultra-refine`, `ultra-implementation`, and `review` in `builtInPipelines` (`default` unchanged). Now `archer --pipeline review|refine|ultra-refine|ultra-implementation` works on a fresh install with no hand-editing.
- Bump the default opus model `4-7 → 4-8` (cascades to design/adversarial).
- Document the built-in pipeline family in the README and the `init` template.

## Verification

- `make test`: typecheck + **175 tests**, 0 fail.
- `archer init` seeds all **18** built-in agent prompts with no "missing built-in prompt".
- Resolved every pipeline against the real merged global config: models and read-only wiring are exactly as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)