### PR TITLE
feat(tui): copy selected session and report text

### DIFF
--- a/src/tui.ts
+++ b/src/tui.ts
@@ -354,7 +354,7 @@ export class TuiProgress implements ProgressUI {
   }
 
   private readonly handleSelection = (selection: Selection) => {
-    if (this.contentTab !== "session" && this.contentTab !== "reports") return
+    if (this.contentTab !== "logs" && this.contentTab !== "session" && this.contentTab !== "reports") return
     const { x, y, width, height } = selection.bounds
     if (
       x < this.feedText.x ||

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -92,6 +92,7 @@ function kindStyle(kind: ActivityKind): { icon: string; color: string } {
 
 const pipelineWidth = 32
 const feedLimit = 100
+const contentTabBarRows = 2
 
 type RunnerSessionContext = {
   targetDir: string
@@ -358,7 +359,7 @@ export class TuiProgress implements ProgressUI {
     if (
       x < this.feedText.x ||
       x + width > this.feedText.x + this.feedText.width ||
-      y < this.feedText.y + 2 ||
+      y < this.feedText.y + contentTabBarRows ||
       y + height > this.feedText.y + this.feedText.height
     ) {
       return
@@ -687,7 +688,7 @@ export class TuiProgress implements ProgressUI {
     // Works live and on the finish screen alike.
     const switchTabFromFeed = (event: { x: number; y: number; preventDefault(): void; stopPropagation(): void }) => {
       const row = event.y - this.feedText.y
-      if (row !== 0 && row !== 1) return
+      if (row < 0 || row >= contentTabBarRows) return
       const col = event.x - this.feedText.x
       const hit = this.feedTabRegions.find((region) => col >= region.start && col < region.end)
       if (!hit) return
@@ -1602,7 +1603,7 @@ export class TuiProgress implements ProgressUI {
     // The content panel fills the rest: a two-row tab strip (labels, then a
     // rail) over the active tab's body, all scoped to the focused phase.
     const feedRows = Math.max(3, bodyHeight - usedHeight - 2)
-    const contentRows = feedRows - 2
+    const contentRows = feedRows - contentTabBarRows
     this.contentPageRows = contentRows
 
     this.dirText.content = this.dirContent(innerWidth)

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -45,7 +45,7 @@ import {
   wrapLines,
 } from "./tui-theme"
 
-import type { BoxOptions, CliRenderer, KeyEvent, TextChunk } from "@opentui/core"
+import type { BoxOptions, CliRenderer, KeyEvent, Selection, TextChunk } from "@opentui/core"
 import type { LimitsSnapshot } from "./limits"
 import type { PaletteColor, PhaseStatus } from "./tui-theme"
 import type {
@@ -350,6 +350,23 @@ export class TuiProgress implements ProgressUI {
     this.applyPalette()
     this.addEvent("convoy", "system", `terminal theme changed: ${mode}`)
     this.render()
+  }
+
+  private readonly handleSelection = (selection: Selection) => {
+    if (this.contentTab !== "session" && this.contentTab !== "reports") return
+    const { x, y, width, height } = selection.bounds
+    if (
+      x < this.feedText.x ||
+      x + width > this.feedText.x + this.feedText.width ||
+      y < this.feedText.y + 2 ||
+      y + height > this.feedText.y + this.feedText.height
+    ) {
+      return
+    }
+    if (selection.selectedRenderables.length !== 1 || selection.selectedRenderables[0] !== this.feedText) return
+
+    const text = selection.getSelectedText()
+    if (text && this.renderer.copyToClipboardOSC52(text)) this.renderer.clearSelection()
   }
 
   private readonly handleKeyPress = (key: KeyEvent) => {
@@ -780,6 +797,7 @@ export class TuiProgress implements ProgressUI {
     this.paletteTargets.push({ box: this.modal, background: "overlay", border: "yellow" })
 
     renderer.keyInput.on("keypress", this.handleKeyPress)
+    renderer.on("selection", this.handleSelection)
     renderer.on("theme_mode", this.handleThemeMode)
 
     this.ticker = setInterval(() => this.render(), 250)
@@ -1226,6 +1244,7 @@ export class TuiProgress implements ProgressUI {
     this.stopLimits()
     log.mute(false)
     this.renderer.keyInput.off("keypress", this.handleKeyPress)
+    this.renderer.off("selection", this.handleSelection)
     this.renderer.off("theme_mode", this.handleThemeMode)
     // A shutdown signal can tear the run down while the finish screen is still
     // up; resolving here keeps that promise from leaking.

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -145,6 +145,49 @@ describe("dashboard content selection", () => {
     }
   })
 
+  test("does not copy selections that include another renderable", async () => {
+    const { dashboard, renderer, renderOnce, copied } = await createDashboard()
+    try {
+      dashboard.phaseStarted("implement")
+      dashboard.phaseMessage("implement", { channel: "response", text: "session selection payload" })
+      await renderOnce()
+
+      const feedText = (dashboard as unknown as DashboardInternals).feedText
+      renderer.emit("selection", {
+        bounds: { x: feedText.x, y: feedText.y + 2, width: 1, height: 1 },
+        selectedRenderables: [feedText, {}],
+        getSelectedText: () => "mixed selection",
+      } as unknown as Selection)
+
+      expect(copied).toEqual([])
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("retains the selection when OSC52 copying is unavailable", async () => {
+    const { dashboard, mockMouse, renderer, renderOnce } = await createDashboard()
+    try {
+      const text = "uncopied session selection"
+      const failedCopies: string[] = []
+      renderer.copyToClipboardOSC52 = (selectedText) => {
+        failedCopies.push(selectedText)
+        return false
+      }
+      dashboard.phaseStarted("implement")
+      dashboard.phaseMessage("implement", { channel: "response", text })
+      dashboard.phaseActivity("implement", "session ready")
+      await renderOnce()
+
+      await selectText(dashboard, mockMouse, text)
+
+      expect(failedCopies).toEqual([text])
+      expect(renderer.hasSelection).toBeTrue()
+    } finally {
+      dashboard.stop()
+    }
+  })
+
   test("removes its selection listener when stopped", async () => {
     const { dashboard, renderer } = await createDashboard()
     try {

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -116,7 +116,24 @@ describe("dashboard content selection", () => {
     }
   })
 
-  test("does not copy logs, tab-strip, empty, or cross-panel selections", async () => {
+  test("copies selected log text", async () => {
+    const { dashboard, mockMouse, renderOnce, copied } = await createDashboard()
+    try {
+      const text = "Next command: /mr-comment 20260717-122207-c4cn 90"
+      const internals = dashboard as unknown as DashboardInternals
+      internals.contentTab = "logs"
+      dashboard.phaseActivity("implement", text)
+      await renderOnce()
+
+      await selectText(dashboard, mockMouse, text)
+
+      expect(copied).toEqual([text])
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("does not copy tab-strip, empty, or cross-panel selections", async () => {
     const { dashboard, mockMouse, renderer, renderOnce, copied } = await createDashboard()
     try {
       const sessionText = "session selection payload"
@@ -133,11 +150,6 @@ describe("dashboard content selection", () => {
         selectedRenderables: [feedText],
         getSelectedText: () => "",
       } as unknown as Selection)
-
-      ;(dashboard as unknown as DashboardInternals).contentTab = "logs"
-      dashboard.phaseActivity("implement", "log selection payload")
-      await renderOnce()
-      await selectText(dashboard, mockMouse, "log selection payload")
 
       expect(copied).toEqual([])
     } finally {

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -1,10 +1,47 @@
 import { describe, expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+import type { Selection } from "@opentui/core"
 
-import { autoFollowGroup, comparisonColumnCount, initialContentTab, iteratePrompt, phaseCapabilityBadges, phaseCapabilityLabel, pickBadge, pipelineSelectionTargets } from "../src/tui"
+import { TuiProgress, autoFollowGroup, comparisonColumnCount, initialContentTab, iteratePrompt, phaseCapabilityBadges, phaseCapabilityLabel, pickBadge, pipelineSelectionTargets } from "../src/tui"
 import { limitsRow } from "../src/tui-theme"
 
 import type { LimitsSnapshot } from "../src/limits"
 import type { ProgressPhase } from "../src/progress"
+
+type DashboardInternals = {
+  feedText: { x: number; y: number; plainText: string }
+  reports: Map<string, string[] | "loading" | "missing">
+  contentTab: "session" | "reports" | "logs"
+}
+
+async function createDashboard() {
+  const testRenderer = await createTestRenderer({ width: 120, height: 40 })
+  const dashboard = new TuiProgress(testRenderer.renderer, [{ name: "implement", description: "" }])
+  const copied: string[] = []
+  testRenderer.renderer.copyToClipboardOSC52 = (text) => {
+    copied.push(text)
+    return true
+  }
+  return { ...testRenderer, dashboard, copied }
+}
+
+async function selectText(
+  dashboard: TuiProgress,
+  mockMouse: Awaited<ReturnType<typeof createTestRenderer>>["mockMouse"],
+  text: string,
+) {
+  const feedText = (dashboard as unknown as DashboardInternals).feedText
+  const lines = feedText.plainText.split("\n")
+  const row = lines.findIndex((line) => line.includes(text))
+  expect(row).toBeGreaterThanOrEqual(2)
+  const column = lines[row]!.indexOf(text)
+  await mockMouse.drag(
+    feedText.x + column,
+    feedText.y + row,
+    feedText.x + column + text.length,
+    feedText.y + row,
+  )
+}
 
 describe("run dashboard defaults", () => {
   test("starts live runs on session and historical runs on reports, never logs", () => {
@@ -38,6 +75,87 @@ describe("run dashboard defaults", () => {
 
     // A writable phase never grows a badge, however much room there is.
     expect(pickBadge(phaseCapabilityBadges({}), 40, false)).toBeUndefined()
+  })
+})
+
+describe("dashboard content selection", () => {
+  test("copies selected session text and clears the successful selection", async () => {
+    const { dashboard, mockMouse, renderer, renderOnce, copied } = await createDashboard()
+    try {
+      const text = "session selection payload"
+      dashboard.phaseStarted("implement")
+      dashboard.phaseMessage("implement", { channel: "response", text })
+      dashboard.phaseActivity("implement", "session ready")
+      await renderOnce()
+
+      await selectText(dashboard, mockMouse, text)
+
+      expect(copied).toEqual([text])
+      expect(renderer.hasSelection).toBeFalse()
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("copies selected report text", async () => {
+    const { dashboard, mockMouse, renderOnce, copied } = await createDashboard()
+    try {
+      const text = "report selection payload"
+      const internals = dashboard as unknown as DashboardInternals
+      dashboard.start("run", "/target", "/run")
+      internals.reports.set("implement", [text])
+      internals.contentTab = "reports"
+      dashboard.phaseActivity("implement", "report ready")
+      await renderOnce()
+
+      await selectText(dashboard, mockMouse, text)
+
+      expect(copied).toEqual([text])
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("does not copy logs, tab-strip, empty, or cross-panel selections", async () => {
+    const { dashboard, mockMouse, renderer, renderOnce, copied } = await createDashboard()
+    try {
+      const sessionText = "session selection payload"
+      dashboard.phaseStarted("implement")
+      dashboard.phaseMessage("implement", { channel: "response", text: sessionText })
+      dashboard.phaseActivity("implement", "session ready")
+      await renderOnce()
+
+      const feedText = (dashboard as unknown as DashboardInternals).feedText
+      await mockMouse.drag(feedText.x, feedText.y, feedText.x + 3, feedText.y)
+      await mockMouse.drag(feedText.x, feedText.y + 2, feedText.x - 10, feedText.y + 2)
+      renderer.emit("selection", {
+        bounds: { x: feedText.x, y: feedText.y + 2, width: 0, height: 0 },
+        selectedRenderables: [feedText],
+        getSelectedText: () => "",
+      } as unknown as Selection)
+
+      ;(dashboard as unknown as DashboardInternals).contentTab = "logs"
+      dashboard.phaseActivity("implement", "log selection payload")
+      await renderOnce()
+      await selectText(dashboard, mockMouse, "log selection payload")
+
+      expect(copied).toEqual([])
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("removes its selection listener when stopped", async () => {
+    const { dashboard, renderer } = await createDashboard()
+    try {
+      expect(renderer.listenerCount("selection")).toBe(1)
+
+      dashboard.stop()
+
+      expect(renderer.listenerCount("selection")).toBe(0)
+    } finally {
+      if (!renderer.isDestroyed) dashboard.stop()
+    }
   })
 })
 

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createTestRenderer } from "@opentui/core/testing"
 import type { Selection } from "@opentui/core"
 
-import { TuiProgress, autoFollowGroup, comparisonColumnCount, initialContentTab, iteratePrompt, phaseCapabilityBadges, phaseCapabilityLabel, pickBadge, pipelineSelectionTargets } from "../src/tui"
+import { TuiProgress, autoFollowGroup, comparisonColumnCount, initialContentTab, iteratePrompt, phaseCapabilityBadges, phaseCapabilityLabel, pickBadge, pipelineSelectionTargets, type ContentTab } from "../src/tui"
 import { limitsRow } from "../src/tui-theme"
 
 import type { LimitsSnapshot } from "../src/limits"
@@ -11,7 +11,7 @@ import type { ProgressPhase } from "../src/progress"
 type DashboardInternals = {
   feedText: { x: number; y: number; plainText: string }
   reports: Map<string, string[] | "loading" | "missing">
-  contentTab: "session" | "reports" | "logs"
+  contentTab: ContentTab
 }
 
 async function createDashboard() {


### PR DESCRIPTION
## Summary

- automatically copy completed text selections from the logs, session, and reports tabs via OSC52
- ignore the tab strip, empty selections, and selections spanning other renderables
- retain the selection when OSC52 is unavailable and clean up the renderer listener on shutdown

## Verification

- `bun test test/tui.test.ts`
- `bun test`
- `bun run typecheck`
- `bun run build`