### PR TITLE
feat(pipeline): rename default pipeline to `implement`; drop human-review from defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Archer is a higher-level orchestration harness for [OpenCode](https://opencode.a
 
 Rather than being only a sequential agent chain, Archer owns the operational layer around OpenCode: repo context attachment, runtime guard rails, permission gates, phase reports, diff tracking, and human-in-the-loop checkpoints.
 
-Pipelines are data, not code: archer ships a family of built-in pipelines (`default`, `ultra-implementation`, `refine`, `ultra-refine`, and a report-only `review` — see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with `human-review` gates anywhere — in `.archer/config.yaml`.
+Pipelines are data, not code: archer ships a family of built-in pipelines (`implement` — the default — plus `ultra-implement`, `refine`, `ultra-refine`, and a report-only `review`; see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with `human-review` gates anywhere — in `.archer/config.yaml`.
 
 Archer is written in Bun + TypeScript and uses `@opencode-ai/sdk` to control OpenCode. The SDK starts/controls the OpenCode server; Archer no longer manually calls `opencode run` nor parses stdout.
 
-## The default pipeline
+## The default pipeline: `implement`
+
+`implement` is the pipeline archer runs when you don't pass `-p/--pipeline`.
 
 ```
 PRD ──► implementer ──► patterns ──► security ──► design ──► tests ──► adversarial
@@ -32,8 +34,8 @@ Archer ships these pipelines; select one with `-p/--pipeline` (no config needed)
 
 | Pipeline | Changes code? | What it does |
 |---|---|---|
-| `default` | yes | Implement a PRD, then audit, polish, test, and adversarial review (the table above). |
-| `ultra-implementation` | yes | Like `default`, but the pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, and the run ends with an audit-only final review, a fixer that applies only blocking findings, and a final validator. |
+| `implement` | yes | **The default** (runs with no `-p`). Implement a PRD, then audit, polish, test, and adversarial review (the table above). |
+| `ultra-implement` | yes | Like `implement`, but the pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, and the run ends with an audit-only final review, a fixer that applies only blocking findings, and a final validator. |
 | `refine` | yes | Audit the current diff (scope → bugs → clean-code → security), triage the findings adversarially, apply the accepted fixes, then validate them. |
 | `ultra-refine` | yes | Like `refine`, but every read-only audit is fanned out across two models before triage, fixes, and validation. |
 | `review` | **no — report only** | Scope the diff, run the bug / clean-code(+patterns) / security audits **in parallel across two models each**, then a single step synthesizes everything into one prioritized findings report. Makes no changes; the run's output is `reports/report.md`, which you read to decide whether to follow up with a `refine` run. |
@@ -278,7 +280,7 @@ The rules:
 - **Aliases**: the built-in agents answer to their short names in steps — `patterns`, `security`, `design`, `tests`, `adversarial` — as well as their full names.
 - **Read-only agents**: set `agents.<name>.readOnly: true` to enforce audit-only behavior. Archer disables the agent's write/edit/bash tools, denies edit/bash/task permissions, and saves the phase report from the assistant response if the agent cannot write it directly.
 - **Parallel steps and model fan-out**: wrap steps in `parallel: [...]` to run them concurrently, and/or give one step a `models: [...]` list (instead of `model:`) to run it once per model. Both are always forced read-only, regardless of the underlying agent's own `readOnly` setting, so concurrent runs can never step on each other's changes to the tree — there's no per-step way to opt out. A `models:` step's variants get disambiguated names (`<step>__<model-slug>`) and reports; `reports: previous` after a parallel block attaches every member's report, and `reports: [<step-name>]` on a fanned-out step's un-suffixed name attaches every one of its model variants. `parallel:` can't nest and can't contain `human-review`.
-- **Project pipelines shadow built-ins**: defining `pipelines.default` replaces the built-in default.
+- **Project pipelines shadow built-ins**: defining `pipelines.implement` replaces the built-in default pipeline.
 - **`--no-human-review`** (and non-TTY runs) drop every `human-review` gate from the pipeline.
 - **Resume is frozen**: the resolved pipeline is persisted in the run's `metadata.json`; `--resume` replays it even if the config changed since.
 - **Dirty-tree recovery**: a phase interrupted before its commit (Ctrl+C, a failed commit step, a killed process) leaves uncommitted work in the tree, which normally blocks `--resume`. In an interactive terminal, resume offers to commit that work as the interrupted phase (`archer(<phase>): …`), mark it done, and continue with the following phases. Decline (or a non-TTY resume) keeps the old "commit/stash first" behavior.
@@ -297,7 +299,7 @@ Both files are merged before a run, with the project winning: `defaults`, `agent
 - Pick models from an autocompleting list: it queries OpenCode for the models your enabled providers expose (including reasoning variants like `#xhigh`), falling back to the full [models.dev](https://models.dev) catalog when OpenCode can't answer, and always accepts a free-typed `provider/model[#variant]`.
 - Edit `defaults` (model, interactiveModel, autoAcceptJudgeModel, maxAttempts, baseRef, pipeline, app command, emulator) and each agent's model/temperature override. Agent `readOnly` is displayed when set; edit it in YAML.
 - Browse pipelines and their steps; add, delete, reorder steps, set a per-step model or max-attempts, and add new pipelines. Permissions and attachments are shown read-only (edit those in the YAML).
-- When a tab has no file yet, `initialize` writes a starter config (the built-in `default` pipeline, expanded and ready to edit).
+- When a tab has no file yet, `initialize` writes a starter config (the built-in `implement` pipeline, expanded and ready to edit).
 
 Keys: `↑/↓` move, `enter` edit/expand, `tab` switch tab, `a` add, `d` delete a step, `shift+↑/↓` reorder a step, `t` agent temperature, `m` step max-attempts, `s` save the active tab, `q` quit. Saving re-validates and rewrites clean YAML (comments are not preserved); the dashboard never paints backgrounds, like the run TUIs. Needs an interactive terminal.
 
@@ -312,7 +314,7 @@ archer init --global       # ~/.archer/config.yaml + ~/.archer/agents/*.md
 archer init --force        # overwrite existing files
 ```
 
-The generated config documents every key (commented out) and inlines the built-in `default` pipeline so it's immediately editable. The copied `agents/*.md` prompts are picked up by name — edit them to override a built-in agent's prompt, or declare a new agent in the config and add its prompt file. Existing files are never overwritten unless `--force` is given. `make install` runs `archer init --global` automatically, so a fresh install ships with a ready-to-edit global config.
+The generated config documents every key (commented out) and inlines the built-in `implement` pipeline so it's immediately editable. The copied `agents/*.md` prompts are picked up by name — edit them to override a built-in agent's prompt, or declare a new agent in the config and add its prompt file. Existing files are never overwritten unless `--force` is given. `make install` runs `archer init --global` automatically, so a fresh install ships with a ready-to-edit global config.
 
 ## Project Context And Custom Agents
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises"
 import { resolve } from "node:path"
 
 import { buildAgentRegistry, loadMergedArcherConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ArcherDefaults } from "./config"
-import { defaultGptModel, defaultGptVariant, defaultPipeline, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
+import { defaultGptModel, defaultGptVariant, defaultPipeline, defaultPipelineName, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
 import { parseModel, run } from "./runner"
 import { browseRuns } from "./runs"
 import type { Pipeline, RunOptions } from "./types"
@@ -212,7 +212,7 @@ export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOpt
   const humanReview = parsed.humanReview ?? Boolean(process.stdin.isTTY && process.stdout.isTTY)
 
   const agents = buildAgentRegistry(config)
-  const pipelineName = parsed.pipeline ?? defaults.pipeline ?? "default"
+  const pipelineName = parsed.pipeline ?? defaults.pipeline ?? defaultPipelineName
   let pipeline: Pipeline
   try {
     pipeline = resolvePipeline({ name: pipelineName, spec: selectPipelineSpec(config, pipelineName), agents, defaultModel: defaults.model })
@@ -435,7 +435,7 @@ Commands:
 Flags:
   --prompt-file <path>     Read the PRD/prompt from a file
   --file, -f <path>        Attach a file or directory to all steps (repeatable)
-  --pipeline, -p <name>    Pipeline to run; built-in "default" runs
+  --pipeline, -p <name>    Pipeline to run (default: "implement"), which runs
                            implementer,patterns,security,design,tests,adversarial
   --only <steps>           Run only these pipeline steps
   --skip <steps>           Skip these pipeline steps

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -754,7 +754,7 @@ export class ConfigEditor {
     rows.push(blankRow(), sectionRow("Pipelines"))
     const pipelineNames = Object.keys(config.pipelines)
     if (pipelineNames.length === 0) {
-      rows.push(infoRow("none defined here — built-in 'default' is used"))
+      rows.push(infoRow("none defined here — built-in 'implement' is used"))
     }
     for (const name of pipelineNames) {
       const open = this.expanded.has(this.expandKey(name))

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import {
   builtInPipelines,
   defaultGptModel,
   defaultGptVariant,
+  defaultPipelineName,
   humanReviewStep,
   readOnlyAgentSuffix,
   splitModelVariant,
@@ -124,7 +125,7 @@ export async function loadMergedArcherConfig(targetDir: string): Promise<ArcherC
 
 /**
  * The commented YAML template written by `archer init`. It documents every key
- * (commented out) and inlines the built-in `default` pipeline so it's an
+ * (commented out) and inlines the built-in `implement` pipeline so it's an
  * immediately editable starting point. Unlike `defaultConfigTemplate` (used by
  * the TUI's initialize action), this is a human-readable string with comments.
  */
@@ -138,7 +139,7 @@ defaults:
   # model: openai/gpt-5.5#xhigh # optional: uncomment to force every agent unless a step/agent overrides it
   # maxAttempts: 2
   # baseRef: main
-  # pipeline: default
+  # pipeline: implement
   # interactiveModel: openai/gpt-5.5#xhigh
   # appRunCommand: pnpm dev # optional: unset by default; used during human-review
   # emulator: Pixel_8 # optional: unset by default; used during human-review
@@ -160,14 +161,14 @@ defaults:
 #     model: openai/gpt-5.5#xhigh
 
 # Archer ships these pipelines built in; pick one with -p/--pipeline without redeclaring it here:
-#   default              implement: build the feature, then audit, polish, test, and adversarial review
-#   ultra-implementation like default, with dual-model parallel audits and a final review/fix/validate stage
+#   implement            the default: build the feature, then audit, polish, test, and adversarial review
+#   ultra-implement      like implement, with dual-model parallel audits and a final review/fix/validate stage
 #   refine               audit the current diff, then apply the triaged fixes (changes code)
 #   ultra-refine         like refine, with every audit fanned out across two models
 #   review               report-only: parallel audits across two models plus one prioritized report (no changes)
-# The built-in \`default\` is inlined below as an editable starting point; redefining a name here overrides the built-in.
+# The default \`implement\` pipeline is inlined below as an editable starting point; redefining a name here overrides the built-in.
 pipelines:
-  default:
+  implement:
     description: Implementation, pattern/security audits, design polish, tests, and adversarial review
     steps:
       - agent: implementer
@@ -438,7 +439,7 @@ export function buildAgentRegistry(config?: ArcherConfig): AgentSpec[] {
   return registry
 }
 
-/** Project pipelines shadow built-ins of the same name (including "default"). */
+/** Project pipelines shadow built-ins of the same name (including "implement", the default). */
 export function selectPipelineSpec(config: ArcherConfig | undefined, name: string): PipelineSpec {
   const spec = config?.pipelines[name] ?? builtInPipelines[name]
   if (spec) return spec
@@ -483,7 +484,7 @@ export async function writeArcherConfig(path: string, config: ArcherConfig, targ
 
 /**
  * Boilerplate written by the config TUI's "initialize" action: the current
- * effective defaults plus the built-in `default` pipeline expanded so it stays
+ * effective defaults plus the built-in `implement` pipeline expanded so it stays
  * editable. Agent model preferences that differ from defaults.model are inlined
  * on their steps, because defaults.model would otherwise shadow them.
  */
@@ -492,7 +493,7 @@ export function defaultConfigTemplate(): ArcherConfig {
   return {
     defaults: { model: globalModel, maxAttempts: 2 },
     agents: {},
-    pipelines: { default: templatePipeline(builtInPipelines.default!, globalModel) },
+    pipelines: { implement: templatePipeline(builtInPipelines[defaultPipelineName]!, globalModel) },
     permissions: { allow: [], deny: [] },
     attachments: [],
   }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -117,7 +117,7 @@ export const builtInAgents: readonly AgentSpec[] = [
     readOnly: true,
     builtIn: true,
   },
-  // ultra-implementation: final-review stage over the whole PR.
+  // ultra-implement: final-review stage over the whole PR.
   {
     name: "implementation-triage",
     description: "Synthesizes parallel pattern/security/adversarial findings into one action plan",
@@ -193,8 +193,11 @@ export type PipelineSpec = {
 /** Suffix reserved for archer's synthesized forced-read-only agent variants; project agents can't use it. */
 export const readOnlyAgentSuffix = "__ro"
 
+/** The pipeline run when none is selected (no -p flag and no defaults.pipeline). */
+export const defaultPipelineName = "implement"
+
 export const builtInPipelines: Record<string, PipelineSpec> = {
-  default: {
+  implement: {
     description: "Implementation, pattern/security audits, design polish, tests, and adversarial review",
     steps: [
       { agent: "implementer", reports: "none" },
@@ -248,12 +251,11 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
       { agent: "review-validator", name: "validator", model: defaultOpusModel, reports: "all" },
     ],
   },
-  "ultra-implementation": {
+  "ultra-implement": {
     description:
-      "Like default, but pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, then design and tests, then an audit-only final review, a fixer that applies only blocking findings, and a final validator.",
+      "Like implement, but pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, then design and tests, then an audit-only final review, a fixer that applies only blocking findings, and a final validator.",
     steps: [
       { agent: "implementer", reports: "none" },
-      "human-review",
       {
         parallel: [
           { agent: "patterns", models: [sonnetModel, glmModel] },
@@ -519,5 +521,5 @@ export function validateStepFilters(pipeline: Pipeline, filters: { onlySteps: st
 }
 
 export function defaultPipeline(): Pipeline {
-  return resolvePipeline({ name: "default", spec: builtInPipelines.default!, agents: builtInAgents })
+  return resolvePipeline({ name: defaultPipelineName, spec: builtInPipelines[defaultPipelineName]!, agents: builtInAgents })
 }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -212,7 +212,7 @@ describe("config precedence", () => {
       "--base",
       "main",
       "--pipeline",
-      "default",
+      "implement",
       "--no-app-run",
       "prompt",
     ])
@@ -222,13 +222,13 @@ describe("config precedence", () => {
     expect(command.options.maxAttempts).toBe(1)
     expect(command.options.baseRef).toBe("main")
     expect(command.options.appRunCommand).toBe("")
-    expect(command.options.pipeline.name).toBe("default")
+    expect(command.options.pipeline.name).toBe("implement")
   })
 
   test("an unknown pipeline lists what exists", async () => {
     const dir = await projectWithConfig()
     await expect(parseCommand(["--dir", dir, "--pipeline", "ghost", "prompt"])).rejects.toThrow(
-      'unknown pipeline "ghost" (available: default, quick, refine, review, ultra-implementation, ultra-refine)',
+      'unknown pipeline "ghost" (available: implement, quick, refine, review, ultra-implement, ultra-refine)',
     )
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -301,13 +301,13 @@ describe("agent registry", () => {
 describe("pipeline selection", () => {
   test("project pipelines shadow built-ins; unknown names list what exists", async () => {
     const dir = await projectDir()
-    const config = parse("pipelines:\n  quick:\n    steps:\n      - implementer\n  default:\n    steps:\n      - tests", dir)
+    const config = parse("pipelines:\n  quick:\n    steps:\n      - implementer\n  implement:\n    steps:\n      - tests", dir)
 
     expect(selectPipelineSpec(config, "quick").steps).toEqual(["implementer"])
-    expect(selectPipelineSpec(config, "default").steps).toEqual(["tests"])
-    expect(selectPipelineSpec(undefined, "default").steps.length).toBeGreaterThan(1)
+    expect(selectPipelineSpec(config, "implement").steps).toEqual(["tests"])
+    expect(selectPipelineSpec(undefined, "implement").steps.length).toBeGreaterThan(1)
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(
-      'unknown pipeline "ghost" (available: default, quick, refine, review, ultra-implementation, ultra-refine)',
+      'unknown pipeline "ghost" (available: implement, quick, refine, review, ultra-implement, ultra-refine)',
     )
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(ConfigError)
   })
@@ -372,7 +372,7 @@ describe("serialization", () => {
   test("defaultConfigTemplate inlines opus on design and round-trips", () => {
     const template = defaultConfigTemplate()
     expect(template.defaults.model).toBe(`${defaultGptModel}#${defaultGptVariant}`)
-    const steps = template.pipelines.default!.steps
+    const steps = template.pipelines.implement!.steps
     expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && step.agent === "design")).toEqual({ agent: "design", model: defaultOpusModel })
     const reparsed = parse(serializeArcherConfig(template))
     expect(reparsed.defaults).toEqual(template.defaults)
@@ -431,7 +431,7 @@ describe("default config init", () => {
 
     expect(body).toContain("# maxAttempts: 2")
     expect(body).toContain("# baseRef: main")
-    expect(body).toContain("# pipeline: default")
+    expect(body).toContain("# pipeline: implement")
     expect(body).toContain("# interactiveModel: openai/gpt-5.5#xhigh")
     expect(body).toContain("# appRunCommand: pnpm dev")
     expect(body).toContain("# agents:")
@@ -443,7 +443,7 @@ describe("default config init", () => {
     for (const agent of builtInAgents) {
       expect(await readFile(join(dir, "agents", `${agent.name}.md`), "utf8")).toContain("#")
     }
-    expect(config.pipelines.default?.steps).toEqual([
+    expect(config.pipelines.implement?.steps).toEqual([
       { agent: "implementer", reports: "none" },
       "patterns",
       "security",

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -89,6 +89,6 @@ describe("run metadata", () => {
     expect(v1?.pipeline).toBeUndefined()
 
     const adopted = await openRunMetadata(ws, "/repo", defaultPipeline())
-    expect(adopted.pipeline.name).toBe("default")
+    expect(adopted.pipeline.name).toBe("implement")
   })
 })


### PR DESCRIPTION
## What & why

Follow-up to the built-in pipelines work:

- **Rename the default pipeline** `default` → `implement`, and `ultra-implementation` → `ultra-implement`. `implement` is still what runs when you don't pass `-p/--pipeline` (via a new `defaultPipelineName` constant). Internal `implementation-*` agent names are left unchanged.
- **Drop the `human-review` gate from every default**: the built-in `ultra-implement` no longer starts with one, and the personal `~/.archer` default drops it too. The `human-review` step keyword stays fully available for custom pipelines (documented inline in the config).

Touches `pipeline.ts` (keys + `defaultPipelineName`), `cli.ts`/`config.ts`/`config-tui.ts` (selection fallback, init template, TUI), the README, and tests.

## Verification
- `make test`: typecheck + **175 tests**, 0 fail.
- Resolved against the real merged config: no `-p` → `implement`; no pipeline has a human gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)