### PR TITLE
Improve interactive launcher flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ The judge model is `--smart-model <provider/model[#variant]>`, falling back to `
 
 Before each commit Archer scans the staged files for common secret names (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `credentials*`, `*.p12`, `*.keystore`, ...). If any match, the commit is aborted, the index reset, and Archer asks you to add them to `.gitignore` (or delete them) before re-running. Combined with `--include-dirty` this is the only line of defense against accidentally publishing a secret your working tree had lying around — review the resulting commits with `git show` before pushing.
 
-During `human-review`, Archer waits 10 seconds for an explicit action. If nobody answers, it prepares the configured app command in the target worktree. By default the app command is disabled; pass `--app-run-command "pnpm dev"`, `--app-run-command "flutter run"`, or the repo's equivalent. Archer only launches a Flutter emulator when `--emulator <id>` is explicitly provided.
+During `human-review`, Archer waits indefinitely for an explicit action. Use the start/rerun app actions to prepare the configured app command in the target worktree. By default the app command is disabled; pass `--app-run-command "pnpm dev"`, `--app-run-command "flutter run"`, or the repo's equivalent. Archer only launches a Flutter emulator when `--emulator <id>` is explicitly provided.
 
 ## Project configuration (`.archer/config.yaml`)
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -19,6 +19,8 @@ export type RepoSnapshot = {
   head: string
 }
 
+export type RepoBootstrapStatus = "ready" | "no-repo" | "no-commits"
+
 async function execFile(command: string, args: string[], options: ExecOptions): Promise<ExecResult> {
   const proc = Bun.spawn([command, ...args], {
     cwd: options.cwd,
@@ -41,17 +43,7 @@ async function execFile(command: string, args: string[], options: ExecOptions): 
 }
 
 export async function ensureRepoReady(cwd: string, options: { includeDirty?: boolean; maxAttempts?: number; baseRef?: string; allowDirty?: boolean } = {}) {
-  const rootResult = await execFile("git", ["rev-parse", "--show-toplevel"], { cwd, allowFailure: true })
-  if (rootResult.exitCode !== 0) {
-    throw new Error("archer must be run at the root of a git repo")
-  }
-
-  // git reports the physical path; resolve symlinks on our side too so a
-  // symlinked --dir (e.g. /tmp on macOS) doesn't false-positive.
-  const root = await realpathSafe(rootResult.stdout.trim())
-  if (root !== (await realpathSafe(cwd))) {
-    throw new Error(`archer must be run at the root of the git repo (${root})`)
-  }
+  await requireRepoRoot(cwd)
 
   if (options.baseRef) {
     const base = await execFile("git", ["rev-parse", "--verify", "--quiet", `${options.baseRef}^{commit}`], { cwd, allowFailure: true })
@@ -73,6 +65,48 @@ export async function ensureRepoReady(cwd: string, options: { includeDirty?: boo
     }
     log.warn("working tree is not clean; --include-dirty will include those changes in the first commit of the pipeline")
   }
+}
+
+export async function repoBootstrapStatus(cwd: string): Promise<RepoBootstrapStatus> {
+  const rootResult = await execFile("git", ["rev-parse", "--show-toplevel"], { cwd, allowFailure: true })
+  if (rootResult.exitCode !== 0) return "no-repo"
+
+  await assertRepoRoot(cwd, rootResult.stdout.trim())
+  const head = await execFile("git", ["rev-parse", "--verify", "--quiet", "HEAD^{commit}"], { cwd, allowFailure: true })
+  return head.exitCode === 0 ? "ready" : "no-commits"
+}
+
+export async function initializeRepoWithInitialCommit(cwd: string, options: { baseRef?: string } = {}) {
+  const status = await repoBootstrapStatus(cwd)
+  if (status === "no-repo") {
+    const args = ["init", "-q"]
+    if (options.baseRef && isSafeInitialBranch(options.baseRef)) args.push("-b", options.baseRef)
+    await execFile("git", args, { cwd })
+  } else if (status === "ready") {
+    return
+  }
+
+  const currentStatus = await repoBootstrapStatus(cwd)
+  if (currentStatus === "ready") return
+  if (currentStatus === "no-repo") throw new Error("couldn't initialize git repository")
+
+  if (options.baseRef && isSafeInitialBranch(options.baseRef)) {
+    await execFile("git", ["symbolic-ref", "HEAD", `refs/heads/${options.baseRef}`], { cwd })
+  }
+
+  await execFile("git", ["add", "-A"], { cwd })
+  const porcelain = await execFile("git", ["status", "--porcelain"], { cwd })
+  const suspicious = findSuspiciousStagedFiles(porcelain.stdout)
+  if (suspicious.length > 0) {
+    await execFile("git", ["reset"], { cwd })
+    throw new Error(
+      `refusing to create initial commit with files that look like secrets: ${suspicious.join(", ")}. ` +
+        `Add them to .gitignore (or remove them) and re-run.`,
+    )
+  }
+
+  const commitArgs = porcelain.stdout.trim() === "" ? ["commit", "--allow-empty", "-m", "archer: initial commit"] : ["commit", "-m", "archer: initial commit"]
+  await execFile("git", commitArgs, { cwd, env: archerGitEnv })
 }
 
 export async function statusPorcelain(cwd: string): Promise<string> {
@@ -152,14 +186,16 @@ export async function addAllAndCommit(message: string, cwd: string) {
 
   await execFile("git", ["commit", "-m", message], {
     cwd,
-    env: {
-      GIT_AUTHOR_NAME: "archer",
-      GIT_AUTHOR_EMAIL: "archer@local",
-      GIT_COMMITTER_NAME: "archer",
-      GIT_COMMITTER_EMAIL: "archer@local",
-    },
+    env: archerGitEnv,
   })
   return true
+}
+
+const archerGitEnv = {
+  GIT_AUTHOR_NAME: "archer",
+  GIT_AUTHOR_EMAIL: "archer@local",
+  GIT_COMMITTER_NAME: "archer",
+  GIT_COMMITTER_EMAIL: "archer@local",
 }
 
 const secretPatterns: RegExp[] = [
@@ -212,4 +248,25 @@ async function realpathSafe(path: string) {
   } catch {
     return resolve(path)
   }
+}
+
+async function requireRepoRoot(cwd: string) {
+  const rootResult = await execFile("git", ["rev-parse", "--show-toplevel"], { cwd, allowFailure: true })
+  if (rootResult.exitCode !== 0) {
+    throw new Error("archer must be run at the root of a git repo")
+  }
+  await assertRepoRoot(cwd, rootResult.stdout.trim())
+}
+
+async function assertRepoRoot(cwd: string, rootPath: string) {
+  // git reports the physical path; resolve symlinks on our side too so a
+  // symlinked --dir (e.g. /tmp on macOS) doesn't false-positive.
+  const root = await realpathSafe(rootPath)
+  if (root !== (await realpathSafe(cwd))) {
+    throw new Error(`archer must be run at the root of the git repo (${root})`)
+  }
+}
+
+function isSafeInitialBranch(value: string) {
+  return value !== "HEAD" && !value.startsWith("-") && !/[~^:?*[\\\s]/.test(value) && !value.includes("..")
 }

--- a/src/human.ts
+++ b/src/human.ts
@@ -6,13 +6,13 @@ import { createInterface } from "node:readline/promises"
 
 import { addAllAndCommit } from "./git"
 import { log } from "./log"
-import { noopProgress, type ProgressUI } from "./progress"
+import { openInteractiveOpencodeWindow } from "./opencode"
+import { noopProgress, type HumanReviewAction, type ProgressUI } from "./progress"
 import type { PermissionGate } from "./permissions"
 import type { RunOptions } from "./types"
 import type { Workspace } from "./workspace"
 
 type AppProcess = ChildProcess
-type HumanAction = "continue" | "iterate" | "rerun" | "abort" | "prepare"
 
 export async function runHumanReviewGate(
   workspace: Workspace,
@@ -30,7 +30,8 @@ export async function runHumanReviewGate(
     return
   }
 
-  if (!stdin.isTTY || !stdout.isTTY) {
+  const askInTui = progress.askHumanReview?.bind(progress)
+  if (!askInTui && (!stdin.isTTY || !stdout.isTTY)) {
     progress.phaseSkipped(stepName)
     log.warn(`[${stepName}] skipped because stdin/stdout are not interactive`)
     return
@@ -46,15 +47,19 @@ export async function runHumanReviewGate(
 
   let iterations = 0
   let app: AppProcess | undefined
+  const inheritOutput = !askInTui
+  const askAction = async (initial = false) =>
+    askInTui
+      ? askInTui(humanReviewInfo(stepName, options, iterations, app))
+      : askHumanAction(initial ? { timeoutMs: 10_000, timeoutAction: "prepare" } : undefined)
 
-  // The whole gate runs with the TUI suspended: the readline prompts, the app
-  // command's inherited stdout, and the interactive OpenCode TUI all need the
-  // terminal to themselves.
-  progress.suspend()
+  // Plain readline fallback still owns the terminal. The TUI path keeps the
+  // dashboard active and resolves actions via ProgressUI.askHumanReview.
+  if (!askInTui) progress.suspend()
   try {
     log.section(`${stepName} - manual review checkpoint`)
-    log.info("choose an action now, or Archer will prepare the configured app command after 10 seconds")
-    let action = await askHumanAction({ timeoutMs: 10_000, timeoutAction: "prepare" })
+    if (!askInTui) log.info("choose an action now, or Archer will prepare the configured app command after 10 seconds")
+    let action = await askAction(true)
 
     for (;;) {
       if (action === "continue") {
@@ -66,26 +71,30 @@ export async function runHumanReviewGate(
 
       if (action === "prepare" || action === "rerun") {
         await stopApp(app)
-        app = await prepareApp(options, progress, stepName)
-        action = await askHumanAction()
+        app = await prepareApp(options, progress, stepName, { inheritOutput })
+        action = await askAction()
         continue
       }
 
       if (action === "iterate") {
         iterations++
-        await stopApp(app)
-        app = undefined
         progress.phaseRunning(stepName, "interactive OpenCode iteration")
-        // The interactive OpenCode TUI answers its own permission prompts;
-        // Archer's gate must not race it for the same requests.
-        permissions?.pause()
-        try {
-          await runInteractiveOpencode(options, opencodeUrl)
-        } finally {
-          permissions?.resume()
+        if (askInTui) {
+          await openExternalIteration(options, opencodeUrl, progress, stepName)
+        } else {
+          await stopApp(app)
+          app = undefined
+          // The interactive OpenCode TUI answers its own permission prompts;
+          // Archer's gate must not race it for the same requests.
+          permissions?.pause()
+          try {
+            await runInteractiveOpencode(options, opencodeUrl)
+          } finally {
+            permissions?.resume()
+          }
+          await commitHumanChanges(options)
         }
-        await commitHumanChanges(options)
-        action = "prepare"
+        action = await askAction()
         continue
       }
 
@@ -95,7 +104,7 @@ export async function runHumanReviewGate(
     }
   } finally {
     await stopApp(app)
-    progress.resume()
+    if (!askInTui) progress.resume()
   }
 }
 
@@ -108,14 +117,26 @@ async function humanReviewApproved(workspace: Workspace, stepName: string) {
   }
 }
 
-async function prepareApp(options: RunOptions, progress: ProgressUI, stepName: string): Promise<AppProcess | undefined> {
-  progress.phaseRunning(stepName, "preparing app")
-  await launchEmulator(options)
-  progress.phaseRunning(stepName, "running app command")
-  return startApp(options)
+function humanReviewInfo(stepName: string, options: RunOptions, iterations: number, app: AppProcess | undefined) {
+  return {
+    stepName,
+    iterations,
+    appRunning: Boolean(app && app.exitCode === null && app.signalCode === null),
+    appCommand: options.appRunCommand,
+    emulatorID: options.emulatorID,
+    interactiveModel: options.interactiveModel,
+    interactiveVariant: options.interactiveVariant,
+  }
 }
 
-async function launchEmulator(options: RunOptions) {
+async function prepareApp(options: RunOptions, progress: ProgressUI, stepName: string, io: { inheritOutput: boolean }): Promise<AppProcess | undefined> {
+  progress.phaseRunning(stepName, "preparing app")
+  await launchEmulator(options, io)
+  progress.phaseRunning(stepName, "running app command")
+  return startApp(options, progress, stepName, io)
+}
+
+async function launchEmulator(options: RunOptions, io: { inheritOutput: boolean }) {
   const emulatorID = options.emulatorID
   if (!emulatorID) {
     log.info("[human-review] no emulator configured; starting app command without launching one")
@@ -126,17 +147,18 @@ async function launchEmulator(options: RunOptions) {
   const proc = Bun.spawn(["flutter", "emulators", "--launch", emulatorID], {
     cwd: options.targetDir,
     stdin: "ignore",
-    stdout: "inherit",
-    stderr: "inherit",
+    stdout: io.inheritOutput ? "inherit" : "ignore",
+    stderr: io.inheritOutput ? "inherit" : "ignore",
     env: process.env,
   })
   const code = await proc.exited
   if (code !== 0) log.warn(`[human-review] emulator launch exited with code ${code}; start it manually if needed`)
 }
 
-function startApp(options: RunOptions): AppProcess | undefined {
+function startApp(options: RunOptions, progress: ProgressUI, stepName: string, io: { inheritOutput: boolean }): AppProcess | undefined {
   if (!options.appRunCommand) {
     log.warn("[human-review] app launch disabled; start the app manually before continuing")
+    progress.phaseActivity(stepName, "app launch disabled; start it manually", "info")
     return undefined
   }
 
@@ -145,13 +167,13 @@ function startApp(options: RunOptions): AppProcess | undefined {
   // whole tree (pnpm/flutter spawn the real servers as grandchildren).
   return spawn("sh", ["-c", options.appRunCommand], {
     cwd: options.targetDir,
-    stdio: ["ignore", "inherit", "inherit"],
+    stdio: io.inheritOutput ? ["ignore", "inherit", "inherit"] : ["ignore", "ignore", "ignore"],
     detached: true,
     env: process.env,
   })
 }
 
-async function askHumanAction(options: { timeoutMs?: number; timeoutAction?: HumanAction } = {}): Promise<HumanAction> {
+async function askHumanAction(options: { timeoutMs?: number; timeoutAction?: HumanReviewAction } = {}): Promise<HumanReviewAction> {
   const rl = createInterface({ input: stdin, output: stdout })
   const controller = new AbortController()
   let interrupted = false
@@ -194,6 +216,21 @@ async function askHumanAction(options: { timeoutMs?: number; timeoutAction?: Hum
   } finally {
     if (timeout) clearTimeout(timeout)
     rl.close()
+  }
+}
+
+async function openExternalIteration(options: RunOptions, opencodeUrl: string, progress: ProgressUI, stepName: string) {
+  progress.phaseActivity(stepName, "opening OpenCode iteration in a new window", "system")
+  try {
+    const backend = await openInteractiveOpencodeWindow({
+      url: opencodeUrl,
+      targetDir: options.targetDir,
+      model: options.interactiveModel,
+      variant: options.interactiveVariant,
+    })
+    progress.phaseActivity(stepName, `OpenCode iteration opened in ${backend}; return here and press c to continue`, "system")
+  } catch (error) {
+    progress.phaseActivity(stepName, `couldn't open OpenCode iteration: ${error instanceof Error ? error.message : String(error)}`, "error")
   }
 }
 

--- a/src/human.ts
+++ b/src/human.ts
@@ -13,6 +13,12 @@ import type { RunOptions } from "./types"
 import type { Workspace } from "./workspace"
 
 type AppProcess = ChildProcess
+type HumanReviewGateDeps = {
+  openInteractiveOpencodeWindow: typeof openInteractiveOpencodeWindow
+  runInteractiveOpencode: typeof runInteractiveOpencode
+}
+
+const defaultHumanReviewGateDeps: HumanReviewGateDeps = { openInteractiveOpencodeWindow, runInteractiveOpencode }
 
 export async function runHumanReviewGate(
   workspace: Workspace,
@@ -21,6 +27,7 @@ export async function runHumanReviewGate(
   progress: ProgressUI = noopProgress,
   permissions?: PermissionGate,
   stepName = "human-review",
+  deps: HumanReviewGateDeps = defaultHumanReviewGateDeps,
 ) {
   // Human steps are filtered out of new pipelines when --no-human-review is
   // set; this guard covers resumed runs whose frozen pipeline still has one.
@@ -48,18 +55,14 @@ export async function runHumanReviewGate(
   let iterations = 0
   let app: AppProcess | undefined
   const inheritOutput = !askInTui
-  const askAction = async (initial = false) =>
-    askInTui
-      ? askInTui(humanReviewInfo(stepName, options, iterations, app))
-      : askHumanAction(initial ? { timeoutMs: 10_000, timeoutAction: "prepare" } : undefined)
+  const askAction = async () => (askInTui ? askInTui(humanReviewInfo(stepName, options, iterations, app)) : askHumanAction())
 
   // Plain readline fallback still owns the terminal. The TUI path keeps the
   // dashboard active and resolves actions via ProgressUI.askHumanReview.
   if (!askInTui) progress.suspend()
   try {
     log.section(`${stepName} - manual review checkpoint`)
-    if (!askInTui) log.info("choose an action now, or Archer will prepare the configured app command after 10 seconds")
-    let action = await askAction(true)
+    let action = await askAction()
 
     for (;;) {
       if (action === "continue") {
@@ -80,18 +83,28 @@ export async function runHumanReviewGate(
         iterations++
         progress.phaseRunning(stepName, "interactive OpenCode iteration")
         if (askInTui) {
-          await openExternalIteration(options, opencodeUrl, progress, stepName)
-        } else {
-          await stopApp(app)
-          app = undefined
-          // The interactive OpenCode TUI answers its own permission prompts;
-          // Archer's gate must not race it for the same requests.
+          // The external OpenCode TUI owns its own permission prompts. Keep
+          // Archer's dashboard gate paused until the user returns to this gate
+          // and chooses the next action.
           permissions?.pause()
           try {
-            await runInteractiveOpencode(options, opencodeUrl)
+            const opened = await openExternalIteration(options, opencodeUrl, progress, stepName, deps.openInteractiveOpencodeWindow)
+            if (opened) {
+              action = await askAction()
+              continue
+            }
           } finally {
             permissions?.resume()
           }
+
+          await stopApp(app)
+          app = undefined
+          await runSuspendedInteractiveIteration(options, opencodeUrl, progress, stepName, permissions, deps.runInteractiveOpencode)
+          await commitHumanChanges(options)
+        } else {
+          await stopApp(app)
+          app = undefined
+          await runInteractiveIteration(options, opencodeUrl, permissions, deps.runInteractiveOpencode)
           await commitHumanChanges(options)
         }
         action = await askAction()
@@ -173,7 +186,7 @@ function startApp(options: RunOptions, progress: ProgressUI, stepName: string, i
   })
 }
 
-async function askHumanAction(options: { timeoutMs?: number; timeoutAction?: HumanReviewAction } = {}): Promise<HumanReviewAction> {
+async function askHumanAction(): Promise<HumanReviewAction> {
   const rl = createInterface({ input: stdin, output: stdout })
   const controller = new AbortController()
   let interrupted = false
@@ -183,12 +196,10 @@ async function askHumanAction(options: { timeoutMs?: number; timeoutAction?: Hum
     interrupted = true
     controller.abort()
   })
-  const timeout = options.timeoutMs ? setTimeout(() => controller.abort(), options.timeoutMs) : undefined
-  const timeoutHint = options.timeoutMs ? ` (auto-starts in ${Math.round(options.timeoutMs / 1000)}s)` : ""
 
   try {
     for (;;) {
-      const answer = (await rl.question(`Human review: [c]ontinue, [i]terate, [s]tart app, [r]erun app, [a]bort${timeoutHint} > `, {
+      const answer = (await rl.question("Human review: [c]ontinue, [i]terate, [s]tart app, [r]erun app, [a]bort > ", {
         signal: controller.signal,
       }))
         .trim()
@@ -207,30 +218,66 @@ async function askHumanAction(options: { timeoutMs?: number; timeoutAction?: Hum
         log.warn("[human-review] Ctrl+C received; aborting")
         return "abort"
       }
-      if (options.timeoutAction) {
-        log.info("[human-review] no response; preparing configured app command")
-        return options.timeoutAction
-      }
     }
     throw error
   } finally {
-    if (timeout) clearTimeout(timeout)
     rl.close()
   }
 }
 
-async function openExternalIteration(options: RunOptions, opencodeUrl: string, progress: ProgressUI, stepName: string) {
+async function openExternalIteration(
+  options: RunOptions,
+  opencodeUrl: string,
+  progress: ProgressUI,
+  stepName: string,
+  openWindow: typeof openInteractiveOpencodeWindow = openInteractiveOpencodeWindow,
+) {
   progress.phaseActivity(stepName, "opening OpenCode iteration in a new window", "system")
   try {
-    const backend = await openInteractiveOpencodeWindow({
+    const backend = await openWindow({
       url: opencodeUrl,
       targetDir: options.targetDir,
       model: options.interactiveModel,
       variant: options.interactiveVariant,
     })
     progress.phaseActivity(stepName, `OpenCode iteration opened in ${backend}; return here and press c to continue`, "system")
+    return true
   } catch (error) {
     progress.phaseActivity(stepName, `couldn't open OpenCode iteration: ${error instanceof Error ? error.message : String(error)}`, "error")
+    return false
+  }
+}
+
+async function runSuspendedInteractiveIteration(
+  options: RunOptions,
+  opencodeUrl: string,
+  progress: ProgressUI,
+  stepName: string,
+  permissions?: PermissionGate,
+  runInteractive: typeof runInteractiveOpencode = runInteractiveOpencode,
+) {
+  progress.phaseActivity(stepName, "falling back to interactive OpenCode in this terminal", "system")
+  progress.suspend()
+  try {
+    await runInteractiveIteration(options, opencodeUrl, permissions, runInteractive)
+  } finally {
+    progress.resume()
+  }
+}
+
+async function runInteractiveIteration(
+  options: RunOptions,
+  opencodeUrl: string,
+  permissions?: PermissionGate,
+  runInteractive: typeof runInteractiveOpencode = runInteractiveOpencode,
+) {
+  // The interactive OpenCode TUI answers its own permission prompts; Archer's
+  // gate must not race it for the same requests.
+  permissions?.pause()
+  try {
+    await runInteractive(options, opencodeUrl)
+  } finally {
+    permissions?.resume()
   }
 }
 

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -724,6 +724,10 @@ class LaunchPicker {
 
     this.pipelineBox.width = pipelineWidth
     this.detailBox.width = detailWidth
+    // Mirror the dashboard focus cue: the accented border marks where Enter,
+    // Esc, and the navigation keys apply in the current setup step.
+    this.pipelineBox.borderColor = this.mode === "pipelines" ? theme.accent : theme.borderDim
+    this.detailBox.borderColor = this.mode === "pipelines" ? theme.borderDim : theme.accent
     this.headerText.content = this.headerContent(innerWidth)
     // Panels reserve 4 cells of chrome (rounded border + paddingX:1 each side),
     // so lay out the rows against the inner text width — matching detailWidth

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -1,6 +1,6 @@
 import { basename } from "node:path"
 
-import { BoxRenderable, StyledText, TextRenderable, bold, createCliRenderer, decodePasteBytes, fg, stripAnsiSequences, t } from "@opentui/core"
+import { BoxRenderable, StyledText, TextRenderable, bg, bold, createCliRenderer, decodePasteBytes, fg, stripAnsiSequences, t } from "@opentui/core"
 
 import { buildAgentRegistry, loadMergedArcherConfig } from "./config"
 import { builtInPipelines, defaultPipelineName, resolvePipeline } from "./pipeline"
@@ -61,8 +61,9 @@ type ToggleSpec = {
 type Mode = "pipelines" | "prompt" | "options"
 
 type Modal =
-  | { kind: "message"; title: string; message: string }
-  | { kind: "loading"; title: string; message: string }
+  | { kind: "message"; title: string; message: string; footer?: string }
+  | { kind: "loading"; title: string; message: string; footer?: string }
+  | { kind: "confirm"; title: string; message: string; footer?: string; onConfirm: () => void }
 
 const toggles: readonly ToggleSpec[] = [
   {
@@ -116,6 +117,7 @@ export async function launchRunTui(options: { targetDir: string }): Promise<Laun
 
   const config = await loadMergedArcherConfig(options.targetDir)
   const choices = pipelineChoices(config, buildAgentRegistry(config))
+  const baseRef = config?.defaults.baseRef ?? "main"
 
   // No backgroundColor yet: the palette is only chosen after the terminal
   // answers the background query, so a light terminal never flashes dark.
@@ -127,7 +129,7 @@ export async function launchRunTui(options: { targetDir: string }): Promise<Laun
   })
   const mode = await renderer.waitForThemeMode(1_000).catch(() => null)
   setTheme(paletteForTerminal(mode, terminalBackgroundHex(renderer)))
-  return new LaunchPicker(renderer, options.targetDir, choices).result
+  return new LaunchPicker(renderer, options.targetDir, choices, baseRef).result
 }
 
 function pipelineChoices(config: ArcherConfig | undefined, agents: readonly AgentSpec[]): PipelineChoice[] {
@@ -226,8 +228,7 @@ class LaunchPicker {
     event.stopPropagation()
     const text = sanitizePaste(stripAnsiSequences(decodePasteBytes(event.bytes)))
     if (!text) return
-    this.prompt = this.prompt.slice(0, this.cursor) + text + this.prompt.slice(this.cursor)
-    this.cursor += text.length
+    this.insertPromptText(text)
     this.promptError = ""
     this.render()
   }
@@ -242,9 +243,20 @@ class LaunchPicker {
 
     key.preventDefault()
     key.stopPropagation()
-    if (this.modal) {
+    const modal = this.modal
+    if (modal) {
+      if (modal.kind === "confirm") {
+        if (key.name === "return" || key.name === "linefeed") {
+          this.modal = undefined
+          modal.onConfirm()
+        } else if (key.name === "escape" || key.name === "q") {
+          this.modal = undefined
+          this.render()
+        }
+        return
+      }
       // Only the message modal can be dismissed; loading blocks input until the async job finishes.
-      if (this.modal.kind === "message" && (key.name === "return" || key.name === "linefeed" || key.name === "escape" || key.name === "space" || key.name === "q")) {
+      if (modal.kind === "message" && (key.name === "return" || key.name === "linefeed" || key.name === "escape" || key.name === "space" || key.name === "q")) {
         this.modal = undefined
         this.render()
       }
@@ -267,6 +279,7 @@ class LaunchPicker {
     private readonly renderer: CliRenderer,
     private readonly targetDir: string,
     private readonly choices: PipelineChoice[],
+    private readonly baseRef: string,
   ) {
     const defaultIndex = choices.findIndex((choice) => choice.isDefault)
     this.selected = defaultIndex >= 0 ? defaultIndex : 0
@@ -438,7 +451,14 @@ class LaunchPicker {
       this.render()
       return
     }
-    if (key.name === "return" || key.name === "linefeed") {
+    const enterAction = promptEnterAction(key)
+    if (enterAction === "newline") {
+      this.insertPromptText("\n")
+      this.promptError = ""
+      this.render()
+      return
+    }
+    if (enterAction === "submit") {
       if (!this.prompt.trim()) {
         this.promptError = "Write a prompt before continuing."
       } else {
@@ -490,11 +510,15 @@ class LaunchPicker {
 
     const text = typedText(key)
     if (text) {
-      this.prompt = this.prompt.slice(0, this.cursor) + text + this.prompt.slice(this.cursor)
-      this.cursor += text.length
+      this.insertPromptText(text)
       this.promptError = ""
       this.render()
     }
+  }
+
+  private insertPromptText(text: string) {
+    this.prompt = this.prompt.slice(0, this.cursor) + text + this.prompt.slice(this.cursor)
+    this.cursor += text.length
   }
 
   private handleOptionsKey(key: KeyEvent) {
@@ -543,15 +567,58 @@ class LaunchPicker {
   }
 
   private startRun() {
+    void this.startRunAfterGitCheck()
+  }
+
+  private async startRunAfterGitCheck() {
     const choice = this.currentChoice()
+    try {
+      const { repoBootstrapStatus } = await import("./git")
+      const status = await repoBootstrapStatus(this.targetDir)
+      if (status !== "ready") {
+        this.modal = {
+          kind: "confirm",
+          title: "Initialize Git",
+          message: status === "no-repo" ? "This project has no Git repository. Initialize it now with an initial commit?" : "This Git repository has no commits. Create an initial commit now?",
+          footer: "enter initialize · esc cancel",
+          onConfirm: () => void this.initializeGitAndStart(choice.name),
+        }
+        this.render()
+        return
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.modal = { kind: "message", title: "git check failed", message }
+      this.render()
+      return
+    }
+
+    this.startReadyRun(choice.name)
+  }
+
+  private async initializeGitAndStart(pipelineName: string) {
+    this.modal = { kind: "loading", title: "initializing Git", message: "creating initial commit…", footer: "please wait…" }
+    this.render()
+    try {
+      const { initializeRepoWithInitialCommit } = await import("./git")
+      await initializeRepoWithInitialCommit(this.targetDir, { baseRef: this.baseRef })
+      this.startReadyRun(pipelineName)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      this.modal = { kind: "message", title: "git init failed", message }
+      this.render()
+    }
+  }
+
+  private startReadyRun(pipelineName: string) {
     if (this.toggleState.worktree) {
-      void this.startWorktreeRun(choice.name)
+      void this.startWorktreeRun(pipelineName)
       return
     }
     this.finish({
       targetDir: this.targetDir,
       prompt: this.prompt,
-      pipeline: choice.name,
+      pipeline: pipelineName,
       humanReview: this.toggleState.humanReview,
       tui: this.toggleState.tui,
       includeDirty: this.toggleState.includeDirty,
@@ -565,7 +632,7 @@ class LaunchPicker {
   // loading modal so the user can't toggle options mid-creation. Any failure
   // falls back to the options screen with an explanatory message modal.
   private async startWorktreeRun(pipelineName: string) {
-    this.modal = { kind: "loading", title: "isolating worktree", message: "generating a branch name…" }
+    this.modal = { kind: "loading", title: "isolating worktree", message: "generating a branch name…", footer: "creating a new branch + worktree…" }
     this.render()
     try {
       const { createIsolatedWorktree } = await import("./worktree")
@@ -687,7 +754,8 @@ class LaunchPicker {
       for (const line of wrapWords(modal.message, width)) lines.push(new StyledText([fg(theme.text)(line)]))
     }
     lines.push(plain(""))
-    lines.push(new StyledText([fg(theme.dim)(modal.kind === "message" ? "press any key to dismiss" : "creating a new branch + worktree…")]))
+    const footer = modal.footer ?? (modal.kind === "message" ? "press any key to dismiss" : modal.kind === "confirm" ? "enter confirm · esc cancel" : "please wait…")
+    lines.push(new StyledText([fg(theme.dim)(footer)]))
 
     this.modalBox.width = boxWidth
     this.modalBox.height = lines.length + 4
@@ -788,11 +856,11 @@ class LaunchPicker {
     const lines: StyledText[] = []
     lines.push(new StyledText([fg(theme.faint)("pipeline "), bold(fg(theme.text)(choice.name))]))
     lines.push(plain(""))
-    lines.push(t`${fg(theme.dim)("Describe what Archer should do. Paste freely; Enter continues.")}`)
+    lines.push(t`${fg(theme.dim)("Describe what Archer should do. Paste freely; Shift+Enter adds a line.")}`)
     lines.push(plain(""))
 
     const fieldWidth = Math.max(10, width - 2)
-    const contentWidth = Math.max(1, fieldWidth - 1)
+    const contentWidth = Math.max(1, fieldWidth)
     const inputHeight = Math.max(5, Math.min(20, this.listHeight() - 6))
     const visibleRows = Math.max(1, inputHeight - 2)
     const wrapped = wrapPromptLines(this.prompt, contentWidth)
@@ -811,16 +879,19 @@ class LaunchPicker {
       const seg = wrapped[r] ?? ""
       const chunks: TextChunk[] = [fg(theme.faint)("│")]
       if (r === cursorRow) {
-        const before = seg.slice(0, cursorCol)
-        const after = seg.slice(cursorCol)
-        const used = before.length + 1 + after.length
         if (!this.prompt && r === 0) {
-          chunks.push(fg(theme.accent)("▏"))
-          chunks.push(fg(theme.faint)(truncate(placeholder, Math.max(0, fieldWidth - 1))))
-          chunks.push(fg(theme.faint)(" ".repeat(Math.max(0, fieldWidth - 1 - truncate(placeholder, fieldWidth - 1).length)) + "│"))
+          const placeholderText = truncate(placeholder, Math.max(0, fieldWidth - 1))
+          chunks.push(cursorChunk(" "))
+          chunks.push(fg(theme.faint)(placeholderText))
+          chunks.push(fg(theme.faint)(" ".repeat(Math.max(0, fieldWidth - 1 - placeholderText.length)) + "│"))
         } else {
+          const col = clamp(cursorCol, 0, Math.max(0, fieldWidth - 1))
+          const before = seg.slice(0, col)
+          const cursorCell = seg[col] ?? " "
+          const after = seg.slice(col + 1)
+          const used = before.length + 1 + after.length
           chunks.push(fg(theme.text)(before))
-          chunks.push(fg(theme.accent)("▏"))
+          chunks.push(cursorChunk(cursorCell))
           chunks.push(fg(theme.text)(after))
           chunks.push(fg(theme.faint)(" ".repeat(Math.max(0, fieldWidth - used)) + "│"))
         }
@@ -840,7 +911,7 @@ class LaunchPicker {
       lines.push(t`${fg(theme.red)(this.promptError)}`)
     }
     lines.push(plain(""))
-    const hint = "←/→ move · home/end jump · ctrl+U clear · esc back"
+    const hint = "shift+enter newline · enter options · ←/→ move · ctrl+U clear · esc back"
     if (wrapped.length > 1) {
       lines.push(new StyledText([fg(theme.faint)(hint + " · "), fg(theme.accent)(`${wrapped.length} lines`)]))
     } else {
@@ -903,7 +974,7 @@ class LaunchPicker {
     }
     if (this.mode === "prompt") {
       return padBetween(
-        [fg(theme.dim)("type/paste · "), fg(theme.accent)("enter"), fg(theme.dim)(" options · "), fg(theme.accent)("esc"), fg(theme.dim)(" back")],
+        [fg(theme.dim)("type/paste · "), fg(theme.accent)("shift+enter"), fg(theme.dim)(" newline · "), fg(theme.accent)("enter"), fg(theme.dim)(" options · "), fg(theme.accent)("esc"), fg(theme.dim)(" back")],
         [fg(theme.faint)(`${this.prompt.length} char${this.prompt.length === 1 ? "" : "s"}`)],
         width,
       )
@@ -961,6 +1032,15 @@ export function typedText(key: KeyEvent): string | undefined {
     if (code >= 0x20 && code !== 0x7f) out += ch
   }
   return out || undefined
+}
+
+export function promptEnterAction(key: Pick<KeyEvent, "name" | "shift">): "newline" | "submit" | undefined {
+  if (key.name !== "return" && key.name !== "linefeed") return undefined
+  return key.shift ? "newline" : "submit"
+}
+
+function cursorChunk(text: string): TextChunk {
+  return bg(theme.accent)(fg(theme.chipText)(text || " "))
 }
 
 export function sanitizePaste(text: string): string {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -222,6 +222,7 @@ export function recordProgress(progress: ProgressUI, store: RunMetadataStore): P
   // The gate decides between in-place prompts and the readline fallback by
   // probing for askPermission, so its presence must mirror the wrapped UI.
   if (progress.askPermission) recorder.askPermission = progress.askPermission.bind(progress)
+  if (progress.askHumanReview) recorder.askHumanReview = progress.askHumanReview.bind(progress)
   // Same probing contract: the runner only holds the finish screen when the UI offers one.
   if (progress.runFinished) recorder.runFinished = progress.runFinished.bind(progress)
   return recorder

--- a/src/opencode.ts
+++ b/src/opencode.ts
@@ -62,6 +62,17 @@ export async function openOpencodeSessionWindow(input: {
   )
 }
 
+export async function openInteractiveOpencodeWindow(input: {
+  url: string
+  targetDir: string
+  model: string
+  variant?: string
+}): Promise<SessionWindowBackend> {
+  const args = ["opencode", "run", "--interactive", "--attach", input.url, "--dir", input.targetDir, "--model", input.model]
+  if (input.variant) args.push("--variant", input.variant)
+  return openSessionCommand(args.map(shellQuote).join(" "))
+}
+
 // Opens a standalone opencode TUI on a stored session — it starts its own
 // server and reads the session from disk — for runs whose live server is gone
 // (so `[o]` in a re-opened finished-run dashboard still works).

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -111,6 +111,18 @@ export type PermissionPromptInfo = {
   judgeReason?: string
 }
 
+export type HumanReviewAction = "continue" | "iterate" | "rerun" | "abort" | "prepare"
+
+export type HumanReviewPromptInfo = {
+  stepName: string
+  iterations: number
+  appRunning: boolean
+  appCommand: string
+  emulatorID: string
+  interactiveModel: string
+  interactiveVariant: string
+}
+
 export type RunOutcome = {
   status: "completed" | "failed"
   error?: string
@@ -142,6 +154,8 @@ export type ProgressUI = {
   phaseRestored(name: string, snapshot: ProgressPhaseSnapshot): void
   /** When present, the UI resolves permission prompts itself (no terminal fallback). */
   askPermission?(info: PermissionPromptInfo): Promise<PermissionReply>
+  /** When present, the UI keeps manual review gates inside the dashboard. */
+  askHumanReview?(info: HumanReviewPromptInfo): Promise<HumanReviewAction>
   /** Holds the dashboard open on a finish screen (phase browser) and resolves when the user dismisses it. */
   runFinished?(outcome: RunOutcome): Promise<void>
   message(message: string): void

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -213,6 +213,7 @@ export class TuiProgress implements ProgressUI {
   private readonly ticker: ReturnType<typeof setInterval>
   private readonly dirText: TextRenderable
   private readonly headerText: TextRenderable
+  private readonly pipelineBox: BoxRenderable
   private readonly pipelineText: TextRenderable
   // The detail panel: header (name, status, model, cost, tokens, diff) of the
   // one focused phase. A single pane now — concurrent phases are browsed via
@@ -221,6 +222,7 @@ export class TuiProgress implements ProgressUI {
   private readonly stepText: TextRenderable
   private readonly todosBox: BoxRenderable
   private readonly todosText: TextRenderable
+  private readonly feedBox: BoxRenderable
   private readonly feedText: TextRenderable
   private readonly footerText: TextRenderable
   // Rebuilt on every pipeline render: panel row index → phase name, so clicks
@@ -244,11 +246,17 @@ export class TuiProgress implements ProgressUI {
   // Phase reports read lazily from the run dir; the cache entry is dropped when
   // a phase finishes so a report written mid-run is picked up on the next view.
   private readonly reports = new Map<string, string[] | "loading" | "missing">()
-  // Visible rows of the reports tab, captured at render time for paging keys.
-  private reportPageRows = 10
-  // Scroll offset + indicator for the reports tab, shared across live/finished.
+  // Visible rows of the content tab, captured at render time for paging keys.
+  private contentPageRows = 10
+  // The content panel has an explicit read focus: normally ↑/↓ move the
+  // pipeline selector; after Enter they scroll the active tab until Escape.
+  private contentFocused = false
+  // Scroll offsets + indicator for the content tabs, shared across live/finished.
+  // sessionScroll is measured from the bottom so live transcripts keep tailing.
   private reportScroll = 0
-  private reportPosition = ""
+  private logScroll = 0
+  private sessionScroll = 0
+  private contentPosition = ""
   // The content panel's active tab, scoped to the focused phase: its activity
   // feed, the report it wrote (if any), or a read-only "follow along" view of
   // its opencode session. [o] still opens the interactive session externally.
@@ -294,21 +302,22 @@ export class TuiProgress implements ProgressUI {
     }
     if (this.humanReview && this.handleHumanReviewKey(key)) return
     // Everything else is navigation, shared by the live dashboard and the
-    // finish screen: move the focused phase, switch the content tab, scroll a
-    // report, or open the external session.
+    // finish screen: move the focused phase, switch the content tab, focus or
+    // scroll the reading panel, or open the external session.
     this.handleNavKey(key)
   }
 
   // Unified navigation for both the live run and the finish screen. Vertical
   // keys move the focused phase through the pipeline (the tab selector);
-  // horizontal keys / Tab / digits switch the content tab; page keys scroll the
-  // reports tab; [o] opens the external session. Finish-only keys come last.
+  // Enter focuses the content panel; horizontal keys / Tab / digits switch the
+  // content tab; page keys scroll; [o] opens the external session.
   private handleNavKey(key: KeyEvent) {
     const finished = this.finished
     const consume = () => {
       key.preventDefault()
       key.stopPropagation()
     }
+    if (this.contentFocused && this.handleContentFocusedKey(key, consume)) return
     switch (key.name) {
       case "up":
       case "k":
@@ -331,14 +340,20 @@ export class TuiProgress implements ProgressUI {
         consume()
         this.cycleContentTab(1)
         return
+      case "return":
+      case "linefeed":
+        consume()
+        this.contentFocused = true
+        this.render()
+        return
       case "pagedown":
       case "space":
         consume()
-        this.scrollReport(this.reportPageRows)
+        this.scrollContent(this.contentPageRows)
         return
       case "pageup":
         consume()
-        this.scrollReport(-this.reportPageRows)
+        this.scrollContent(-this.contentPageRows)
         return
       case "o":
         consume()
@@ -370,6 +385,53 @@ export class TuiProgress implements ProgressUI {
       this.manualFocus = false
       this.render()
     }
+  }
+
+  private handleContentFocusedKey(key: KeyEvent, consume: () => void) {
+    switch (key.name) {
+      case "up":
+      case "k":
+        consume()
+        this.scrollContent(-1)
+        return true
+      case "down":
+      case "j":
+        consume()
+        this.scrollContent(1)
+        return true
+      case "pageup":
+        consume()
+        this.scrollContent(-this.contentPageRows)
+        return true
+      case "pagedown":
+      case "space":
+        consume()
+        this.scrollContent(this.contentPageRows)
+        return true
+      case "home":
+        consume()
+        this.scrollContentToStart()
+        return true
+      case "end":
+        consume()
+        this.scrollContentToEnd()
+        return true
+      case "g":
+        consume()
+        if (key.shift) this.scrollContentToEnd()
+        else this.scrollContentToStart()
+        return true
+      case "escape":
+        consume()
+        this.contentFocused = false
+        this.render()
+        return true
+      case "return":
+      case "linefeed":
+        consume()
+        return true
+    }
+    return false
   }
 
   constructor(
@@ -539,11 +601,13 @@ export class TuiProgress implements ProgressUI {
 
     this.dirText = dirLine
     this.headerText = header.text
+    this.pipelineBox = pipeline.box
     this.pipelineText = pipeline.text
     this.stepBox = step.box
     this.stepText = step.text
     this.todosBox = todos.box
     this.todosText = todos.text
+    this.feedBox = feed.box
     this.feedText = feed.text
     this.footerText = footer.text
 
@@ -821,7 +885,7 @@ export class TuiProgress implements ProgressUI {
         this.selected = failed
         this.manualFocus = true
       }
-      this.reportScroll = 0
+      this.resetContentScroll()
       for (const pending of this.permissionQueue.splice(0)) pending.resolve("reject")
       this.addEvent(
         "archer",
@@ -846,7 +910,7 @@ export class TuiProgress implements ProgressUI {
     if (this.phases.length === 0) return
     this.manualFocus = true
     this.selected = Math.max(0, Math.min(this.phases.length - 1, this.selected + delta))
-    this.reportScroll = 0
+    this.resetContentScroll()
     this.render()
   }
 
@@ -855,7 +919,7 @@ export class TuiProgress implements ProgressUI {
     if (index === -1) return
     this.manualFocus = true
     this.selected = index
-    this.reportScroll = 0
+    this.resetContentScroll()
     this.render()
   }
 
@@ -867,14 +931,43 @@ export class TuiProgress implements ProgressUI {
   private setContentTab(tab: ContentTab) {
     if (this.contentTab !== tab) {
       this.contentTab = tab
-      this.reportScroll = 0
+      this.resetContentScroll()
     }
     this.render()
   }
 
-  private scrollReport(delta: number) {
-    if (this.contentTab !== "reports") return
-    this.reportScroll = Math.max(0, this.reportScroll + delta)
+  private resetContentScroll() {
+    this.reportScroll = 0
+    this.logScroll = 0
+    this.sessionScroll = 0
+  }
+
+  private scrollContent(delta: number) {
+    switch (this.contentTab) {
+      case "reports":
+        this.reportScroll = Math.max(0, this.reportScroll + delta)
+        break
+      case "logs":
+        this.logScroll = Math.max(0, this.logScroll + delta)
+        break
+      case "session":
+        this.sessionScroll = Math.max(0, this.sessionScroll - delta)
+        break
+    }
+    this.render()
+  }
+
+  private scrollContentToStart() {
+    if (this.contentTab === "session") this.sessionScroll = Number.MAX_SAFE_INTEGER
+    else if (this.contentTab === "reports") this.reportScroll = 0
+    else this.logScroll = 0
+    this.render()
+  }
+
+  private scrollContentToEnd() {
+    if (this.contentTab === "session") this.sessionScroll = 0
+    else if (this.contentTab === "reports") this.reportScroll = Number.MAX_SAFE_INTEGER
+    else this.logScroll = Number.MAX_SAFE_INTEGER
     this.render()
   }
 
@@ -1166,6 +1259,8 @@ export class TuiProgress implements ProgressUI {
       if (activeIndex >= 0) this.selected = activeIndex
     }
     const focus = this.focusedPhase()
+    this.pipelineBox.borderColor = this.contentFocused ? theme.borderDim : theme.accent
+    this.feedBox.borderColor = this.contentFocused ? theme.accent : theme.borderDim
 
     // Detail panel: the focused phase's header — name, status, model, cost,
     // tokens, diff — the same shape whether it's running, finished, or still
@@ -1191,13 +1286,13 @@ export class TuiProgress implements ProgressUI {
     // rail) over the active tab's body, all scoped to the focused phase.
     const feedRows = Math.max(3, bodyHeight - usedHeight - 2)
     const contentRows = feedRows - 2
-    this.reportPageRows = contentRows
+    this.contentPageRows = contentRows
 
     this.dirText.content = this.dirContent(innerWidth)
     this.headerText.content = this.headerContent(now, innerWidth)
     this.pipelineText.content = this.pipelineContent(now)
 
-    // Body first: the reports tab computes the scroll indicator the title shows.
+    // Body first: the active content tab computes the scroll indicator the rail shows.
     const body =
       this.contentTab === "reports"
         ? this.reportPanelLines(focus, rightWidth, contentRows)
@@ -1478,7 +1573,7 @@ export class TuiProgress implements ProgressUI {
   // Works live (the run dir is known from start) and on the finish screen; a
   // step that hasn't finished yet — or wrote nothing — says so.
   private reportPanelLines(phase: PhaseState | undefined, width: number, visible: number): StyledText[] {
-    this.reportPosition = ""
+    this.contentPosition = ""
     if (visible <= 0) return []
     if (!phase) return [t`${fg(theme.dim)("no step selected")}`]
     if (!this.runDir) return [t`${fg(theme.dim)("report directory not ready yet…")}`]
@@ -1497,9 +1592,7 @@ export class TuiProgress implements ProgressUI {
     const wrapped = wrapLines(report, Math.max(20, width))
     const maxScroll = Math.max(0, wrapped.length - visible)
     this.reportScroll = Math.max(0, Math.min(this.reportScroll, maxScroll))
-    if (maxScroll > 0) {
-      this.reportPosition = `${Math.round(((this.reportScroll + visible) / wrapped.length) * 100)}%`
-    }
+    this.contentPosition = scrollPosition(this.reportScroll, maxScroll)
     return wrapped.slice(this.reportScroll, this.reportScroll + visible).map(styleSummaryLine)
   }
 
@@ -1507,12 +1600,17 @@ export class TuiProgress implements ProgressUI {
   // phase (the tab selector picks it), so there's no cross-phase label column —
   // just time, kind icon, and message, leaving more room for the message.
   private phaseFeedLines(phase: PhaseState | undefined, width: number, visible: number): StyledText[] {
+    this.contentPosition = ""
     if (visible <= 0) return []
     if (!phase) return [t`${fg(theme.dim)("no step selected")}`]
-    const events = this.feed.filter((entry) => entry.phase === phase.name).slice(-visible).reverse()
+    const events = this.feed.filter((entry) => entry.phase === phase.name).reverse()
     if (events.length === 0) return [t`${fg(theme.dim)("no activity for this step yet…")}`]
 
-    return events.map((entry) => {
+    const maxScroll = Math.max(0, events.length - visible)
+    this.logScroll = Math.max(0, Math.min(this.logScroll, maxScroll))
+    this.contentPosition = scrollPosition(this.logScroll, maxScroll)
+
+    return events.slice(this.logScroll, this.logScroll + visible).map((entry) => {
       const style = kindStyle(entry.kind)
       return new StyledText([
         fg(theme.faint)(formatTime(entry.time)),
@@ -1530,7 +1628,7 @@ export class TuiProgress implements ProgressUI {
   // browser tab underline — with faint dashes elsewhere. Pure character
   // styling, no painted chip. Records each label's column span (shared by
   // both rows) so a click on either row resolves to the right tab. The
-  // reports tab's scroll position rides in faint text at the rail's tail.
+  // active tab's scroll position rides in faint text at the rail's tail.
   private contentTabBar(width: number): StyledText[] {
     this.feedTabRegions = []
     const labelChunks: TextChunk[] = []
@@ -1560,7 +1658,7 @@ export class TuiProgress implements ProgressUI {
     const activeEnd = Math.min(Math.max(active.end, activeStart), width)
     pushRail("╌".repeat(activeStart), theme.faint)
     pushRail("━".repeat(activeEnd - activeStart), theme.accent)
-    const suffix = this.contentTab === "reports" ? this.reportPosition : ""
+    const suffix = this.contentPosition
     const remaining = width - activeEnd
     if (suffix.length > 0 && suffix.length < remaining) {
       pushRail("╌".repeat(remaining - suffix.length), theme.faint)
@@ -1584,6 +1682,7 @@ export class TuiProgress implements ProgressUI {
   // so this whole pane is the transcript. Tails the newest rows, like a
   // terminal, since streaming means the interesting end is the bottom.
   private sessionLines(phase: PhaseState | undefined, width: number, visible: number): StyledText[] {
+    this.contentPosition = ""
     if (visible <= 0) return []
     if (!phase) return [t`${fg(theme.dim)("no active session yet — waiting for a phase to start…")}`]
 
@@ -1607,24 +1706,44 @@ export class TuiProgress implements ProgressUI {
       const live = running && index === blocks.length - 1
       lines.push(...transcriptBlockLines(block, width, live))
     })
-    // Newest at the bottom: keep only the rows that fit.
-    return lines.slice(-visible)
+    if (!this.contentFocused) this.sessionScroll = 0
+    const maxScroll = Math.max(0, lines.length - visible)
+    this.sessionScroll = Math.max(0, Math.min(this.sessionScroll, maxScroll))
+    const topOffset = maxScroll - this.sessionScroll
+    this.contentPosition = scrollPosition(topOffset, maxScroll)
+    // Newest at the bottom by default, but explicit read focus can scroll back.
+    return lines.slice(topOffset, topOffset + visible)
   }
 
   private footerContent(now: number, width: number) {
     if (this.finished) {
+      if (this.contentFocused) {
+        const left: TextChunk[] = [
+          fg(theme.dim)("read · ["),
+          fg(theme.accent)("↑↓"),
+          fg(theme.dim)("] scroll · ["),
+          fg(theme.accent)("pgup/pgdn"),
+          fg(theme.dim)("] page · ["),
+          fg(theme.accent)("esc"),
+          fg(theme.dim)("] pipeline · ["),
+          fg(theme.accent)("q"),
+          fg(theme.dim)("] close"),
+        ]
+        const right: TextChunk[] = [fg(theme.faint)(this.runID ? `run ${this.runID}` : "run …")]
+        return padBetween(left, right, width)
+      }
       const left: TextChunk[] = [
         fg(theme.dim)("["),
         fg(theme.accent)("↑↓"),
         fg(theme.dim)("] step · ["),
+        fg(theme.accent)("enter"),
+        fg(theme.dim)("] read · ["),
         fg(theme.accent)("←→"),
         fg(theme.dim)("] tab · ["),
         fg(theme.accent)("o"),
         fg(theme.dim)("] session · ["),
         fg(theme.accent)("g"),
         fg(theme.dim)("] lazygit · ["),
-        fg(theme.accent)("pgdn"),
-        fg(theme.dim)("] scroll · ["),
         fg(theme.accent)("q"),
         fg(theme.dim)("] close"),
       ]
@@ -1671,20 +1790,31 @@ export class TuiProgress implements ProgressUI {
       return padBetween(left, right, width)
     }
 
-    const left: TextChunk[] = [
-      fg(theme.dim)("["),
-      fg(theme.accent)("↑↓"),
-      fg(theme.dim)("] step · ["),
-      fg(theme.accent)("←→"),
-      fg(theme.dim)("] tab · ["),
-      fg(theme.accent)("o"),
-      fg(theme.dim)("] session · "),
-      fg(theme.yellow)("ctrl+c"),
-      fg(theme.dim)(" abort"),
-    ]
-    if (this.contentTab === "reports") {
-      left.push(fg(theme.dim)(" · ["), fg(theme.accent)("pgdn"), fg(theme.dim)("] scroll"))
-    }
+    const left: TextChunk[] = this.contentFocused
+      ? [
+          fg(theme.dim)("read · ["),
+          fg(theme.accent)("↑↓"),
+          fg(theme.dim)("] scroll · ["),
+          fg(theme.accent)("pgup/pgdn"),
+          fg(theme.dim)("] page · ["),
+          fg(theme.accent)("esc"),
+          fg(theme.dim)("] pipeline · "),
+          fg(theme.yellow)("ctrl+c"),
+          fg(theme.dim)(" abort"),
+        ]
+      : [
+          fg(theme.dim)("["),
+          fg(theme.accent)("↑↓"),
+          fg(theme.dim)("] step · ["),
+          fg(theme.accent)("enter"),
+          fg(theme.dim)("] read · ["),
+          fg(theme.accent)("←→"),
+          fg(theme.dim)("] tab · ["),
+          fg(theme.accent)("o"),
+          fg(theme.dim)("] session · "),
+          fg(theme.yellow)("ctrl+c"),
+          fg(theme.dim)(" abort"),
+        ]
     if (this.autoAccept) {
       left.push(fg(theme.dim)(" · "), fg(theme.accent)("shift+tab"))
       left.push(autoAcceptStatusChunk(this.autoAccept.mode))
@@ -1875,6 +2005,13 @@ function wrapWords(text: string, width: number): string[] {
   }
   if (current) lines.push(current)
   return lines.length > 0 ? lines : [""]
+}
+
+function scrollPosition(topOffset: number, maxScroll: number) {
+  if (maxScroll <= 0) return ""
+  if (topOffset <= 0) return "top"
+  if (topOffset >= maxScroll) return "end"
+  return `${Math.round((topOffset / maxScroll) * 100)}%`
 }
 
 function phaseMetaChunks(phase: PhaseState, now: number): TextChunk[] {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -50,6 +50,8 @@ import type {
   PermissionReply,
   ProgressAttempt,
   ProgressDiffSummary,
+  HumanReviewAction,
+  HumanReviewPromptInfo,
   ProgressMessage,
   ProgressMessageChannel,
   ProgressPhase,
@@ -150,6 +152,11 @@ type PendingPermission = {
   resolve: (reply: PermissionReply) => void
 }
 
+type PendingHumanReview = {
+  info: HumanReviewPromptInfo
+  resolve: (action: HumanReviewAction) => void
+}
+
 // The post-run screen keeps the very same dashboard: the pipeline is still the
 // phase selector and the content panel still carries its logs/reports/session
 // tabs. Only the run is over, so it becomes frozen-in-time browsing.
@@ -225,6 +232,7 @@ export class TuiProgress implements ProgressUI {
   // Panels repainted when the terminal reports a theme change mid-run.
   private readonly paletteTargets: Array<{ box: BoxRenderable; background: PaletteColor; border?: PaletteColor }> = []
   private readonly permissionQueue: PendingPermission[] = []
+  private humanReview?: PendingHumanReview
   private permissionChoice = 0
   // Suspension nests: outer scopes (human-review gate) and inner prompts may
   // both suspend; only the outermost transition touches the renderer.
@@ -284,6 +292,7 @@ export class TuiProgress implements ProgressUI {
       this.handlePermissionKey(key)
       return
     }
+    if (this.humanReview && this.handleHumanReviewKey(key)) return
     // Everything else is navigation, shared by the live dashboard and the
     // finish screen: move the focused phase, switch the content tab, scroll a
     // report, or open the external session.
@@ -786,6 +795,17 @@ export class TuiProgress implements ProgressUI {
     })
   }
 
+  askHumanReview(info: HumanReviewPromptInfo): Promise<HumanReviewAction> {
+    if (this.renderer.isDestroyed) return Promise.resolve("abort")
+    return new Promise((resolve) => {
+      this.humanReview = { info, resolve }
+      this.selectPhaseByName(info.stepName)
+      this.manualFocus = false
+      this.addEvent(info.stepName, "permission", "waiting for human review action")
+      this.render()
+    })
+  }
+
   // Resolves when the user dismisses the screen (q/esc/ctrl+c). Until then the
   // run stays alive upstream: the opencode server keeps serving [o] and the
   // run dir keeps the reports readable.
@@ -928,6 +948,8 @@ export class TuiProgress implements ProgressUI {
     // A shutdown signal can tear the run down while the finish screen is still
     // up; resolving here keeps that promise from leaking.
     this.finished?.resolve()
+    this.humanReview?.resolve("abort")
+    this.humanReview = undefined
     for (const pending of this.permissionQueue.splice(0)) pending.resolve("reject")
     if (this.renderer.isDestroyed) return
     this.renderer.destroy()
@@ -1018,6 +1040,24 @@ export class TuiProgress implements ProgressUI {
     const verdict = reply === "once" ? "allowed once" : reply === "always" ? "always allowed" : "rejected"
     this.addEvent("archer", "permission", `${verdict}: ${permissionSummary(pending.info)}`)
     pending.resolve(reply)
+    this.render()
+  }
+
+  private handleHumanReviewKey(key: KeyEvent) {
+    const action = humanReviewActionForKey(key)
+    if (!action) return false
+    key.preventDefault()
+    key.stopPropagation()
+    this.resolveHumanReview(action)
+    return true
+  }
+
+  private resolveHumanReview(action: HumanReviewAction) {
+    const pending = this.humanReview
+    if (!pending) return
+    this.humanReview = undefined
+    this.addEvent(pending.info.stepName, action === "prepare" ? "step" : action === "abort" ? "error" : "permission", humanReviewActionLabel(action))
+    pending.resolve(action)
     this.render()
   }
 
@@ -1422,6 +1462,15 @@ export class TuiProgress implements ProgressUI {
     if (this.finished?.error && phase.status === "failed") {
       out.push(t`${fg(theme.red)(truncate(this.finished.error, Math.max(20, width)))}`)
     }
+    if (this.humanReview?.info.stepName === phase.name) {
+      out.push(plain(""))
+      out.push(new StyledText([fg(theme.yellow)("human review"), fg(theme.faint)(" · choose from the dashboard shortcuts")]))
+      out.push(new StyledText([fg(theme.accent)("c"), fg(theme.dim)(" continue pipeline   "), fg(theme.accent)("s"), fg(theme.dim)(" start app   "), fg(theme.accent)("r"), fg(theme.dim)(" rerun app")]))
+      out.push(new StyledText([fg(theme.accent)("i"), fg(theme.dim)(" open OpenCode iteration   "), fg(theme.accent)("a"), fg(theme.dim)(" abort")]))
+      const info = this.humanReview.info
+      const app = info.appCommand ? (info.appRunning ? "running" : "configured") : "disabled"
+      out.push(new StyledText([fg(theme.faint)("app "), fg(theme.dim)(app), fg(theme.faint)(" · iterations "), fg(theme.dim)(String(info.iterations))]))
+    }
     return out
   }
 
@@ -1604,6 +1653,24 @@ export class TuiProgress implements ProgressUI {
       return padBetween(left, right, width)
     }
 
+    if (this.humanReview) {
+      const left: TextChunk[] = [
+        fg(theme.yellow)("human review · "),
+        fg(theme.accent)("c"),
+        fg(theme.dim)(" continue · "),
+        fg(theme.accent)("s"),
+        fg(theme.dim)(" start app · "),
+        fg(theme.accent)("r"),
+        fg(theme.dim)(" rerun app · "),
+        fg(theme.accent)("i"),
+        fg(theme.dim)(" iterate · "),
+        fg(theme.accent)("a"),
+        fg(theme.dim)(" abort"),
+      ]
+      const right: TextChunk[] = [fg(theme.faint)(this.humanReview.info.appRunning ? "app running" : this.humanReview.info.appCommand ? "app configured" : "app disabled")]
+      return padBetween(left, right, width)
+    }
+
     const left: TextChunk[] = [
       fg(theme.dim)("["),
       fg(theme.accent)("↑↓"),
@@ -1689,6 +1756,37 @@ function statusWordChunk(phase: PhaseState, now: number): TextChunk {
       return fg(theme.faint)("skipped")
     default:
       return fg(theme.faint)("scheduled")
+  }
+}
+
+function humanReviewActionForKey(key: KeyEvent): HumanReviewAction | undefined {
+  switch (key.name) {
+    case "c":
+      return "continue"
+    case "s":
+      return "prepare"
+    case "r":
+      return "rerun"
+    case "i":
+      return "iterate"
+    case "a":
+      return "abort"
+  }
+  return undefined
+}
+
+function humanReviewActionLabel(action: HumanReviewAction) {
+  switch (action) {
+    case "continue":
+      return "human review: continue"
+    case "prepare":
+      return "human review: start app"
+    case "rerun":
+      return "human review: rerun app"
+    case "iterate":
+      return "human review: open OpenCode iteration"
+    case "abort":
+      return "human review: abort"
   }
 }
 

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { addWorktree, ensureRepoReady, findSuspiciousStagedFiles } from "../src/git"
+import { addWorktree, ensureRepoReady, findSuspiciousStagedFiles, initializeRepoWithInitialCommit, repoBootstrapStatus } from "../src/git"
 
 describe("findSuspiciousStagedFiles", () => {
   test("flags common secret filenames", () => {
@@ -85,6 +85,81 @@ describe("ensureRepoReady", () => {
   test("allowDirty defers the dirty-tree decision so resume can recover", async () => {
     const dir = await dirtyRepo()
     await expect(ensureRepoReady(dir, { allowDirty: true })).resolves.toBeUndefined()
+  })
+})
+
+describe("initializeRepoWithInitialCommit", () => {
+  const dirs: string[] = []
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  async function tmpRepoDir() {
+    const dir = await mkdtemp(join(tmpdir(), "archer-init-repo-"))
+    dirs.push(dir)
+    return dir
+  }
+
+  async function gitOutput(args: string[], cwd: string) {
+    const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe", env: process.env })
+    const stdout = await new Response(proc.stdout).text()
+    const stderr = await new Response(proc.stderr).text()
+    const exitCode = await proc.exited
+    if (exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${stderr}`)
+    return stdout.trim()
+  }
+
+  test("detects a directory without a git repository", async () => {
+    const dir = await tmpRepoDir()
+    expect(await repoBootstrapStatus(dir)).toBe("no-repo")
+  })
+
+  test("initializes a new repository with an empty initial commit", async () => {
+    const dir = await tmpRepoDir()
+
+    await initializeRepoWithInitialCommit(dir, { baseRef: "main" })
+
+    expect(await repoBootstrapStatus(dir)).toBe("ready")
+    expect(await gitOutput(["branch", "--show-current"], dir)).toBe("main")
+    expect(await gitOutput(["log", "-1", "--format=%s"], dir)).toBe("archer: initial commit")
+    await expect(ensureRepoReady(dir, { baseRef: "main" })).resolves.toBeUndefined()
+  })
+
+  test("includes existing project files in the initial commit", async () => {
+    const dir = await tmpRepoDir()
+    await writeFile(join(dir, "README.md"), "hello\n")
+
+    await initializeRepoWithInitialCommit(dir, { baseRef: "main" })
+
+    expect(await gitOutput(["show", "--format=", "--name-only", "HEAD"], dir)).toBe("README.md")
+    expect(await gitOutput(["status", "--porcelain"], dir)).toBe("")
+  })
+
+  test("creates an initial commit for a repository with no commits", async () => {
+    const dir = await tmpRepoDir()
+    await gitOutput(["init", "-q", "-b", "main"], dir)
+
+    expect(await repoBootstrapStatus(dir)).toBe("no-commits")
+    await initializeRepoWithInitialCommit(dir, { baseRef: "main" })
+    expect(await repoBootstrapStatus(dir)).toBe("ready")
+  })
+
+  test("creates the initial commit on the requested base branch", async () => {
+    const dir = await tmpRepoDir()
+    await gitOutput(["init", "-q", "-b", "master"], dir)
+
+    await initializeRepoWithInitialCommit(dir, { baseRef: "main" })
+
+    expect(await gitOutput(["branch", "--show-current"], dir)).toBe("main")
+    await expect(ensureRepoReady(dir, { baseRef: "main" })).resolves.toBeUndefined()
+  })
+
+  test("refuses to create an initial commit with likely secrets", async () => {
+    const dir = await tmpRepoDir()
+    await writeFile(join(dir, ".env"), "TOKEN=secret\n")
+
+    await expect(initializeRepoWithInitialCommit(dir, { baseRef: "main" })).rejects.toThrow(/look like secrets/)
+    expect(await repoBootstrapStatus(dir)).toBe("no-commits")
   })
 })
 

--- a/test/human.test.ts
+++ b/test/human.test.ts
@@ -1,0 +1,96 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { runHumanReviewGate } from "../src/human"
+import { noopProgress, type HumanReviewAction, type HumanReviewPromptInfo, type ProgressUI } from "../src/progress"
+
+import type { RunOptions } from "../src/types"
+import type { Workspace } from "../src/workspace"
+
+const dirs: string[] = []
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function git(args: string[], cwd: string) {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t", GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t" },
+  })
+  const [stderr, code] = await Promise.all([new Response(proc.stderr).text(), proc.exited])
+  if (code !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`)
+}
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "archer-human-review-"))
+  dirs.push(root)
+  const targetDir = join(root, "repo")
+  const runDir = join(root, "run")
+  await mkdir(targetDir)
+  await mkdir(runDir)
+  await git(["init", "-q"], targetDir)
+  await writeFile(join(targetDir, "README.md"), "base\n")
+  await git(["add", "-A"], targetDir)
+  await git(["commit", "-qm", "base"], targetDir)
+  return {
+    workspace: { dir: runDir, runID: "20260708-120000-test" } as Workspace,
+    options: {
+      humanReview: true,
+      targetDir,
+      resumeRunID: "",
+      appRunCommand: "",
+      emulatorID: "",
+      interactiveModel: "openai/gpt-5.5",
+      interactiveVariant: "",
+    } as RunOptions,
+  }
+}
+
+function progressWithActions(actions: HumanReviewAction[]) {
+  const calls = { suspend: 0, resume: 0, completed: 0, activities: [] as string[], prompts: [] as HumanReviewPromptInfo[] }
+  const progress: ProgressUI = {
+    ...noopProgress,
+    suspend: () => void calls.suspend++, 
+    resume: () => void calls.resume++,
+    phaseCompleted: () => void calls.completed++,
+    phaseActivity: (_name, detail) => void calls.activities.push(detail),
+    askHumanReview: (info) => {
+      calls.prompts.push(info)
+      return Promise.resolve(actions.shift() ?? "continue")
+    },
+  }
+  return { calls, progress }
+}
+
+describe("runHumanReviewGate", () => {
+  test("keeps human review inside the TUI when askHumanReview is available", async () => {
+    const { workspace, options } = await fixture()
+    const { calls, progress } = progressWithActions(["continue"])
+
+    await runHumanReviewGate(workspace, options, "http://127.0.0.1:1234", progress)
+
+    expect(calls.suspend).toBe(0)
+    expect(calls.resume).toBe(0)
+    expect(calls.completed).toBe(1)
+    expect(calls.prompts).toHaveLength(1)
+    expect(calls.prompts[0]).toMatchObject({ stepName: "human-review", appRunning: false, appCommand: "" })
+    await expect(readFile(join(workspace.dir, "reports", "human-review.md"), "utf8")).resolves.toContain("- Result: approved")
+  })
+
+  test("handles start-app from the TUI without inheriting terminal output", async () => {
+    const { workspace, options } = await fixture()
+    const { calls, progress } = progressWithActions(["prepare", "continue"])
+
+    await runHumanReviewGate(workspace, options, "http://127.0.0.1:1234", progress)
+
+    expect(calls.suspend).toBe(0)
+    expect(calls.prompts).toHaveLength(2)
+    expect(calls.activities).toContain("app launch disabled; start it manually")
+    await expect(readFile(join(workspace.dir, "reports", "human-review.md"), "utf8")).resolves.toContain("- Result: approved")
+  })
+})

--- a/test/human.test.ts
+++ b/test/human.test.ts
@@ -52,10 +52,16 @@ async function fixture() {
 }
 
 function progressWithActions(actions: HumanReviewAction[]) {
-  const calls = { suspend: 0, resume: 0, completed: 0, activities: [] as string[], prompts: [] as HumanReviewPromptInfo[] }
+  const calls = {
+    suspend: 0,
+    resume: 0,
+    completed: 0,
+    activities: [] as string[],
+    prompts: [] as HumanReviewPromptInfo[],
+  }
   const progress: ProgressUI = {
     ...noopProgress,
-    suspend: () => void calls.suspend++, 
+    suspend: () => void calls.suspend++,
     resume: () => void calls.resume++,
     phaseCompleted: () => void calls.completed++,
     phaseActivity: (_name, detail) => void calls.activities.push(detail),
@@ -92,5 +98,80 @@ describe("runHumanReviewGate", () => {
     expect(calls.prompts).toHaveLength(2)
     expect(calls.activities).toContain("app launch disabled; start it manually")
     await expect(readFile(join(workspace.dir, "reports", "human-review.md"), "utf8")).resolves.toContain("- Result: approved")
+  })
+
+  test("pauses the permission gate while an external TUI iteration is active", async () => {
+    const { workspace, options } = await fixture()
+    let paused = false
+    const events: string[] = []
+    const { calls, progress } = progressWithActions(["iterate", "continue"])
+    const originalAsk = progress.askHumanReview!
+    const pausedAtPrompt: boolean[] = []
+    progress.askHumanReview = (info) => {
+      pausedAtPrompt.push(paused)
+      return originalAsk(info)
+    }
+
+    await runHumanReviewGate(
+      workspace,
+      options,
+      "http://127.0.0.1:1234",
+      progress,
+      {
+        stop: async () => {},
+        pause: () => {
+          paused = true
+          events.push("pause")
+        },
+        resume: () => {
+          paused = false
+          events.push("resume")
+        },
+      },
+      "human-review",
+      {
+        openInteractiveOpencodeWindow: async () => "terminal",
+        runInteractiveOpencode: async () => {},
+      },
+    )
+
+    expect(events).toEqual(["pause", "resume"])
+    expect(pausedAtPrompt).toEqual([false, true])
+    expect(calls.activities).toContain("OpenCode iteration opened in terminal; return here and press c to continue")
+    await expect(readFile(join(workspace.dir, "reports", "human-review.md"), "utf8")).resolves.toContain("- Manual OpenCode iterations: 1")
+  })
+
+  test("falls back to suspended same-terminal iteration when the TUI window cannot open", async () => {
+    const { workspace, options } = await fixture()
+    const events: string[] = []
+    let interactiveRuns = 0
+    const { calls, progress } = progressWithActions(["iterate", "continue"])
+
+    await runHumanReviewGate(
+      workspace,
+      options,
+      "http://127.0.0.1:1234",
+      progress,
+      {
+        stop: async () => {},
+        pause: () => void events.push("pause"),
+        resume: () => void events.push("resume"),
+      },
+      "human-review",
+      {
+        openInteractiveOpencodeWindow: async () => {
+          throw new Error("unsupported platform")
+        },
+        runInteractiveOpencode: async () => void interactiveRuns++,
+      },
+    )
+
+    expect(interactiveRuns).toBe(1)
+    expect(calls.suspend).toBe(1)
+    expect(calls.resume).toBe(1)
+    expect(events).toEqual(["pause", "resume", "pause", "resume"])
+    expect(calls.activities).toContain("couldn't open OpenCode iteration: unsupported platform")
+    expect(calls.activities).toContain("falling back to interactive OpenCode in this terminal")
+    await expect(readFile(join(workspace.dir, "reports", "human-review.md"), "utf8")).resolves.toContain("- Manual OpenCode iterations: 1")
   })
 })

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { cursorPosition, sanitizePaste, typedText, wrapPromptLines } from "../src/launch-tui"
+import { cursorPosition, promptEnterAction, sanitizePaste, typedText, wrapPromptLines } from "../src/launch-tui"
 
 import type { KeyEvent } from "@opentui/core"
 
@@ -37,5 +37,12 @@ describe("launch TUI prompt input", () => {
     expect(typedText(key({ name: "", raw: "pasted text" }))).toBe("pasted text")
     expect(typedText(key({ name: "left", raw: "\u001b[D" }))).toBeUndefined()
     expect(typedText(key({ name: "v", raw: "v", ctrl: true }))).toBeUndefined()
+  })
+
+  test("uses Shift+Enter for prompt new-lines and Enter for continuing", () => {
+    expect(promptEnterAction(key({ name: "return" }))).toBe("submit")
+    expect(promptEnterAction(key({ name: "linefeed" }))).toBe("submit")
+    expect(promptEnterAction(key({ name: "return", shift: true }))).toBe("newline")
+    expect(promptEnterAction(key({ name: "a" }))).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- Improve the interactive prompt editor cursor rendering and add Shift+Enter multiline input.
- Add an interactive Git bootstrap flow that initializes repositories or creates an initial commit without aborting the launcher.
- Keep human-review gates inside the TUI with single-key actions for continue, start/rerun app, iterate, and abort.
- Add an explicit dashboard reading focus: Enter moves focus from the pipeline to the session/reports/logs panel, arrow keys scroll, and Escape returns to pipeline navigation.
- Highlight the active TUI panel border in both the dashboard and interactive launcher so users can see where keyboard input applies.

## Testing
- bun run typecheck
- bun test