### PR TITLE
feat: add interchangeable model gateways and run plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,3 +459,32 @@ convoy/
 ├── tsconfig.json
 └── Makefile
 ```
+# Model gateways and run review
+
+Convoy can change how every OpenCode model is reached without rewriting a pipeline:
+
+```sh
+convoy "Implement the feature" --gateway direct
+convoy "Implement the feature" --gateway openrouter
+convoy "Implement the feature" --gateway vercel
+convoy "Implement the feature" --gateway configured
+```
+
+`configured` (the default) preserves model IDs literally. `direct` uses the model owner's provider; `openrouter` and `vercel` wrap the logical provider/model. Claude Code steps are never rerouted. A `--model` selects the logical model first, then the gateway is applied.
+
+Persist the choice globally in `~/.convoy/config.yaml` or per project in `.convoy/config.yaml` (CLI > project > global > configured):
+
+```yaml
+version: 1
+modelRouting:
+  gateway: vercel
+  overrides:
+    zai/glm-5.2:
+      direct: zai/glm-5.2
+      openrouter: openrouter/z-ai/glm-5.2
+      vercel: vercel/zai/glm-5.2
+```
+
+Unknown model namespaces require an explicit override when rerouting; `configured` always remains literal. Authenticate Vercel through `opencode providers login` (choose Vercel AI Gateway) or set `AI_GATEWAY_API_KEY`; Convoy never stores gateway credentials.
+
+Every interactive manual run now displays its fully resolved plan before repository effects. `--plan` prints that plan and exits without creating a run, running hooks, or starting OpenCode. `--no-confirm` prints a compact plan and starts immediately. Non-TTY environments continue automatically after the compact summary.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This leaves `convoy` in `~/.local/bin/convoy` and creates `~/.convoy/config.yaml
 From the root of the target repo, ideally on a working branch:
 
 ```bash
-# interactive launcher: choose a pipeline, enter the prompt, then toggle options
+# interactive launcher: choose a pipeline, enter the prompt, set options, then review
 convoy
 
 # inline prompt
@@ -487,4 +487,4 @@ modelRouting:
 
 Unknown model namespaces require an explicit override when rerouting; `configured` always remains literal. Authenticate Vercel through `opencode providers login` (choose Vercel AI Gateway) or set `AI_GATEWAY_API_KEY`; Convoy never stores gateway credentials.
 
-Every interactive manual run now displays its fully resolved plan before repository effects. `--plan` prints that plan and exits without creating a run, running hooks, or starting OpenCode. `--no-confirm` prints a compact plan and starts immediately. Non-TTY environments continue automatically after the compact summary.
+Every interactive manual run now displays its fully resolved plan before repository effects. The launcher has a native **Review** step after Options: use Enter or `s` to start, Escape to return to Options, `q` to cancel, arrow/page keys or the mouse wheel to scroll, and `p` to expand the complete prompt. `--plan` prints that plan and exits without creating a run, running hooks, or starting OpenCode. `--no-confirm` prints a compact plan and starts immediately. Non-TTY environments continue automatically after the compact summary.

--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ convoy/
 ├── tsconfig.json
 └── Makefile
 ```
-# Model gateways and run review
+## Model gateways and run review
 
 Convoy can change how every OpenCode model is reached without rewriting a pipeline:
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -86,6 +86,7 @@ function providerTimeouts(): Config["provider"] {
     anthropic: { options },
     openai: { options },
     openrouter: { options },
+    vercel: { options },
   }
 }
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -87,6 +87,7 @@ function providerTimeouts(): Config["provider"] {
     openai: { options },
     openrouter: { options },
     vercel: { options },
+    zai: { options },
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -314,6 +314,9 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
       // Legacy/incomplete workspaces retain the empty resume prompt.
     }
   }
+  // Resume filters can only be checked after metadata has restored its frozen
+  // pipeline. Validate them before building a potentially empty review plan.
+  validateStepFilters(options.pipeline, options)
   options.plan = buildRunPlan({ ...options, promptSource: parsed.resumeRunID ? "resume" : parsed.promptFile ? "file" : "inline" })
   return { type: "run", options }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import type { Pipeline, RunOptions } from "./types"
 import { isValidRunID, resumeWorkspace } from "./workspace"
 import { readRunMetadata } from "./metadata"
 import { preflightRunPlan } from "./preflight"
+import type { LaunchRunPreparation, LaunchRunSelection } from "./launch-tui"
 
 /**
  * Flags as written: every scalar stays undefined until the user sets it, so
@@ -125,14 +126,52 @@ async function launchInteractiveRun(targetDir: string) {
   // Imported lazily so normal CLI invocations don't pull in OpenTUI until they
   // explicitly ask for the zero-argument interactive launcher.
   const { launchRunTui } = await import("./launch-tui")
-  const selection = await launchRunTui({ targetDir })
+  const selection = await launchRunTui({
+    targetDir,
+    prepareRun: (runSelection) => prepareInteractiveRun(targetDir, runSelection),
+  })
   if (!selection) return
-  if ("action" in selection) {
-    if (selection.action === "runs") await openRunsBrowser()
-    else await openConfigEditor(targetDir)
+  if (selection.action === "runs") {
+    await openRunsBrowser()
+    return
+  }
+  if (selection.action === "config") {
+    await openConfigEditor(targetDir)
     return
   }
 
+  let options = selection.options
+  const plan = selection.plan
+  const runSelection = selection.selection
+  await preflightRunPlan(plan)
+  if (runSelection.initializeGit) {
+    const { initializeRepoWithInitialCommit } = await import("./git")
+    await initializeRepoWithInitialCommit(targetDir, { baseRef: options.baseRef === "HEAD" ? undefined : options.baseRef })
+  }
+  // Revalidate Git only after the native Review has been accepted. In
+  // particular, validate the source before a worktree can create a branch.
+  const { ensureRepoReady } = await import("./git")
+  await ensureRepoReady(targetDir, {
+    baseRef: options.baseRef,
+    includeDirty: options.includeDirty,
+    maxAttempts: options.maxAttempts,
+    // A fresh worktree starts clean, so source changes are intentionally left
+    // untouched and don't need to be included in this run.
+    allowDirty: Boolean(runSelection.isolateWorktree),
+  })
+  if (runSelection.isolateWorktree) {
+    const { createIsolatedWorktree } = await import("./worktree")
+    const namer = plan.branchNamer?.model.target
+    if (!namer) throw new Error("worktree plan is missing its branch-namer model")
+    const worktree = await createIsolatedWorktree({ targetDir, prompt: runSelection.prompt, model: namer })
+    options = { ...options, targetDir: worktree.dir, includeDirty: false }
+    log.info(`running in isolated worktree (branch: ${worktree.branch})`)
+    log.info(`  dir: ${worktree.dir}`)
+  }
+  await run({ ...options, plan, noConfirm: true })
+}
+
+async function prepareInteractiveRun(targetDir: string, selection: LaunchRunSelection): Promise<LaunchRunPreparation> {
   const parsed = parseArgs([])
   parsed.targetDir = selection.targetDir
   parsed.baseDetectionDir = targetDir
@@ -162,22 +201,7 @@ async function launchInteractiveRun(targetDir: string) {
     worktree: Boolean(selection.isolateWorktree),
     ...(branchNameModel ? { branchNameModel } : {}),
   })
-  if (!(await confirmRunPlan(plan))) return
-  await preflightRunPlan(plan)
-  if (selection.initializeGit) {
-    const { initializeRepoWithInitialCommit } = await import("./git")
-    await initializeRepoWithInitialCommit(targetDir, { baseRef: options.baseRef === "HEAD" ? undefined : options.baseRef })
-  }
-  if (selection.isolateWorktree) {
-    const { createIsolatedWorktree } = await import("./worktree")
-    const namer = plan.branchNamer?.model.target
-    if (!namer) throw new Error("worktree plan is missing its branch-namer model")
-    const worktree = await createIsolatedWorktree({ targetDir, prompt: selection.prompt, model: namer })
-    options = { ...options, targetDir: worktree.dir, includeDirty: false }
-    log.info(`running in isolated worktree (branch: ${worktree.branch})`)
-    log.info(`  dir: ${worktree.dir}`)
-  }
-  await run({ ...options, plan, noConfirm: true })
+  return { options, plan }
 }
 
 async function openRunsBrowser(initialRunID?: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,7 +9,7 @@ import { defaultGptModel, defaultGptVariant, defaultPipeline, defaultPipelineNam
 import { parseModel, run } from "./runner"
 import { buildRunPlan } from "./run-plan"
 import { confirmRunPlan, renderRunPlan } from "./run-review"
-import { isModelGateway, resolveModel, type ModelGateway } from "./model-routing"
+import { isModelGateway, type ModelGateway } from "./model-routing"
 import { browseRuns } from "./runs"
 import { deleteKeychainSecret, keychainAvailable, storeKeychainSecret } from "./secrets"
 import type { Pipeline, RunOptions } from "./types"
@@ -147,13 +147,21 @@ async function launchInteractiveRun(targetDir: string) {
   parsed.gateway = selection.gateway
   if (selection.includeDirty) parsed.maxAttempts = 1
 
-  if (selection.worktree) {
-    log.info(`running in isolated worktree (branch: ${selection.worktree.branch})`)
-    log.info(`  dir: ${selection.worktree.dir}`)
-  }
-
   let options = { ...(await resolveRunOptions(parsed)), prompt: selection.prompt }
-  const plan = buildRunPlan({ ...options, worktree: Boolean(selection.worktree || selection.isolateWorktree) })
+  // Resolve the branch namer before the review so the exact routed target is
+  // part of the confirmed plan; the AI naming call itself stays behind the
+  // confirmation gate.
+  let branchNameModel: string | undefined
+  if (selection.isolateWorktree) {
+    const { defaultBranchNameModel } = await import("./worktree")
+    const config = await loadMergedConvoyConfig(targetDir)
+    branchNameModel = config?.defaults.branchNameModel ?? defaultBranchNameModel
+  }
+  const plan = buildRunPlan({
+    ...options,
+    worktree: Boolean(selection.isolateWorktree),
+    ...(branchNameModel ? { branchNameModel } : {}),
+  })
   if (!(await confirmRunPlan(plan))) return
   await preflightRunPlan(plan)
   if (selection.initializeGit) {
@@ -161,9 +169,9 @@ async function launchInteractiveRun(targetDir: string) {
     await initializeRepoWithInitialCommit(targetDir, { baseRef: options.baseRef === "HEAD" ? undefined : options.baseRef })
   }
   if (selection.isolateWorktree) {
-    const { createIsolatedWorktree, defaultBranchNameModel } = await import("./worktree")
-    const config = await loadMergedConvoyConfig(targetDir)
-    const namer = resolveModel(config?.defaults.branchNameModel ?? defaultBranchNameModel, parsed.gateway ?? "configured", config?.modelRouting?.overrides ?? {}).target
+    const { createIsolatedWorktree } = await import("./worktree")
+    const namer = plan.branchNamer?.model.target
+    if (!namer) throw new Error("worktree plan is missing its branch-namer model")
     const worktree = await createIsolatedWorktree({ targetDir, prompt: selection.prompt, model: namer })
     options = { ...options, targetDir: worktree.dir, includeDirty: false }
     log.info(`running in isolated worktree (branch: ${worktree.branch})`)
@@ -303,11 +311,14 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
   }
 
   const options: RunOptions = { ...(await resolveRunOptions(parsed)), prompt }
+  // The gateway the run froze at launch, for the review's resume-override banner.
+  let resumeGateway: ModelGateway | undefined
   if (parsed.resumeRunID) {
     const workspace = await resumeWorkspace(parsed.resumeRunID)
     const metadata = await readRunMetadata(resolve(workspace.dir, "metadata.json"))
     if (metadata?.pipeline) options.pipeline = metadata.pipeline
     if (parsed.gateway === undefined) options.gateway = metadata?.modelRouting?.gateway ?? "configured"
+    else resumeGateway = metadata?.modelRouting?.gateway ?? "configured"
     try {
       options.prompt = await readFile(resolve(workspace.dir, "prd.md"), "utf8")
     } catch {
@@ -317,7 +328,11 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
   // Resume filters can only be checked after metadata has restored its frozen
   // pipeline. Validate them before building a potentially empty review plan.
   validateStepFilters(options.pipeline, options)
-  options.plan = buildRunPlan({ ...options, promptSource: parsed.resumeRunID ? "resume" : parsed.promptFile ? "file" : "inline" })
+  options.plan = buildRunPlan({
+    ...options,
+    promptSource: parsed.resumeRunID ? "resume" : parsed.promptFile ? "file" : "inline",
+    ...(resumeGateway ? { resumeGateway } : {}),
+  })
   return { type: "run", options }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,10 +7,15 @@ import { openRouterKeySources } from "./limits"
 import { log } from "./log"
 import { defaultGptModel, defaultGptVariant, defaultPipeline, defaultPipelineName, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
 import { parseModel, run } from "./runner"
+import { buildRunPlan } from "./run-plan"
+import { confirmRunPlan, renderRunPlan } from "./run-review"
+import { isModelGateway, resolveModel, type ModelGateway } from "./model-routing"
 import { browseRuns } from "./runs"
 import { deleteKeychainSecret, keychainAvailable, storeKeychainSecret } from "./secrets"
 import type { Pipeline, RunOptions } from "./types"
-import { isValidRunID } from "./workspace"
+import { isValidRunID, resumeWorkspace } from "./workspace"
+import { readRunMetadata } from "./metadata"
+import { preflightRunPlan } from "./preflight"
 
 /**
  * Flags as written: every scalar stays undefined until the user sets it, so
@@ -44,6 +49,9 @@ export type ParsedArgs = {
   yolo?: boolean
   smart?: boolean
   smartModel?: string
+  gateway?: ModelGateway
+  planOnly?: boolean
+  noConfirm?: boolean
 }
 
 export type InitOptions = {
@@ -95,7 +103,22 @@ export async function parseAndRun(argv: string[]) {
     return
   }
 
-  await run(command.options)
+  const plan = command.options.plan ?? buildRunPlan(command.options)
+  if (command.options.planOnly) {
+    process.stdout.write(renderRunPlan(plan))
+    return
+  }
+  const interactive = Boolean(process.stdin.isTTY && process.stdout.isTTY)
+  if (interactive && !command.options.noConfirm) {
+    if (!(await confirmRunPlan(plan))) {
+      log.info("Run cancelled")
+      return
+    }
+  } else {
+    process.stdout.write(renderRunPlan(plan, true))
+  }
+  await preflightRunPlan(plan)
+  await run({ ...command.options, plan })
 }
 
 async function launchInteractiveRun(targetDir: string) {
@@ -121,6 +144,7 @@ async function launchInteractiveRun(targetDir: string) {
   parsed.keepRunDir = selection.keepRunDir
   parsed.yolo = selection.yolo
   parsed.smart = selection.smart
+  parsed.gateway = selection.gateway
   if (selection.includeDirty) parsed.maxAttempts = 1
 
   if (selection.worktree) {
@@ -128,7 +152,24 @@ async function launchInteractiveRun(targetDir: string) {
     log.info(`  dir: ${selection.worktree.dir}`)
   }
 
-  await run({ ...(await resolveRunOptions(parsed)), prompt: selection.prompt })
+  let options = { ...(await resolveRunOptions(parsed)), prompt: selection.prompt }
+  const plan = buildRunPlan({ ...options, worktree: Boolean(selection.worktree || selection.isolateWorktree) })
+  if (!(await confirmRunPlan(plan))) return
+  await preflightRunPlan(plan)
+  if (selection.initializeGit) {
+    const { initializeRepoWithInitialCommit } = await import("./git")
+    await initializeRepoWithInitialCommit(targetDir, { baseRef: options.baseRef === "HEAD" ? undefined : options.baseRef })
+  }
+  if (selection.isolateWorktree) {
+    const { createIsolatedWorktree, defaultBranchNameModel } = await import("./worktree")
+    const config = await loadMergedConvoyConfig(targetDir)
+    const namer = resolveModel(config?.defaults.branchNameModel ?? defaultBranchNameModel, parsed.gateway ?? "configured", config?.modelRouting?.overrides ?? {}).target
+    const worktree = await createIsolatedWorktree({ targetDir, prompt: selection.prompt, model: namer })
+    options = { ...options, targetDir: worktree.dir, includeDirty: false }
+    log.info(`running in isolated worktree (branch: ${worktree.branch})`)
+    log.info(`  dir: ${worktree.dir}`)
+  }
+  await run({ ...options, plan, noConfirm: true })
 }
 
 async function openRunsBrowser(initialRunID?: string) {
@@ -138,7 +179,11 @@ async function openRunsBrowser(initialRunID?: string) {
   for (;;) {
     const resolution = await browseRuns(currentRunID)
     if (resolution.type === "resume") {
-      await run(await resumeOptions(resolution.runID, resolution.targetDir))
+      const options = await resumeOptions(resolution.runID, resolution.targetDir)
+      const plan = options.plan ?? buildRunPlan({ ...options, promptSource: "resume" })
+      if (!(await confirmRunPlan(plan))) return
+      await preflightRunPlan(plan)
+      await run({ ...options, plan })
       return
     }
     if (resolution.type === "open") {
@@ -164,7 +209,18 @@ async function resumeOptions(runID: string, targetDir?: string): Promise<RunOpti
   const parsed = parseArgs([])
   parsed.resumeRunID = runID
   if (targetDir) parsed.targetDir = targetDir
-  return { ...(await resolveRunOptions(parsed)), prompt: "" }
+  const options: RunOptions = { ...(await resolveRunOptions(parsed)), prompt: "" }
+  const workspace = await resumeWorkspace(runID)
+  const metadata = await readRunMetadata(resolve(workspace.dir, "metadata.json"))
+  if (metadata?.pipeline) options.pipeline = metadata.pipeline
+  options.gateway = metadata?.modelRouting?.gateway ?? "configured"
+  try {
+    options.prompt = await readFile(resolve(workspace.dir, "prd.md"), "utf8")
+  } catch {
+    // Legacy/incomplete workspace.
+  }
+  options.plan = buildRunPlan({ ...options, promptSource: "resume" })
+  return options
 }
 
 /**
@@ -246,7 +302,20 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
     throw new Error("need a prompt (positional or --prompt-file) or --resume <id>")
   }
 
-  return { type: "run", options: { ...(await resolveRunOptions(parsed)), prompt } }
+  const options: RunOptions = { ...(await resolveRunOptions(parsed)), prompt }
+  if (parsed.resumeRunID) {
+    const workspace = await resumeWorkspace(parsed.resumeRunID)
+    const metadata = await readRunMetadata(resolve(workspace.dir, "metadata.json"))
+    if (metadata?.pipeline) options.pipeline = metadata.pipeline
+    if (parsed.gateway === undefined) options.gateway = metadata?.modelRouting?.gateway ?? "configured"
+    try {
+      options.prompt = await readFile(resolve(workspace.dir, "prd.md"), "utf8")
+    } catch {
+      // Legacy/incomplete workspaces retain the empty resume prompt.
+    }
+  }
+  options.plan = buildRunPlan({ ...options, promptSource: parsed.resumeRunID ? "resume" : parsed.promptFile ? "file" : "inline" })
+  return { type: "run", options }
 }
 
 type ParsedInitArgs = InitOptions & { help?: boolean }
@@ -351,6 +420,11 @@ export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOpt
     yolo: parsed.yolo ?? false,
     smart: parsed.smart ?? false,
     smartJudgeModel,
+    gateway: parsed.gateway ?? config?.modelRouting?.gateway ?? "configured",
+    gatewayExplicit: parsed.gateway !== undefined,
+    modelRoutingOverrides: config?.modelRouting?.overrides ?? {},
+    planOnly: parsed.planOnly ?? false,
+    noConfirm: parsed.noConfirm ?? false,
     pipeline,
     agents,
     permissions: config?.permissions ?? { allow: [], deny: [] },
@@ -452,6 +526,20 @@ export function parseArgs(argv: string[]): ParsedArgs {
       case "--model":
         parsed.modelOverride = takeValue()
         break
+      case "--gateway": {
+        const gateway = takeValue()
+        if (!isModelGateway(gateway)) throw new Error('--gateway must be "configured", "direct", "openrouter", or "vercel"')
+        parsed.gateway = gateway
+        break
+      }
+      case "--plan":
+        if (value !== undefined) throw new Error("--plan does not take a value")
+        parsed.planOnly = true
+        break
+      case "--no-confirm":
+        if (value !== undefined) throw new Error("--no-confirm does not take a value")
+        parsed.noConfirm = true
+        break
       case "--tui":
         parsed.tui = true
         break
@@ -542,6 +630,9 @@ Flags:
   --smart-model <provider/model[#variant]> Model for the smart auto-accept judge (default: defaults.autoAcceptJudgeModel, else the run's model)
   --include-dirty          Include existing changes in the first commit (requires --max-attempts 1)
   --model <provider/model[#variant]> Force a model for OpenCode steps (Claude Code steps keep their CLI model)
+  --gateway <configured|direct|openrouter|vercel> Route all OpenCode models through the selected gateway
+  --plan                   Print the complete resolved plan without creating or running anything
+  --no-confirm             Show a compact plan and start without the interactive confirmation
   --tui                    Show visual phase progress (default in interactive terminals)
   --no-tui                 Disable visual phase progress
   --human-step             Enable human steps (alias: --human-review; default in interactive terminals)
@@ -557,6 +648,7 @@ Config files:
 
 Config keys:
   defaults:                model, maxAttempts, baseRef, pipeline, autoAcceptJudgeModel, branchNameModel
+  modelRouting:            gateway and explicit per-logical-model overrides
   agents:                  project agents or built-in overrides; prompts live at agents/<name>.md
   pipelines:               named step lists mixing agents and human gates
   permissions:             allow/deny additions to the bash policy (deny always wins)

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -31,6 +31,7 @@ import {
   type PipelineSpec,
   type StepSpec,
 } from "./pipeline"
+import { gatewayLabel } from "./model-routing"
 import { claudeCodeModelAliases, normalizeStepRunnerModel, stepRunnerFor } from "./step-runners"
 import {
   joinLines,
@@ -610,10 +611,10 @@ export class ConfigEditor {
       index: 0,
       options: [
         { value: "", label: "inherit", hint: "clear this scope's override" },
-        { value: "configured", label: "As configured", hint: "preserve pipeline model IDs literally" },
-        { value: "direct", label: "Direct", hint: "use the model owner's provider" },
-        { value: "openrouter", label: "OpenRouter" },
-        { value: "vercel", label: "Vercel AI Gateway" },
+        { value: "configured", label: gatewayLabel("configured"), hint: "preserve pipeline model IDs literally" },
+        { value: "direct", label: gatewayLabel("direct"), hint: "use the model owner's provider" },
+        { value: "openrouter", label: gatewayLabel("openrouter") },
+        { value: "vercel", label: gatewayLabel("vercel") },
       ],
       commit: (value) => {
         config.modelRouting ??= { overrides: {} }
@@ -1253,7 +1254,7 @@ export class ConfigEditor {
     const rows: Row[] = []
 
     rows.push(sectionRow("Defaults"))
-    rows.push(fieldRow("Gateway", config.modelRouting?.gateway ?? "(inherits configured)", { t: "gateway" }))
+    rows.push(fieldRow("Gateway", config.modelRouting?.gateway ? gatewayLabel(config.modelRouting.gateway) : "(inherits)", { t: "gateway" }))
     for (const field of defaultFields) {
       const value = config.defaults[field.key]
       rows.push(fieldRow(field.key, value === undefined ? "(unset)" : String(value), { t: "default", field }))

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -99,6 +99,7 @@ type Modal =
 type RowMeta =
   | { t: "initialize" }
   | { t: "default"; field: DefaultField }
+  | { t: "gateway" }
   | { t: "agent"; name: string }
   | { t: "pipeline"; name: string }
   /** member set: the row is `steps[index].parallel[member]`; unset: `steps[index]` (a parallel group's header when that spec is a parallel block). */
@@ -508,6 +509,9 @@ export class ConfigEditor {
       case "default":
         this.editDefault(meta.field)
         return
+      case "gateway":
+        this.editGateway()
+        return
       case "agent":
         this.editAgentModel(meta.name)
         return
@@ -594,6 +598,31 @@ export class ConfigEditor {
         this.markDirty()
       },
     })
+  }
+
+  private editGateway() {
+    const config = this.tab().config
+    if (!config) return
+    this.modal = {
+      kind: "choose",
+      title: "modelRouting.gateway",
+      filter: "",
+      index: 0,
+      options: [
+        { value: "", label: "inherit", hint: "clear this scope's override" },
+        { value: "configured", label: "As configured", hint: "preserve pipeline model IDs literally" },
+        { value: "direct", label: "Direct", hint: "use the model owner's provider" },
+        { value: "openrouter", label: "OpenRouter" },
+        { value: "vercel", label: "Vercel AI Gateway" },
+      ],
+      commit: (value) => {
+        config.modelRouting ??= { overrides: {} }
+        if (value === "") delete config.modelRouting.gateway
+        else config.modelRouting.gateway = value as "configured" | "direct" | "openrouter" | "vercel"
+        this.markDirty()
+      },
+    }
+    this.render()
   }
 
   private editAgentModel(name: string) {
@@ -1224,6 +1253,7 @@ export class ConfigEditor {
     const rows: Row[] = []
 
     rows.push(sectionRow("Defaults"))
+    rows.push(fieldRow("Gateway", config.modelRouting?.gateway ?? "(inherits configured)", { t: "gateway" }))
     for (const field of defaultFields) {
       const value = config.defaults[field.key]
       rows.push(fieldRow(field.key, value === undefined ? "(unset)" : String(value), { t: "default", field }))
@@ -1366,6 +1396,12 @@ export class ConfigEditor {
         push([fg(theme.faint)(describeDefault(meta.field.key))])
         lines.push(plain(""))
         push([fg(theme.accent)("enter"), fg(theme.dim)(meta.field.type === "model" ? " pick a model" : " edit value")])
+        break
+      case "gateway":
+        push([fg(theme.text)("modelRouting.gateway")])
+        push([fg(theme.faint)("Routes every OpenCode model without changing pipeline YAML.")])
+        lines.push(plain(""))
+        push([fg(theme.accent)("enter"), fg(theme.dim)(" choose gateway")])
         break
       case "agent":
         push([fg(theme.text)(`agent: ${meta.name}`)])

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ import {
 } from "./pipeline"
 import { isStepRunnerId, normalizeStepRunnerModel, stepRunnerFor, type StepRunnerId } from "./step-runners"
 import type { AgentSpec, HookSet, HookSpec, HooksConfig, HookWhen, PermissionAdditions } from "./types"
+import { isModelGateway, type ModelRoutingConfig, type ModelRoutingOverrides } from "./model-routing"
 import { convoyHome, convoyRoot, globalConfigPath } from "./workspace"
 
 /**
@@ -40,6 +41,7 @@ export type ConvoyConfig = {
   permissions: PermissionAdditions
   hooks: HooksConfig
   attachments: string[]
+  modelRouting?: ModelRoutingConfig
 }
 
 export type ConvoyDefaults = {
@@ -123,6 +125,11 @@ export function mergeConvoyConfigs(global: ConvoyConfig | undefined, project: Co
     },
     hooks: mergeHooksConfig(global.hooks, project.hooks),
     attachments: [...global.attachments, ...project.attachments],
+    modelRouting: {
+      ...(global.modelRouting?.gateway !== undefined ? { gateway: global.modelRouting.gateway } : {}),
+      ...(project.modelRouting?.gateway !== undefined ? { gateway: project.modelRouting.gateway } : {}),
+      overrides: mergeRoutingOverrides(global.modelRouting?.overrides ?? {}, project.modelRouting?.overrides ?? {}),
+    },
   }
 }
 
@@ -164,6 +171,14 @@ export const defaultConvoyConfig = `# Convoy configuration.
 # Project override path: .convoy/config.yaml
 
 version: 1
+
+# Route OpenCode models without rewriting pipelines. Project config overrides the global choice.
+# modelRouting:
+#   gateway: configured # configured | direct | openrouter | vercel
+#   overrides:
+#     zai/glm-5.2:
+#       openrouter: openrouter/z-ai/glm-5.2
+#       vercel: vercel/zai/glm-5.2
 
 defaults:
   # model: openai/gpt-5.6-terra#xhigh # optional: uncomment to force every agent unless a step/agent overrides it
@@ -321,14 +336,14 @@ export function parseConvoyConfig(body: string, source: string, targetDir: strin
     throw new ConfigError(`${source}: invalid YAML: ${error instanceof Error ? error.message : String(error)}`)
   }
 
-  const config: ConvoyConfig = { defaults: {}, agents: {}, pipelines: {}, permissions: { allow: [], deny: [] }, hooks: emptyHooksConfig(), attachments: [] }
+  const config: ConvoyConfig = { defaults: {}, agents: {}, pipelines: {}, permissions: { allow: [], deny: [] }, hooks: emptyHooksConfig(), attachments: [], modelRouting: { overrides: {} } }
   if (raw === null || raw === undefined) return config
 
   const v = new Validator(source)
   const root = v.record(raw, "")
   // Unknown keys warn instead of failing so configs written for a newer
   // convoy still load; typos surface in the warning either way.
-  v.knownKeys(root, "", ["version", "defaults", "agents", "pipelines", "permissions", "hooks", "attachments"])
+  v.knownKeys(root, "", ["version", "defaults", "agents", "pipelines", "permissions", "hooks", "attachments", "modelRouting"])
 
   if (root.version !== undefined && root.version !== 1) v.fail("version", `unsupported value ${JSON.stringify(root.version)}; this convoy reads version 1`)
 
@@ -338,8 +353,40 @@ export function parseConvoyConfig(body: string, source: string, targetDir: strin
   if (root.permissions !== undefined) config.permissions = validatePermissions(v, root.permissions)
   if (root.hooks !== undefined) config.hooks = validateHooks(v, root.hooks)
   if (root.attachments !== undefined) config.attachments = v.stringArray(root.attachments, "attachments")
+  if (root.modelRouting !== undefined) config.modelRouting = validateModelRouting(v, root.modelRouting)
 
   return config
+}
+
+function validateModelRouting(v: Validator, raw: unknown): ModelRoutingConfig {
+  const record = v.record(raw, "modelRouting")
+  v.knownKeys(record, "modelRouting", ["gateway", "overrides"])
+  const routing: ModelRoutingConfig = { overrides: {} }
+  if (record.gateway !== undefined) {
+    if (!isModelGateway(record.gateway)) v.fail("modelRouting.gateway", 'must be "configured", "direct", "openrouter", or "vercel"')
+    routing.gateway = record.gateway
+  }
+  if (record.overrides !== undefined) {
+    const overrides = v.record(record.overrides, "modelRouting.overrides")
+    for (const [logical, rawTargets] of Object.entries(overrides)) {
+      if (!isValidModelString(logical)) v.fail(`modelRouting.overrides.${logical}`, "key must be a provider/model")
+      const targets = v.record(rawTargets, `modelRouting.overrides.${logical}`)
+      v.knownKeys(targets, `modelRouting.overrides.${logical}`, ["configured", "direct", "openrouter", "vercel"])
+      const parsed: Partial<Record<import("./model-routing").ModelGateway, string>> = {}
+      for (const [gateway, target] of Object.entries(targets)) {
+        if (!isModelGateway(gateway)) continue
+        parsed[gateway] = v.model(target, `modelRouting.overrides.${logical}.${gateway}`)
+      }
+      routing.overrides[splitModelVariant(logical).model] = parsed
+    }
+  }
+  return routing
+}
+
+function mergeRoutingOverrides(global: ModelRoutingOverrides, project: ModelRoutingOverrides): ModelRoutingOverrides {
+  const result: ModelRoutingOverrides = structuredClone(global)
+  for (const [model, targets] of Object.entries(project)) result[model] = { ...(result[model] ?? {}), ...targets }
+  return result
 }
 
 function validateDefaults(v: Validator, raw: unknown): ConvoyDefaults {
@@ -624,6 +671,7 @@ export function serializeConvoyConfig(config: ConvoyConfig): string {
   const hooks = serializeHooks(config.hooks)
   if (hooks) out.hooks = hooks
   if (config.attachments.length > 0) out.attachments = config.attachments
+  if (config.modelRouting && (config.modelRouting.gateway !== undefined || Object.keys(config.modelRouting.overrides).length > 0)) out.modelRouting = config.modelRouting
   return Bun.YAML.stringify(out, null, 2)
 }
 
@@ -666,6 +714,7 @@ export function defaultConfigTemplate(): ConvoyConfig {
     permissions: { allow: [], deny: [] },
     hooks: emptyHooksConfig(),
     attachments: [],
+    modelRouting: { overrides: {} },
   }
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,7 +19,6 @@ import {
   isSafeStepName,
   readOnlyAgentSuffix,
   resolvePipeline,
-  splitModelVariant,
   type AgentStepSpec,
   type HumanStepSpec,
   type PipelineSpec,
@@ -27,7 +26,7 @@ import {
 } from "./pipeline"
 import { isStepRunnerId, normalizeStepRunnerModel, stepRunnerFor, type StepRunnerId } from "./step-runners"
 import type { AgentSpec, HookSet, HookSpec, HooksConfig, HookWhen, PermissionAdditions } from "./types"
-import { isModelGateway, type ModelRoutingConfig, type ModelRoutingOverrides } from "./model-routing"
+import { isModelGateway, logicalModel, type ModelRoutingConfig, type ModelRoutingOverrides } from "./model-routing"
 import { convoyHome, convoyRoot, globalConfigPath } from "./workspace"
 
 /**
@@ -370,6 +369,16 @@ function validateModelRouting(v: Validator, raw: unknown): ModelRoutingConfig {
     const overrides = v.record(record.overrides, "modelRouting.overrides")
     for (const [logical, rawTargets] of Object.entries(overrides)) {
       if (!isValidModelString(logical)) v.fail(`modelRouting.overrides.${logical}`, "key must be a provider/model")
+      // Keys name the canonical logical model, exactly as resolveModel recovers
+      // it: wrapped gateway prefixes are unwrapped and known aliases (z-ai/zai)
+      // are normalized, so "openrouter/z-ai/glm-5.2" and "zai/glm-5.2" are the
+      // same override.
+      let canonical: string
+      try {
+        canonical = logicalModel(logical).model
+      } catch (error) {
+        v.fail(`modelRouting.overrides.${logical}`, error instanceof Error ? error.message : String(error))
+      }
       const targets = v.record(rawTargets, `modelRouting.overrides.${logical}`)
       v.knownKeys(targets, `modelRouting.overrides.${logical}`, ["configured", "direct", "openrouter", "vercel"])
       const parsed: Partial<Record<import("./model-routing").ModelGateway, string>> = {}
@@ -377,7 +386,7 @@ function validateModelRouting(v: Validator, raw: unknown): ModelRoutingConfig {
         if (!isModelGateway(gateway)) continue
         parsed[gateway] = v.model(target, `modelRouting.overrides.${logical}.${gateway}`)
       }
-      routing.overrides[splitModelVariant(logical).model] = parsed
+      routing.overrides[canonical] = parsed
     }
   }
   return routing

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -7,7 +7,7 @@ import { hooksForPipeline } from "./hooks"
 import { startLimitsPoller } from "./limits"
 import { builtInPipelines, defaultPipelineName, resolvePipeline } from "./pipeline"
 import { stepRunnerFor } from "./step-runners"
-import { modelGateways, type ModelGateway } from "./model-routing"
+import { gatewayLabel, modelGateways, type ModelGateway } from "./model-routing"
 import { joinLines, limitsRow, padBetween, paletteForTerminal, plain, raw, setTheme, spinnerFrame, terminalBackgroundHex, theme, truncate } from "./tui-theme"
 
 import type { ConvoyConfig } from "./config"
@@ -972,7 +972,7 @@ class LaunchPicker {
     lines.push(new StyledText([fg(theme.faint)("prompt   "), fg(theme.text)(truncate(this.prompt, Math.max(10, width - 9)))]))
     lines.push(plain(""))
     lines.push(t`${fg(theme.dim)("Toggle extra run parameters, then press Enter to start.")}`)
-    lines.push(new StyledText([fg(theme.faint)("Gateway  "), bold(fg(theme.accent)(this.gateway)), fg(theme.dim)("  (g to change)")]))
+    lines.push(new StyledText([fg(theme.faint)("gateway  "), bold(fg(theme.text)(gatewayLabel(this.gateway))), fg(theme.dim)("  (g to change)")]))
     lines.push(plain(""))
 
     this.optionRows = Array(lines.length).fill(undefined)

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -7,6 +7,7 @@ import { hooksForPipeline } from "./hooks"
 import { startLimitsPoller } from "./limits"
 import { builtInPipelines, defaultPipelineName, resolvePipeline } from "./pipeline"
 import { stepRunnerFor } from "./step-runners"
+import { modelGateways, type ModelGateway } from "./model-routing"
 import { joinLines, limitsRow, padBetween, paletteForTerminal, plain, raw, setTheme, spinnerFrame, terminalBackgroundHex, theme, truncate } from "./tui-theme"
 
 import type { ConvoyConfig } from "./config"
@@ -25,8 +26,13 @@ export type LaunchRunSelection = {
   keepRunDir: boolean
   yolo: boolean
   smart: boolean
+  gateway: ModelGateway
   /** When set, Convoy ran against an isolated worktree created on launch. */
   worktree?: { dir: string; branch: string }
+  /** Worktree creation is intentionally deferred until after plan confirmation. */
+  isolateWorktree?: boolean
+  /** Empty repositories are initialized only after the review is confirmed. */
+  initializeGit?: boolean
 }
 
 export type LaunchNavigationSelection =
@@ -152,7 +158,7 @@ export async function launchRunTui(options: { targetDir: string }): Promise<Laun
   })
   const mode = await renderer.waitForThemeMode(1_000).catch(() => null)
   setTheme(paletteForTerminal(mode, terminalBackgroundHex(renderer)))
-  return new LaunchPicker(renderer, options.targetDir, choices, baseRef, config?.defaults.branchNameModel).result
+  return new LaunchPicker(renderer, options.targetDir, choices, baseRef, config?.modelRouting?.gateway ?? "configured").result
 }
 
 function pipelineChoices(config: ConvoyConfig | undefined, agents: readonly AgentSpec[]): PipelineChoice[] {
@@ -323,7 +329,7 @@ class LaunchPicker {
     private readonly targetDir: string,
     private readonly choices: PipelineChoice[],
     private readonly baseRef: string | undefined,
-    private readonly branchNameModel: string | undefined,
+    private gateway: ModelGateway,
   ) {
     const defaultIndex = choices.findIndex((choice) => choice.isDefault)
     this.selected = defaultIndex >= 0 ? defaultIndex : 0
@@ -593,6 +599,10 @@ class LaunchPicker {
       case "s":
         this.startRun()
         return
+      case "g":
+        this.gateway = modelGateways[(modelGateways.indexOf(this.gateway) + 1) % modelGateways.length]!
+        this.render()
+        return
       case "p":
       case "escape":
         this.mode = "prompt"
@@ -635,14 +645,7 @@ class LaunchPicker {
       const { repoBootstrapStatus } = await import("./git")
       const status = await repoBootstrapStatus(this.targetDir)
       if (status !== "ready") {
-        this.modal = {
-          kind: "confirm",
-          title: "Initialize Git",
-          message: status === "no-repo" ? "This project has no Git repository. Initialize it now with an initial commit?" : "This Git repository has no commits. Create an initial commit now?",
-          footer: "enter initialize · esc cancel",
-          onConfirm: () => void this.initializeGitAndStart(choice.name),
-        }
-        this.render()
+        this.finishRunSelection(choice.name, true)
         return
       }
     } catch (error) {
@@ -653,20 +656,6 @@ class LaunchPicker {
     }
 
     await this.startReadyRun(choice.name)
-  }
-
-  private async initializeGitAndStart(pipelineName: string) {
-    this.modal = { kind: "loading", title: "initializing Git", message: "creating initial commit…", footer: "please wait…" }
-    this.render()
-    try {
-      const { initializeRepoWithInitialCommit } = await import("./git")
-      await initializeRepoWithInitialCommit(this.targetDir, { baseRef: this.baseRef })
-      await this.startReadyRun(pipelineName)
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      this.modal = { kind: "message", title: "git init failed", message }
-      this.render()
-    }
   }
 
   // Mirrors the checks `run()` re-does after the launcher closes (ensureRepoReady
@@ -689,10 +678,10 @@ class LaunchPicker {
       this.render()
       return
     }
-    if (this.toggleState.worktree) {
-      void this.startWorktreeRun(pipelineName)
-      return
-    }
+    this.finishRunSelection(pipelineName)
+  }
+
+  private finishRunSelection(pipelineName: string, initializeGit = false) {
     this.finish({
       targetDir: this.targetDir,
       prompt: this.prompt,
@@ -703,45 +692,10 @@ class LaunchPicker {
       keepRunDir: this.toggleState.keepRunDir,
       yolo: this.toggleState.yolo,
       smart: this.toggleState.smart,
+      gateway: this.gateway,
+      isolateWorktree: this.toggleState.worktree,
+      ...(initializeGit ? { initializeGit: true } : {}),
     })
-  }
-
-  // The AI naming call + `git worktree add` happen here, behind a blocking
-  // loading modal so the user can't toggle options mid-creation. Any failure
-  // falls back to the options screen with an explanatory message modal.
-  private async startWorktreeRun(pipelineName: string) {
-    try {
-      const { createIsolatedWorktree, defaultBranchNameModel } = await import("./worktree")
-      const namerModel = this.branchNameModel ?? defaultBranchNameModel
-      this.modal = {
-        kind: "loading",
-        title: "isolating worktree",
-        message: `investigating prompt & naming branch… (${namerModel})`,
-        footer: "creating a new branch + worktree…",
-      }
-      this.render()
-      const result = await createIsolatedWorktree({
-        targetDir: this.targetDir,
-        prompt: this.prompt,
-        model: namerModel,
-      })
-      this.finish({
-        targetDir: result.dir,
-        prompt: this.prompt,
-        pipeline: pipelineName,
-        humanReview: this.toggleState.humanReview,
-        tui: this.toggleState.tui,
-        includeDirty: false,
-        keepRunDir: this.toggleState.keepRunDir,
-        yolo: this.toggleState.yolo,
-        smart: this.toggleState.smart,
-        worktree: { dir: result.dir, branch: result.branch },
-      })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      this.modal = { kind: "message", title: "worktree failed", message }
-      this.render()
-    }
   }
 
   private toggleOption() {
@@ -1018,6 +972,7 @@ class LaunchPicker {
     lines.push(new StyledText([fg(theme.faint)("prompt   "), fg(theme.text)(truncate(this.prompt, Math.max(10, width - 9)))]))
     lines.push(plain(""))
     lines.push(t`${fg(theme.dim)("Toggle extra run parameters, then press Enter to start.")}`)
+    lines.push(new StyledText([fg(theme.faint)("Gateway  "), bold(fg(theme.accent)(this.gateway)), fg(theme.dim)("  (g to change)")]))
     lines.push(plain(""))
 
     this.optionRows = Array(lines.length).fill(undefined)
@@ -1044,6 +999,7 @@ class LaunchPicker {
 
   private enabledFlags() {
     const flags = [`--pipeline ${this.currentChoice().name}`]
+    flags.push(`--gateway ${this.gateway}`)
     if (this.toggleState.smart) flags.push("--smart")
     if (this.toggleState.yolo) flags.push("--yolo")
     flags.push(this.toggleState.humanReview ? "--human-step" : "--no-human-step")
@@ -1071,7 +1027,7 @@ class LaunchPicker {
       )
     }
     return padBetween(
-      [fg(theme.dim)("↑/↓ select · "), fg(theme.accent)("space"), fg(theme.dim)(" toggle · "), fg(theme.accent)("enter"), fg(theme.dim)(" start · "), fg(theme.accent)("p"), fg(theme.dim)(" prompt · "), fg(theme.accent)("r"), fg(theme.dim)(" runs · "), fg(theme.accent)("c"), fg(theme.dim)(" config · "), fg(theme.accent)("q"), fg(theme.dim)(" quit")],
+      [fg(theme.dim)("↑/↓ select · "), fg(theme.accent)("space"), fg(theme.dim)(" toggle · "), fg(theme.accent)("g"), fg(theme.dim)(" gateway · "), fg(theme.accent)("enter"), fg(theme.dim)(" start · "), fg(theme.accent)("p"), fg(theme.dim)(" prompt · "), fg(theme.accent)("q"), fg(theme.dim)(" quit")],
       [fg(theme.faint)(`${this.optionIndex + 1}/${toggles.length}`)],
       width,
     )

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -27,8 +27,6 @@ export type LaunchRunSelection = {
   yolo: boolean
   smart: boolean
   gateway: ModelGateway
-  /** When set, Convoy ran against an isolated worktree created on launch. */
-  worktree?: { dir: string; branch: string }
   /** Worktree creation is intentionally deferred until after plan confirmation. */
   isolateWorktree?: boolean
   /** Empty repositories are initialized only after the review is confirmed. */

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -8,12 +8,13 @@ import { startLimitsPoller } from "./limits"
 import { builtInPipelines, defaultPipelineName, resolvePipeline } from "./pipeline"
 import { stepRunnerFor } from "./step-runners"
 import { gatewayLabel, modelGateways, type ModelGateway } from "./model-routing"
+import { renderRunPlan } from "./run-review"
 import { joinLines, limitsRow, padBetween, paletteForTerminal, plain, raw, setTheme, spinnerFrame, terminalBackgroundHex, theme, truncate } from "./tui-theme"
 
 import type { ConvoyConfig } from "./config"
 import type { BoxOptions, CliRenderer, KeyEvent, PasteEvent, TextChunk } from "@opentui/core"
 import type { LimitsSnapshot } from "./limits"
-import type { AgentSpec, AgentStep, HookSet, HookSpec, Step } from "./types"
+import type { AgentSpec, AgentStep, HookSet, HookSpec, RunOptions, RunPlan, Step } from "./types"
 import type { PaletteColor } from "./tui-theme"
 
 export type LaunchRunSelection = {
@@ -37,7 +38,24 @@ export type LaunchNavigationSelection =
   | { action: "runs" }
   | { action: "config" }
 
-export type LaunchRunTuiResult = LaunchRunSelection | LaunchNavigationSelection | undefined
+export type LaunchRunPreparation = {
+  /** The exact options and immutable plan that will be handed to the runner. */
+  options: RunOptions
+  plan: RunPlan
+}
+
+export type LaunchReviewedRun = LaunchRunPreparation & {
+  action: "run"
+  selection: LaunchRunSelection
+}
+
+export type LaunchRunTuiResult = LaunchReviewedRun | LaunchNavigationSelection | undefined
+
+export type LaunchRunTuiOptions = {
+  targetDir: string
+  /** Resolves the run without effects so Review and the runner share one frozen plan. */
+  prepareRun(selection: LaunchRunSelection): Promise<LaunchRunPreparation>
+}
 
 // One resolved step, flattened for the preview: `groupId` ties concurrent
 // steps together (the runner batches same-groupId steps), and `stepName` is
@@ -83,7 +101,7 @@ type ToggleSpec = {
   description: string
 }
 
-type Mode = "pipelines" | "prompt" | "options"
+type Mode = "pipelines" | "prompt" | "options" | "review"
 
 type Modal =
   | { kind: "message"; title: string; message: string; footer?: string }
@@ -135,16 +153,13 @@ const toggles: readonly ToggleSpec[] = [
   },
 ]
 
-export async function launchRunTui(options: { targetDir: string }): Promise<LaunchRunTuiResult> {
+export async function launchRunTui(options: LaunchRunTuiOptions): Promise<LaunchRunTuiResult> {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     throw new Error("convoy needs an interactive terminal to open the launcher")
   }
 
   const config = await loadMergedConvoyConfig(options.targetDir)
   const choices = pipelineChoices(config, buildAgentRegistry(config))
-  // No "main" fallback: a brand-new repo initialized without a baseRef keeps
-  // the user's own init.defaultBranch, and the run auto-detects it afterwards.
-  const baseRef = config?.defaults.baseRef
 
   // No backgroundColor yet: the palette is only chosen after the terminal
   // answers the background query, so a light terminal never flashes dark.
@@ -156,7 +171,7 @@ export async function launchRunTui(options: { targetDir: string }): Promise<Laun
   })
   const mode = await renderer.waitForThemeMode(1_000).catch(() => null)
   setTheme(paletteForTerminal(mode, terminalBackgroundHex(renderer)))
-  return new LaunchPicker(renderer, options.targetDir, choices, baseRef, config?.modelRouting?.gateway ?? "configured").result
+  return new LaunchPicker(renderer, options.targetDir, choices, config?.modelRouting?.gateway ?? "configured", options.prepareRun).result
 }
 
 function pipelineChoices(config: ConvoyConfig | undefined, agents: readonly AgentSpec[]): PipelineChoice[] {
@@ -235,6 +250,10 @@ class LaunchPicker {
   private optionIndex = 0
   private message = ""
   private modal?: Modal
+  private prepared?: LaunchReviewedRun
+  private reviewScroll = 0
+  private reviewTotalLines = 0
+  private reviewFullPrompt = false
 
   private readonly toggleState: Record<ToggleKey, boolean> = {
     smart: true,
@@ -319,6 +338,9 @@ class LaunchPicker {
       case "options":
         this.handleOptionsKey(key)
         break
+      case "review":
+        this.handleReviewKey(key)
+        break
     }
   }
 
@@ -326,8 +348,8 @@ class LaunchPicker {
     private readonly renderer: CliRenderer,
     private readonly targetDir: string,
     private readonly choices: PipelineChoice[],
-    private readonly baseRef: string | undefined,
     private gateway: ModelGateway,
+    private readonly prepareRun: (selection: LaunchRunSelection) => Promise<LaunchRunPreparation>,
   ) {
     const defaultIndex = choices.findIndex((choice) => choice.isDefault)
     this.selected = defaultIndex >= 0 ? defaultIndex : 0
@@ -350,8 +372,9 @@ class LaunchPicker {
     const selectFromList = (event: { y: number; preventDefault(): void; stopPropagation(): void }) => {
       event.preventDefault()
       event.stopPropagation()
-      // Ignore clicks while a loading/message modal is up.
-      if (this.modal) return
+      // Review is deliberately a committed, read-only screen: use Escape to
+      // return to Options instead of changing the pipeline behind its plan.
+      if (this.modal || this.mode === "review") return
       const row = event.y - this.pipelineText.y
       const index = this.pipelineRows[row]
       if (index === undefined) return
@@ -385,6 +408,15 @@ class LaunchPicker {
       this.toggleOption()
     }
 
+    const scrollReview = (event: LauncherWheelEvent) => {
+      if (this.mode !== "review" || this.modal) return
+      const delta = wheelDelta(event)
+      if (delta === 0) return
+      event.preventDefault()
+      event.stopPropagation()
+      this.scrollReview(delta)
+    }
+
     const detail = this.panel({
       id: "convoy-launch-detail",
       flexGrow: 1,
@@ -394,8 +426,10 @@ class LaunchPicker {
       title: " run setup ",
       titleAlignment: "left",
       onMouseDown: selectOption,
+      onMouseScroll: scrollReview,
     })
     detail.text.onMouseDown = selectOption
+    detail.text.onMouseScroll = scrollReview
     const footer = this.panel({ id: "convoy-launch-footer", height: 3, borderColor: theme.borderDim, backgroundColor: theme.bg })
 
     this.headerText = header.text
@@ -619,6 +653,55 @@ class LaunchPicker {
     }
   }
 
+  private handleReviewKey(key: KeyEvent) {
+    switch (reviewActionForKey(key)) {
+      case "scroll-back":
+        this.scrollReview(-1)
+        return
+      case "scroll-forward":
+        this.scrollReview(1)
+        return
+      case "page-back":
+        this.scrollReview(-this.listHeight())
+        return
+      case "page-forward":
+        this.scrollReview(this.listHeight())
+        return
+      case "top":
+        this.reviewScroll = 0
+        this.render()
+        return
+      case "bottom":
+        this.reviewScroll = Math.max(0, this.reviewTotalLines - this.listHeight())
+        this.render()
+        return
+      case "toggle-prompt":
+        this.reviewFullPrompt = !this.reviewFullPrompt
+        this.reviewScroll = 0
+        this.render()
+        return
+      case "start":
+        if (this.prepared) this.finish(this.prepared)
+        return
+      case "back":
+        this.prepared = undefined
+        this.mode = "options"
+        this.reviewScroll = 0
+        this.reviewTotalLines = 0
+        this.render()
+        return
+      case "cancel":
+        this.finish(undefined)
+        return
+    }
+  }
+
+  private scrollReview(delta: number) {
+    const maxScroll = Math.max(0, this.reviewTotalLines - this.listHeight())
+    this.reviewScroll = clamp(this.reviewScroll + delta, 0, maxScroll)
+    this.render()
+  }
+
   private openPrompt() {
     const choice = this.currentChoice()
     if (!choice.valid) {
@@ -634,53 +717,39 @@ class LaunchPicker {
   }
 
   private startRun() {
-    void this.startRunAfterGitCheck()
+    const choice = this.currentChoice()
+    if (!choice.valid) {
+      this.message = `Pipeline "${choice.name}" is invalid: ${choice.error ?? "unknown error"}`
+      this.render()
+      return
+    }
+    void this.prepareReview(choice.name)
   }
 
-  private async startRunAfterGitCheck() {
-    const choice = this.currentChoice()
+  private async prepareReview(pipelineName: string) {
+    this.modal = { kind: "loading", title: "preparing review", message: "Resolving the exact run plan…" }
+    this.render()
     try {
       const { repoBootstrapStatus } = await import("./git")
       const status = await repoBootstrapStatus(this.targetDir)
-      if (status !== "ready") {
-        this.finishRunSelection(choice.name, true)
-        return
-      }
+      const selection = this.runSelection(pipelineName, status !== "ready")
+      const preparation = await this.prepareRun(selection)
+      this.prepared = { action: "run", selection, ...preparation }
+      this.mode = "review"
+      this.reviewScroll = 0
+      this.reviewTotalLines = 0
+      this.reviewFullPrompt = false
+      this.modal = undefined
+      this.render()
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      this.modal = { kind: "message", title: "git check failed", message }
+      this.modal = { kind: "message", title: "can't prepare the review", message, footer: "esc dismiss · adjust options and try again" }
       this.render()
-      return
     }
-
-    await this.startReadyRun(choice.name)
   }
 
-  // Mirrors the checks `run()` re-does after the launcher closes (ensureRepoReady
-  // in runner.ts): failing here keeps the wizard open, so the typed prompt and
-  // toggles survive a bad base ref or a dirty tree instead of dying with the process.
-  private async startReadyRun(pipelineName: string) {
-    try {
-      const { ensureRepoReady } = await import("./git")
-      await ensureRepoReady(this.targetDir, {
-        baseRef: this.baseRef,
-        includeDirty: this.toggleState.includeDirty,
-        // The interactive flow always forces max attempts to 1 with includeDirty.
-        maxAttempts: 1,
-        // A fresh worktree is always clean, so worktree runs tolerate a dirty source tree.
-        allowDirty: this.toggleState.worktree,
-      })
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      this.modal = { kind: "message", title: "can't start the run", message, footer: "esc dismiss · fix and press enter to retry" }
-      this.render()
-      return
-    }
-    this.finishRunSelection(pipelineName)
-  }
-
-  private finishRunSelection(pipelineName: string, initializeGit = false) {
-    this.finish({
+  private runSelection(pipelineName: string, initializeGit = false): LaunchRunSelection {
+    return {
       targetDir: this.targetDir,
       prompt: this.prompt,
       pipeline: pipelineName,
@@ -693,7 +762,7 @@ class LaunchPicker {
       gateway: this.gateway,
       isolateWorktree: this.toggleState.worktree,
       ...(initializeGit ? { initializeGit: true } : {}),
-    })
+    }
   }
 
   private toggleOption() {
@@ -762,6 +831,7 @@ class LaunchPicker {
 
     this.pipelineBox.width = pipelineWidth
     this.detailBox.width = detailWidth
+    this.detailBox.title = this.mode === "review" ? " review " : " run setup "
     // Mirror the dashboard focus cue: the accented border marks where Enter,
     // Esc, and the navigation keys apply in the current setup step.
     this.pipelineBox.borderColor = this.mode === "pipelines" ? theme.accent : theme.borderDim
@@ -814,9 +884,9 @@ class LaunchPicker {
     const project = basename(this.targetDir) || this.targetDir
     const title: TextChunk[] = [fg(theme.faint)("target "), bold(fg(theme.text)(truncate(project, Math.max(12, width - 32))))]
     const stage: TextChunk[] = []
-    for (const [index, step] of ["pipeline", "prompt", "options"].entries()) {
+    for (const [index, step] of ["pipeline", "prompt", "options", "review"].entries()) {
       if (index > 0) stage.push(fg(theme.faint)(" → "))
-      const active = (this.mode === "pipelines" && index === 0) || (this.mode === "prompt" && index === 1) || (this.mode === "options" && index === 2)
+      const active = (this.mode === "pipelines" && index === 0) || (this.mode === "prompt" && index === 1) || (this.mode === "options" && index === 2) || (this.mode === "review" && index === 3)
       stage.push(active ? bold(fg(theme.accent)(step)) : fg(theme.dim)(step))
     }
     const line1 = padBetween(title, stage, width)
@@ -867,6 +937,8 @@ class LaunchPicker {
         return this.promptDetail(width)
       case "options":
         return this.optionsDetail(width)
+      case "review":
+        return this.reviewDetail(width)
     }
   }
 
@@ -969,7 +1041,7 @@ class LaunchPicker {
     lines.push(new StyledText([fg(theme.faint)("pipeline "), bold(fg(theme.text)(choice.name))]))
     lines.push(new StyledText([fg(theme.faint)("prompt   "), fg(theme.text)(truncate(this.prompt, Math.max(10, width - 9)))]))
     lines.push(plain(""))
-    lines.push(t`${fg(theme.dim)("Toggle extra run parameters, then press Enter to start.")}`)
+    lines.push(t`${fg(theme.dim)("Toggle extra run parameters, then press Enter to review.")}`)
     lines.push(new StyledText([fg(theme.faint)("gateway  "), bold(fg(theme.text)(gatewayLabel(this.gateway))), fg(theme.dim)("  (g to change)")]))
     lines.push(plain(""))
 
@@ -992,6 +1064,25 @@ class LaunchPicker {
     this.optionRows.push(undefined)
     lines.push(new StyledText([fg(theme.faint)("will run with "), fg(theme.text)(flags.length ? flags.join(" ") : "no extra flags")]))
     this.optionRows.push(undefined)
+    return joinLines(lines)
+  }
+
+  private reviewDetail(width: number) {
+    const prepared = this.prepared
+    if (!prepared) return joinLines([t`${fg(theme.red)("Unable to load the run review.")}`])
+
+    const rendered = renderRunPlan(prepared.plan, false, { fullPrompt: this.reviewFullPrompt })
+    const reviewLines = rendered
+      .trimEnd()
+      .split("\n")
+      .flatMap((line) => wrapReviewLine(line, width))
+    const visible = this.listHeight()
+    const maxScroll = Math.max(0, reviewLines.length - visible)
+    this.reviewScroll = clamp(this.reviewScroll, 0, maxScroll)
+    this.reviewTotalLines = reviewLines.length
+
+    const lines = reviewLines.slice(this.reviewScroll, this.reviewScroll + visible).map(reviewTextLine)
+    while (lines.length < visible) lines.push(plain(""))
     return joinLines(lines)
   }
 
@@ -1024,6 +1115,26 @@ class LaunchPicker {
         width,
       )
     }
+    if (this.mode === "review") {
+      const end = Math.min(this.reviewScroll + this.listHeight(), this.reviewTotalLines)
+      return padBetween(
+        [
+          fg(theme.dim)("↑/↓ scroll · "),
+          fg(theme.accent)("pgup/pgdn"),
+          fg(theme.dim)(" page · "),
+          fg(theme.accent)("p"),
+          fg(theme.dim)(this.reviewFullPrompt ? " collapse prompt · " : " expand prompt · "),
+          fg(theme.accent)("enter/s"),
+          fg(theme.dim)(" start · "),
+          fg(theme.accent)("esc"),
+          fg(theme.dim)(" options · "),
+          fg(theme.accent)("q"),
+          fg(theme.dim)(" cancel"),
+        ],
+        [fg(theme.faint)(`${end}/${this.reviewTotalLines}`)],
+        width,
+      )
+    }
     return padBetween(
       [fg(theme.dim)("↑/↓ select · "), fg(theme.accent)("space"), fg(theme.dim)(" toggle · "), fg(theme.accent)("g"), fg(theme.dim)(" gateway · "), fg(theme.accent)("enter"), fg(theme.dim)(" start · "), fg(theme.accent)("p"), fg(theme.dim)(" prompt · "), fg(theme.accent)("q"), fg(theme.dim)(" quit")],
       [fg(theme.faint)(`${this.optionIndex + 1}/${toggles.length}`)],
@@ -1047,6 +1158,85 @@ class LaunchPicker {
 
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value))
+}
+
+export type ReviewAction = "scroll-back" | "scroll-forward" | "page-back" | "page-forward" | "top" | "bottom" | "toggle-prompt" | "start" | "back" | "cancel"
+
+/** Keyboard contract for the launcher's native Review step. */
+export function reviewActionForKey(key: Pick<KeyEvent, "name" | "shift">): ReviewAction | undefined {
+  switch (key.name) {
+    case "up":
+    case "k":
+      return "scroll-back"
+    case "down":
+    case "j":
+      return "scroll-forward"
+    case "pageup":
+      return "page-back"
+    case "pagedown":
+    case "space":
+      return "page-forward"
+    case "home":
+      return "top"
+    case "end":
+      return "bottom"
+    case "p":
+      return "toggle-prompt"
+    case "return":
+    case "linefeed":
+    case "s":
+      return "start"
+    case "escape":
+      return "back"
+    case "q":
+      return "cancel"
+  }
+  return undefined
+}
+
+// Preserve the hierarchy from renderRunPlan while fitting every long, dynamic
+// value into the review panel. renderRunPlan has already removed terminal
+// controls; this only handles ordinary layout wrapping.
+export function wrapReviewLine(line: string, width: number): string[] {
+  if (!line) return [""]
+  const indent = line.match(/^\s*/)?.[0] ?? ""
+  const prefix = indent.length < Math.max(1, width - 8) ? indent : ""
+  const content = line.slice(indent.length).trim()
+  const available = Math.max(1, width - prefix.length)
+  const wrapped: string[] = []
+  let remaining = content
+
+  while (remaining.length > available) {
+    let breakAt = remaining.lastIndexOf(" ", available)
+    if (breakAt < 1) breakAt = available
+    wrapped.push(remaining.slice(0, breakAt).trimEnd())
+    remaining = remaining.slice(breakAt).trimStart()
+  }
+  wrapped.push(remaining)
+
+  return wrapped.map((part, index) => `${index === 0 ? prefix : " ".repeat(prefix.length)}${part}`)
+}
+
+function reviewTextLine(line: string): StyledText {
+  if (line === "Review Convoy run") return new StyledText([bold(fg(theme.accent)(line))])
+  if (/^(Prompt|Target|Pipeline|Gateway|Branch naming|Runtime|Hooks|Resume gateway override):/.test(line)) {
+    return new StyledText([bold(fg(theme.text)(line))])
+  }
+  if (/^\s*(Logical|Target|Model|Judge|pre|post):/.test(line)) return new StyledText([fg(theme.dim)(line)])
+  return new StyledText([fg(theme.text)(line)])
+}
+
+type LauncherWheelEvent = {
+  scroll?: { direction: string; delta: number }
+  preventDefault(): void
+  stopPropagation(): void
+}
+
+function wheelDelta(event: LauncherWheelEvent): number {
+  const scroll = event.scroll
+  if (!scroll || (scroll.direction !== "up" && scroll.direction !== "down")) return 0
+  const magnitude = Math.max(1, Math.round(scroll.delta || 1))
+  return scroll.direction === "up" ? -magnitude : magnitude
 }
 
 // A slider-style toggle: the knob (●) sits on the right when on, left when

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -8,7 +8,7 @@ import { startLimitsPoller } from "./limits"
 import { builtInPipelines, defaultPipelineName, resolvePipeline } from "./pipeline"
 import { stepRunnerFor } from "./step-runners"
 import { gatewayLabel, modelGateways, type ModelGateway } from "./model-routing"
-import { renderRunPlan } from "./run-review"
+import { runReviewLines } from "./review-tui"
 import { joinLines, limitsRow, padBetween, paletteForTerminal, plain, raw, setTheme, spinnerFrame, terminalBackgroundHex, theme, truncate } from "./tui-theme"
 
 import type { ConvoyConfig } from "./config"
@@ -826,12 +826,16 @@ class LaunchPicker {
   private render() {
     if (this.renderer.isDestroyed) return
     const innerWidth = Math.max(40, this.renderer.width - 6)
+    const reviewing = this.mode === "review"
+    // The Review step owns the whole screen: the pipeline list would only
+    // repeat what the plan already freezes, and the plan needs the width.
+    this.pipelineBox.visible = !reviewing
     const pipelineWidth = this.pipelineWidth()
-    const detailWidth = Math.max(40, this.renderer.width - pipelineWidth - 7)
+    const detailWidth = reviewing ? innerWidth : Math.max(40, this.renderer.width - pipelineWidth - 7)
 
     this.pipelineBox.width = pipelineWidth
     this.detailBox.width = detailWidth
-    this.detailBox.title = this.mode === "review" ? " review " : " run setup "
+    this.detailBox.title = reviewing ? " review " : " run setup "
     // Mirror the dashboard focus cue: the accented border marks where Enter,
     // Esc, and the navigation keys apply in the current setup step.
     this.pipelineBox.borderColor = this.mode === "pipelines" ? theme.accent : theme.borderDim
@@ -1071,17 +1075,13 @@ class LaunchPicker {
     const prepared = this.prepared
     if (!prepared) return joinLines([t`${fg(theme.red)("Unable to load the run review.")}`])
 
-    const rendered = renderRunPlan(prepared.plan, false, { fullPrompt: this.reviewFullPrompt })
-    const reviewLines = rendered
-      .trimEnd()
-      .split("\n")
-      .flatMap((line) => wrapReviewLine(line, width))
+    const reviewRows = runReviewLines(prepared.plan, width, { fullPrompt: this.reviewFullPrompt })
     const visible = this.listHeight()
-    const maxScroll = Math.max(0, reviewLines.length - visible)
+    const maxScroll = Math.max(0, reviewRows.length - visible)
     this.reviewScroll = clamp(this.reviewScroll, 0, maxScroll)
-    this.reviewTotalLines = reviewLines.length
+    this.reviewTotalLines = reviewRows.length
 
-    const lines = reviewLines.slice(this.reviewScroll, this.reviewScroll + visible).map(reviewTextLine)
+    const lines = reviewRows.slice(this.reviewScroll, this.reviewScroll + visible)
     while (lines.length < visible) lines.push(plain(""))
     return joinLines(lines)
   }
@@ -1136,7 +1136,7 @@ class LaunchPicker {
       )
     }
     return padBetween(
-      [fg(theme.dim)("↑/↓ select · "), fg(theme.accent)("space"), fg(theme.dim)(" toggle · "), fg(theme.accent)("g"), fg(theme.dim)(" gateway · "), fg(theme.accent)("enter"), fg(theme.dim)(" start · "), fg(theme.accent)("p"), fg(theme.dim)(" prompt · "), fg(theme.accent)("q"), fg(theme.dim)(" quit")],
+      [fg(theme.dim)("↑/↓ select · "), fg(theme.accent)("space"), fg(theme.dim)(" toggle · "), fg(theme.accent)("g"), fg(theme.dim)(" gateway · "), fg(theme.accent)("enter"), fg(theme.dim)(" review · "), fg(theme.accent)("p"), fg(theme.dim)(" prompt · "), fg(theme.accent)("q"), fg(theme.dim)(" quit")],
       [fg(theme.faint)(`${this.optionIndex + 1}/${toggles.length}`)],
       width,
     )
@@ -1192,38 +1192,6 @@ export function reviewActionForKey(key: Pick<KeyEvent, "name" | "shift">): Revie
       return "cancel"
   }
   return undefined
-}
-
-// Preserve the hierarchy from renderRunPlan while fitting every long, dynamic
-// value into the review panel. renderRunPlan has already removed terminal
-// controls; this only handles ordinary layout wrapping.
-export function wrapReviewLine(line: string, width: number): string[] {
-  if (!line) return [""]
-  const indent = line.match(/^\s*/)?.[0] ?? ""
-  const prefix = indent.length < Math.max(1, width - 8) ? indent : ""
-  const content = line.slice(indent.length).trim()
-  const available = Math.max(1, width - prefix.length)
-  const wrapped: string[] = []
-  let remaining = content
-
-  while (remaining.length > available) {
-    let breakAt = remaining.lastIndexOf(" ", available)
-    if (breakAt < 1) breakAt = available
-    wrapped.push(remaining.slice(0, breakAt).trimEnd())
-    remaining = remaining.slice(breakAt).trimStart()
-  }
-  wrapped.push(remaining)
-
-  return wrapped.map((part, index) => `${index === 0 ? prefix : " ".repeat(prefix.length)}${part}`)
-}
-
-function reviewTextLine(line: string): StyledText {
-  if (line === "Review Convoy run") return new StyledText([bold(fg(theme.accent)(line))])
-  if (/^(Prompt|Target|Pipeline|Gateway|Branch naming|Runtime|Hooks|Resume gateway override):/.test(line)) {
-    return new StyledText([bold(fg(theme.text)(line))])
-  }
-  if (/^\s*(Logical|Target|Model|Judge|pre|post):/.test(line)) return new StyledText([fg(theme.dim)(line)])
-  return new StyledText([fg(theme.text)(line)])
 }
 
 type LauncherWheelEvent = {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -65,9 +65,25 @@ export type RunMetadataStore = {
   flush(): Promise<void>
 }
 
+export type OpenRunMetadataOptions = {
+  gateway?: ModelGateway
+  /** A CLI gateway override reroutes only phases that have not finished. */
+  gatewayOverride?: boolean
+  /** A CLI model override reroutes only phases that have not finished. */
+  modelOverride?: boolean
+  /** Execute the reviewed resume subset without replacing the stored full pipeline. */
+  useExecutionPipeline?: boolean
+}
+
 const saveDebounceMs = 2_000
 
-export async function openRunMetadata(workspace: Workspace, targetDir: string, pipeline: Pipeline, gateway: ModelGateway = "configured", gatewayOverride = false): Promise<RunMetadataStore> {
+export async function openRunMetadata(
+  workspace: Workspace,
+  targetDir: string,
+  pipeline: Pipeline,
+  options: OpenRunMetadataOptions = {},
+): Promise<RunMetadataStore> {
+  const gateway = options.gateway ?? "configured"
   const path = join(workspace.dir, "metadata.json")
   const data = (await loadMetadata(path, workspace.runID)) ?? newMetadata(workspace.runID, targetDir)
   // Step names are user-configurable safe identifiers and may still equal
@@ -75,20 +91,25 @@ export async function openRunMetadata(workspace: Workspace, targetDir: string, p
   data.phases = Object.assign(Object.create(null) as Record<string, PhaseMetadata>, data.phases)
   // First open freezes the pipeline; pre-pipeline (v1) runs adopt the current
   // one, whose default step names match what those runs executed.
-  let effectivePipeline = (data.pipeline ??= pipeline)
-  if (gatewayOverride && data.pipeline) {
+  let frozenPipeline = (data.pipeline ??= pipeline)
+  if (options.gatewayOverride || options.modelOverride) {
     const routedByName = new Map(pipeline.steps.map((step) => [step.name, step]))
-    effectivePipeline = data.pipeline = {
-      ...data.pipeline,
-      steps: data.pipeline.steps.map((step) => {
+    frozenPipeline = data.pipeline = {
+      ...frozenPipeline,
+      steps: frozenPipeline.steps.map((step) => {
         const status = data.phases[step.name]?.status
         return status === "completed" || status === "skipped" ? step : (routedByName.get(step.name) ?? step)
       }),
     }
-    data.modelRouting = { gateway }
+    if (options.gatewayOverride) data.modelRouting = { gateway }
   } else {
     data.modelRouting ??= { gateway }
   }
+  // A filtered resume is deliberately transient: it executes exactly the
+  // reviewed subset, while metadata retains the complete frozen pipeline for
+  // future resumes.
+  const effectivePipeline = options.useExecutionPipeline ? pipeline : frozenPipeline
+  assertSafePipelineArtifacts(frozenPipeline)
   assertSafePipelineArtifacts(effectivePipeline)
   // One accumulator per phase. Kept out of the persisted shape — PhaseUsage holds
   // cumulative per-session totals, so re-counting them on resume would double up.
@@ -129,7 +150,7 @@ export async function openRunMetadata(workspace: Workspace, targetDir: string, p
   for (const step of effectivePipeline.steps) {
     if (step.type !== "agent" || !step.resolvedModel) continue
     const entry = phase(step.name)
-    if (gatewayOverride && entry.status !== "completed" && entry.status !== "skipped") {
+    if ((options.gatewayOverride || options.modelOverride) && entry.status !== "completed" && entry.status !== "skipped") {
       entry.logicalModel = step.resolvedModel.logical
       entry.targetModel = step.resolvedModel.target
     } else {

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -13,6 +13,7 @@ import type {
   ProgressUsage,
 } from "./progress"
 import type { Pipeline } from "./types"
+import type { ModelGateway } from "./model-routing"
 import { PhaseUsage } from "./usage"
 import type { Workspace } from "./workspace"
 
@@ -27,6 +28,8 @@ export type PhaseMetadata = {
   cost?: number
   tokens?: ProgressTokens
   model?: string
+  logicalModel?: string
+  targetModel?: string
   repositoryBaseline?: RepoSnapshot
 }
 
@@ -38,6 +41,7 @@ export type RunMetadata = {
   updatedAt: number
   /** The resolved pipeline this run executes; resume replays it even if the project config changed since. */
   pipeline?: Pipeline
+  modelRouting?: { gateway: ModelGateway }
   /** The live opencode server for this run while it executes; cleared on shutdown, so a lingering entry means the run process died mid-flight. Lets `convoy runs` attach to a running run. */
   server?: { url: string; pid: number; startedAt: number }
   phases: Record<string, PhaseMetadata>
@@ -63,7 +67,7 @@ export type RunMetadataStore = {
 
 const saveDebounceMs = 2_000
 
-export async function openRunMetadata(workspace: Workspace, targetDir: string, pipeline: Pipeline): Promise<RunMetadataStore> {
+export async function openRunMetadata(workspace: Workspace, targetDir: string, pipeline: Pipeline, gateway: ModelGateway = "configured", gatewayOverride = false): Promise<RunMetadataStore> {
   const path = join(workspace.dir, "metadata.json")
   const data = (await loadMetadata(path, workspace.runID)) ?? newMetadata(workspace.runID, targetDir)
   // Step names are user-configurable safe identifiers and may still equal
@@ -71,7 +75,20 @@ export async function openRunMetadata(workspace: Workspace, targetDir: string, p
   data.phases = Object.assign(Object.create(null) as Record<string, PhaseMetadata>, data.phases)
   // First open freezes the pipeline; pre-pipeline (v1) runs adopt the current
   // one, whose default step names match what those runs executed.
-  const effectivePipeline = (data.pipeline ??= pipeline)
+  let effectivePipeline = (data.pipeline ??= pipeline)
+  if (gatewayOverride && data.pipeline) {
+    const routedByName = new Map(pipeline.steps.map((step) => [step.name, step]))
+    effectivePipeline = data.pipeline = {
+      ...data.pipeline,
+      steps: data.pipeline.steps.map((step) => {
+        const status = data.phases[step.name]?.status
+        return status === "completed" || status === "skipped" ? step : (routedByName.get(step.name) ?? step)
+      }),
+    }
+    data.modelRouting = { gateway }
+  } else {
+    data.modelRouting ??= { gateway }
+  }
   assertSafePipelineArtifacts(effectivePipeline)
   // One accumulator per phase. Kept out of the persisted shape — PhaseUsage holds
   // cumulative per-session totals, so re-counting them on resume would double up.
@@ -109,6 +126,17 @@ export async function openRunMetadata(workspace: Workspace, targetDir: string, p
   }
 
   const phase = (name: string) => (data.phases[name] ??= { status: "pending" })
+  for (const step of effectivePipeline.steps) {
+    if (step.type !== "agent" || !step.resolvedModel) continue
+    const entry = phase(step.name)
+    if (gatewayOverride && entry.status !== "completed" && entry.status !== "skipped") {
+      entry.logicalModel = step.resolvedModel.logical
+      entry.targetModel = step.resolvedModel.target
+    } else {
+      entry.logicalModel ??= step.resolvedModel.logical
+      entry.targetModel ??= step.resolvedModel.target
+    }
+  }
 
   const recalculate = (name: string) => {
     const accumulator = usage.get(name)

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -62,7 +62,8 @@ export function resolveModel(configured: string, gateway: ModelGateway, override
   const configuredParts = splitModelVariant(configured)
   const recovered = logicalModel(configured)
   const logical = recovered.model
-  const variant = recovered.variant
+  const logicalVariant = recovered.variant
+  let variant = logicalVariant
 
   let physical: string
   if (gateway === "configured") {
@@ -71,10 +72,14 @@ export function resolveModel(configured: string, gateway: ModelGateway, override
     const override = overrides[logical]?.[gateway]
     if (override) {
       const overrideParts = splitModelVariant(override)
-      if (overrideParts.variant && variant && overrideParts.variant !== variant) {
-        throw new Error(`modelRouting override for ${logical}.${gateway} must not replace variant #${variant}`)
+      if (overrideParts.variant && logicalVariant && overrideParts.variant !== logicalVariant) {
+        throw new Error(`modelRouting override for ${logical}.${gateway} must not replace variant #${logicalVariant}`)
       }
       physical = overrideParts.model
+      // An override can select a provider-specific default variant when the
+      // configured logical model does not name one. A caller-selected variant
+      // still wins (and conflicting values above remain an error).
+      variant ??= overrideParts.variant
     } else {
       const [provider, ...model] = logical.split("/")
       if (!provider || model.length === 0) throw unsafeConversion(configured, gateway)
@@ -91,7 +96,7 @@ export function resolveModel(configured: string, gateway: ModelGateway, override
   const target = `${physical}${variant ? `#${variant}` : ""}`
   return {
     configured,
-    logical: `${logical}${variant ? `#${variant}` : ""}`,
+    logical: `${logical}${logicalVariant ? `#${logicalVariant}` : ""}`,
     gateway,
     providerID,
     modelID,

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -36,8 +36,15 @@ export function logicalModel(value: string): { model: string; variant?: string }
   if (parts.length < 2) throw new Error(`model must look like provider/model[#variant], got "${value}"`)
   if (gatewayProviders.has(parts[0]!)) parts.shift()
   if (parts.length < 2) throw new Error(`gateway model must include its logical provider, got "${value}"`)
+  if (parts.some((part) => !isSafeModelPart(part)) || (parsed.variant !== undefined && !isSafeModelPart(parsed.variant))) {
+    throw new Error(`model must contain non-empty provider, model, and variant segments without whitespace or control characters, got "${value}"`)
+  }
   parts[0] = directAliases[parts[0]!] ?? parts[0]!
   return { model: parts.join("/"), ...(parsed.variant ? { variant: parsed.variant } : {}) }
+}
+
+function isSafeModelPart(value: string) {
+  return value.length > 0 && !/[\s/#\u0000-\u001f\u007f-\u009f]/u.test(value)
 }
 
 export function resolveModel(configured: string, gateway: ModelGateway, overrides: ModelRoutingOverrides = {}): ResolvedModel {

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -29,6 +29,17 @@ export function isModelGateway(value: unknown): value is ModelGateway {
   return typeof value === "string" && modelGateways.includes(value as ModelGateway)
 }
 
+/** Single display label shared by the launcher, config editor, review, and errors. */
+export function gatewayLabel(gateway: ModelGateway): string {
+  return gateway === "vercel"
+    ? "Vercel AI Gateway"
+    : gateway === "openrouter"
+      ? "OpenRouter"
+      : gateway === "direct"
+        ? "Direct"
+        : "As configured"
+}
+
 /** Recover the provider-owned model identity from a direct or gateway-wrapped OpenCode model. */
 export function logicalModel(value: string): { model: string; variant?: string } {
   const parsed = splitModelVariant(value)

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -1,0 +1,89 @@
+import { splitModelVariant } from "./pipeline"
+
+export const modelGateways = ["configured", "direct", "openrouter", "vercel"] as const
+export type ModelGateway = (typeof modelGateways)[number]
+
+export type ModelRoutingOverrides = Record<string, Partial<Record<ModelGateway, string>>>
+
+export type ModelRoutingConfig = {
+  gateway?: ModelGateway
+  overrides: ModelRoutingOverrides
+}
+
+export type ResolvedModel = {
+  configured: string
+  logical: string
+  gateway: ModelGateway
+  providerID: string
+  modelID: string
+  variant?: string
+  target: string
+}
+
+const gatewayProviders = new Set(["openrouter", "vercel"])
+const directAliases: Record<string, string> = { "z-ai": "zai" }
+const openRouterAliases: Record<string, string> = { zai: "z-ai" }
+const safelyRoutableProviders = new Set(["openai", "anthropic", "zai"])
+
+export function isModelGateway(value: unknown): value is ModelGateway {
+  return typeof value === "string" && modelGateways.includes(value as ModelGateway)
+}
+
+/** Recover the provider-owned model identity from a direct or gateway-wrapped OpenCode model. */
+export function logicalModel(value: string): { model: string; variant?: string } {
+  const parsed = splitModelVariant(value)
+  const parts = parsed.model.split("/")
+  if (parts.length < 2) throw new Error(`model must look like provider/model[#variant], got "${value}"`)
+  if (gatewayProviders.has(parts[0]!)) parts.shift()
+  if (parts.length < 2) throw new Error(`gateway model must include its logical provider, got "${value}"`)
+  parts[0] = directAliases[parts[0]!] ?? parts[0]!
+  return { model: parts.join("/"), ...(parsed.variant ? { variant: parsed.variant } : {}) }
+}
+
+export function resolveModel(configured: string, gateway: ModelGateway, overrides: ModelRoutingOverrides = {}): ResolvedModel {
+  const configuredParts = splitModelVariant(configured)
+  const recovered = logicalModel(configured)
+  const logical = recovered.model
+  const variant = recovered.variant
+
+  let physical: string
+  if (gateway === "configured") {
+    physical = configuredParts.model
+  } else {
+    const override = overrides[logical]?.[gateway]
+    if (override) {
+      const overrideParts = splitModelVariant(override)
+      if (overrideParts.variant && variant && overrideParts.variant !== variant) {
+        throw new Error(`modelRouting override for ${logical}.${gateway} must not replace variant #${variant}`)
+      }
+      physical = overrideParts.model
+    } else {
+      const [provider, ...model] = logical.split("/")
+      if (!provider || model.length === 0) throw unsafeConversion(configured, gateway)
+      if (!safelyRoutableProviders.has(provider)) throw unsafeConversion(configured, gateway)
+      if (gateway === "direct") physical = `${provider}/${model.join("/")}`
+      else if (gateway === "openrouter") physical = `openrouter/${openRouterAliases[provider] ?? provider}/${model.join("/")}`
+      else physical = `vercel/${provider}/${model.join("/")}`
+    }
+  }
+
+  const [providerID, ...modelParts] = physical.split("/")
+  const modelID = modelParts.join("/")
+  if (!providerID || !modelID) throw unsafeConversion(configured, gateway)
+  const target = `${physical}${variant ? `#${variant}` : ""}`
+  return {
+    configured,
+    logical: `${logical}${variant ? `#${variant}` : ""}`,
+    gateway,
+    providerID,
+    modelID,
+    ...(variant ? { variant } : {}),
+    target,
+  }
+}
+
+function unsafeConversion(configured: string, gateway: ModelGateway) {
+  return new Error(
+    `cannot safely route model "${configured}" through ${gateway}; add modelRouting.overrides or select --gateway configured`,
+  )
+}

--- a/src/preflight-validation.ts
+++ b/src/preflight-validation.ts
@@ -10,6 +10,7 @@ export function preflightTargets(plan: RunPlan): ResolvedModel[] {
     step.type === "agent" && step.runner !== "claude-code" && step.resolvedModel ? [step.resolvedModel] : [],
   )
   if (plan.smartJudge) targets.push(plan.smartJudge.model)
+  if (plan.branchNamer) targets.push(plan.branchNamer.model)
   return targets
 }
 

--- a/src/preflight-validation.ts
+++ b/src/preflight-validation.ts
@@ -1,0 +1,36 @@
+import { gatewayLabel, type ResolvedModel } from "./model-routing"
+import type { RunPlan } from "./types"
+
+type DiscoveredProvider = { id?: unknown; enabled?: unknown }
+type DiscoveredModel = { providerID?: unknown; id?: unknown }
+
+/** The exact OpenCode targets that must be available before a run can begin. */
+export function preflightTargets(plan: RunPlan): ResolvedModel[] {
+  const targets = plan.pipeline.steps.flatMap((step) =>
+    step.type === "agent" && step.runner !== "claude-code" && step.resolvedModel ? [step.resolvedModel] : [],
+  )
+  if (plan.smartJudge) targets.push(plan.smartJudge.model)
+  return targets
+}
+
+/** Throws actionable errors for provider and physical-model discovery results. */
+export function validatePreflightTargets(
+  targets: readonly ResolvedModel[],
+  providers: readonly DiscoveredProvider[],
+  models: readonly DiscoveredModel[],
+): void {
+  for (const target of targets) {
+    const provider = providers.find((entry) => entry.id === target.providerID)
+    if (!provider || provider.enabled === false) {
+      const auth = target.providerID === "vercel"
+        ? "Authenticate with `opencode providers login` (Vercel AI Gateway) or set AI_GATEWAY_API_KEY."
+        : `Authenticate provider ${target.providerID} with \`opencode providers login\`.`
+      throw new Error(`Cannot start run\n\nMissing provider credentials: ${target.providerID}\n\n${auth}`)
+    }
+    if (!models.some((model) => model.providerID === target.providerID && model.id === target.modelID)) {
+      throw new Error(
+        `Model unavailable through ${gatewayLabel(target.gateway)}:\n\n  logical: ${target.logical}\n  target:  ${target.target}\n\nAdd modelRouting.overrides or select --gateway configured.`,
+      )
+    }
+  }
+}

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,0 +1,40 @@
+import { startOpencode } from "./opencode"
+import type { RunPlan } from "./types"
+
+const preflightTimeoutMs = 15_000
+
+/** Validate the exact physical OpenCode targets after approval and before run/worktree creation. */
+export async function preflightRunPlan(plan: RunPlan): Promise<void> {
+  const targets = plan.pipeline.steps.flatMap((step) =>
+    step.type === "agent" && step.runner !== "claude-code" && step.resolvedModel ? [step.resolvedModel] : [],
+  )
+  if (plan.smartJudge) targets.push(plan.smartJudge.model)
+  if (targets.length === 0) return
+
+  const handle = await startOpencode({}, AbortSignal.timeout(preflightTimeoutMs))
+  try {
+    const [providerResult, modelResult] = await Promise.all([
+      handle.client.v2.provider.list({ location: { directory: plan.target.directory } }),
+      handle.client.v2.model.list({ location: { directory: plan.target.directory } }),
+    ])
+    if (providerResult.error || modelResult.error) throw new Error("OpenCode could not list enabled providers and models")
+    const providers = providerResult.data ?? []
+    const models = modelResult.data ?? []
+    for (const target of targets) {
+      const provider = providers.find((entry) => entry.id === target.providerID)
+      if (!provider || provider.enabled === false) {
+        const auth = target.providerID === "vercel"
+          ? "Authenticate with `opencode providers login` (Vercel AI Gateway) or set AI_GATEWAY_API_KEY."
+          : `Authenticate provider ${target.providerID} with \`opencode providers login\`.`
+        throw new Error(`Cannot start run\n\nMissing provider credentials: ${target.providerID}\n\n${auth}`)
+      }
+      if (!models.some((model) => model.providerID === target.providerID && model.id === target.modelID)) {
+        throw new Error(
+          `Model unavailable through ${target.gateway}:\n\n  logical: ${target.logical}\n  target:  ${target.target}\n\nAdd modelRouting.overrides or select --gateway configured.`,
+        )
+      }
+    }
+  } finally {
+    handle.close()
+  }
+}

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,4 +1,5 @@
 import { startOpencode } from "./opencode"
+import { gatewayLabel } from "./model-routing"
 import type { RunPlan } from "./types"
 
 const preflightTimeoutMs = 15_000
@@ -34,7 +35,7 @@ export async function preflightRunPlan(plan: RunPlan): Promise<void> {
       }
       if (!models.some((model) => model.providerID === target.providerID && model.id === target.modelID)) {
         throw new Error(
-          `Model unavailable through ${target.gateway}:\n\n  logical: ${target.logical}\n  target:  ${target.target}\n\nAdd modelRouting.overrides or select --gateway configured.`,
+          `Model unavailable through ${gatewayLabel(target.gateway)}:\n\n  logical: ${target.logical}\n  target:  ${target.target}\n\nAdd modelRouting.overrides or select --gateway configured.`,
         )
       }
     }

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -11,12 +11,16 @@ export async function preflightRunPlan(plan: RunPlan): Promise<void> {
   if (plan.smartJudge) targets.push(plan.smartJudge.model)
   if (targets.length === 0) return
 
-  const handle = await startOpencode({}, AbortSignal.timeout(preflightTimeoutMs))
+  const timeout = AbortSignal.timeout(preflightTimeoutMs)
+  const handle = await startOpencode({}, timeout)
   try {
-    const [providerResult, modelResult] = await Promise.all([
-      handle.client.v2.provider.list({ location: { directory: plan.target.directory } }),
-      handle.client.v2.model.list({ location: { directory: plan.target.directory } }),
-    ])
+    const [providerResult, modelResult] = await withinPreflightTimeout(
+      Promise.all([
+        handle.client.v2.provider.list({ location: { directory: plan.target.directory } }),
+        handle.client.v2.model.list({ location: { directory: plan.target.directory } }),
+      ]),
+      timeout,
+    )
     if (providerResult.error || modelResult.error) throw new Error("OpenCode could not list enabled providers and models")
     const providers = providerResult.data ?? []
     const models = modelResult.data ?? []
@@ -37,4 +41,14 @@ export async function preflightRunPlan(plan: RunPlan): Promise<void> {
   } finally {
     handle.close()
   }
+}
+
+function withinPreflightTimeout<T>(operation: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(new Error("OpenCode preflight timed out"))
+  return Promise.race([
+    operation,
+    new Promise<never>((_, reject) => {
+      signal.addEventListener("abort", () => reject(new Error("OpenCode preflight timed out")), { once: true })
+    }),
+  ])
 }

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,15 +1,12 @@
 import { startOpencode } from "./opencode"
-import { gatewayLabel } from "./model-routing"
 import type { RunPlan } from "./types"
+import { preflightTargets, validatePreflightTargets } from "./preflight-validation"
 
 const preflightTimeoutMs = 15_000
 
 /** Validate the exact physical OpenCode targets after approval and before run/worktree creation. */
 export async function preflightRunPlan(plan: RunPlan): Promise<void> {
-  const targets = plan.pipeline.steps.flatMap((step) =>
-    step.type === "agent" && step.runner !== "claude-code" && step.resolvedModel ? [step.resolvedModel] : [],
-  )
-  if (plan.smartJudge) targets.push(plan.smartJudge.model)
+  const targets = preflightTargets(plan)
   if (targets.length === 0) return
 
   const timeout = AbortSignal.timeout(preflightTimeoutMs)
@@ -23,22 +20,7 @@ export async function preflightRunPlan(plan: RunPlan): Promise<void> {
       timeout,
     )
     if (providerResult.error || modelResult.error) throw new Error("OpenCode could not list enabled providers and models")
-    const providers = providerResult.data ?? []
-    const models = modelResult.data ?? []
-    for (const target of targets) {
-      const provider = providers.find((entry) => entry.id === target.providerID)
-      if (!provider || provider.enabled === false) {
-        const auth = target.providerID === "vercel"
-          ? "Authenticate with `opencode providers login` (Vercel AI Gateway) or set AI_GATEWAY_API_KEY."
-          : `Authenticate provider ${target.providerID} with \`opencode providers login\`.`
-        throw new Error(`Cannot start run\n\nMissing provider credentials: ${target.providerID}\n\n${auth}`)
-      }
-      if (!models.some((model) => model.providerID === target.providerID && model.id === target.modelID)) {
-        throw new Error(
-          `Model unavailable through ${gatewayLabel(target.gateway)}:\n\n  logical: ${target.logical}\n  target:  ${target.target}\n\nAdd modelRouting.overrides or select --gateway configured.`,
-        )
-      }
-    }
+    validatePreflightTargets(targets, providerResult.data ?? [], modelResult.data ?? [])
   } finally {
     handle.close()
   }

--- a/src/review-tui.ts
+++ b/src/review-tui.ts
@@ -1,0 +1,195 @@
+import { homedir } from "node:os"
+
+import { StyledText, fg } from "@opentui/core"
+
+import { gatewayLabel } from "./model-routing"
+import { plannedStepModel } from "./run-plan"
+import { sanitizeReviewInline, sanitizeReviewText } from "./run-review"
+import { stepRunnerFor } from "./step-runners"
+import { plain, raw, theme, truncate } from "./tui-theme"
+
+import type { TextChunk } from "@opentui/core"
+import type { AgentStep, HookSpec, RunPlan } from "./types"
+
+// Same 9-cell label column as the launcher's options screen ("pipeline ", …).
+const labelWidth = 9
+
+export type RunReviewRenderOptions = {
+  /** Show the complete sanitized prompt instead of its one-line excerpt. */
+  fullPrompt?: boolean
+}
+
+/**
+ * The launcher's full-width Review step: a sectioned, styled rendering of the
+ * exact frozen plan the runner will execute. Section labels share the options
+ * screen's label column; models collapse to one dim line when logical and
+ * physical targets match and become `logical → target` when a gateway reroutes
+ * them, so the physical target is always visible without duplicated noise.
+ */
+export function runReviewLines(plan: RunPlan, width: number, options: RunReviewRenderOptions = {}): StyledText[] {
+  const rows: StyledText[] = []
+  const value = Math.max(20, width - labelWidth)
+
+  const prompt = sanitizeReviewText(plan.prompt.text)
+  const lineCount = prompt.split("\n").length
+  rows.push(labelRow("prompt", [fg(theme.text)(`${plan.prompt.source} · ${prompt.length} characters · ${lineCount} line${lineCount === 1 ? "" : "s"}`)]))
+  if (options.fullPrompt) {
+    for (const line of prompt.split("\n")) {
+      for (const wrapped of hardWrap(line, value)) rows.push(continuation([fg(theme.dim)(wrapped)]))
+    }
+  } else {
+    rows.push(continuation([fg(theme.dim)(truncate(prompt.replace(/\s+/g, " ").trim(), value))]))
+  }
+  rows.push(plain(""))
+
+  rows.push(labelRow("target", [fg(theme.text)(truncate(displayPath(sanitizeReviewInline(plan.target.directory)), value))]))
+  rows.push(continuation([fg(theme.dim)(`diff base ${sanitizeReviewInline(plan.target.baseRef)} · ${plan.target.dirty ? "dirty tree included" : "clean tree required"}`)]))
+  rows.push(continuation([fg(theme.dim)(plan.target.worktree ? "worktree and branch created after confirmation" : "runs in the current checkout")]))
+  if (plan.branchNamer) {
+    rows.push(
+      continuation([
+        fg(theme.faint)("branch named by "),
+        fg(theme.text)(truncate(sanitizeReviewInline(plan.branchNamer.model.target), Math.max(8, value - 34))),
+        fg(theme.faint)(" after confirmation"),
+      ]),
+    )
+  }
+  rows.push(plain(""))
+
+  rows.push(labelRow("gateway", [fg(theme.text)(gatewayLabel(plan.modelRouting.gateway))]))
+  if (plan.resume?.gatewayOverride) {
+    const override = plan.resume.gatewayOverride
+    rows.push(continuation([fg(theme.yellow)("resume override · "), fg(theme.dim)(`original ${gatewayLabel(override.original)} · pending phases ${gatewayLabel(override.pending)}`)]))
+  }
+  rows.push(plain(""))
+
+  rows.push(labelRow("pipeline", [fg(theme.text)(truncate(`${sanitizeReviewInline(plan.pipeline.name)} · ${pipelineSummary(plan)}`, value))]))
+  pushStepRows(rows, plan, width)
+  rows.push(plain(""))
+
+  const hooks = [...plan.hooks.pre.map((hook) => hookChunks("pre", hook, value)), ...plan.hooks.post.map((hook) => hookChunks("post", hook, value))]
+  if (hooks.length > 0) {
+    rows.push(labelRow("hooks", hooks[0]!))
+    for (const chunks of hooks.slice(1)) rows.push(continuation(chunks))
+    rows.push(plain(""))
+  }
+
+  const runtime = `${plan.permissions} permissions · ${plan.attachments.length} attachment${plan.attachments.length === 1 ? "" : "s"}`
+  const judge = plan.smartJudge ? sanitizeReviewInline(plan.smartJudge.model.target) : ""
+  if (judge && labelWidth + runtime.length + 9 + judge.length <= width) {
+    rows.push(labelRow("runtime", [fg(theme.text)(runtime), fg(theme.faint)(" · judge "), fg(theme.dim)(judge)]))
+  } else {
+    rows.push(labelRow("runtime", [fg(theme.text)(runtime)]))
+    if (judge) rows.push(continuation([fg(theme.faint)("judge "), fg(theme.dim)(truncate(judge, Math.max(8, value - 6)))]))
+  }
+
+  return rows
+}
+
+function pipelineSummary(plan: RunPlan): string {
+  const steps = plan.pipeline.steps
+  const agents = steps.filter((step): step is AgentStep => step.type === "agent")
+  const writable = agents.filter((step) => !step.readOnly).length
+  const readOnly = agents.length - writable
+  const humans = steps.length - agents.length
+  const parts = [`${steps.length} step${steps.length === 1 ? "" : "s"}`]
+  if (writable) parts.push(`${writable} writable`)
+  if (readOnly) parts.push(`${readOnly} read-only`)
+  if (humans) parts.push(`${humans} manual`)
+  return parts.join(" · ")
+}
+
+function pushStepRows(rows: StyledText[], plan: RunPlan, width: number) {
+  const steps = plan.pipeline.steps
+  let index = 0
+  while (index < steps.length) {
+    const step = steps[index]!
+    if (step.type === "human") {
+      rows.push(continuation([fg(theme.faint)("○ "), fg(theme.yellow)(truncate(sanitizeReviewInline(step.name), Math.max(8, width - labelWidth - 16))), fg(theme.faint)(" · manual gate")]))
+      index += 1
+      continue
+    }
+
+    let end = index + 1
+    while (end < steps.length) {
+      const next = steps[end]!
+      if (next.type !== "agent" || next.groupId !== step.groupId) break
+      end += 1
+    }
+    const members = steps.slice(index, end) as AgentStep[]
+    if (members.length === 1) {
+      pushAgentStep(rows, step, plan, width)
+    } else {
+      const shared = members.every((member) => member.stepName === members[0]!.stepName)
+      const title = shared ? members[0]!.stepName : "parallel"
+      const attempts = members[0]!.maxAttempts ?? plan.maxAttempts
+      const meta = `${members.length} runs · ${members[0]!.readOnly ? "read-only" : "writable"} · ${attemptsLabel(attempts)}`
+      rows.push(continuation([fg(theme.faint)("○ "), fg(theme.text)(truncate(sanitizeReviewInline(title), Math.max(8, width - labelWidth - meta.length - 6))), fg(theme.faint)(` · ${meta}`)]))
+      members.forEach((member, memberIndex) => {
+        const connector = memberIndex === members.length - 1 ? "└─ " : "├─ "
+        const sharedPrefix = `${member.stepName}__`
+        const label = shared && member.name.startsWith(sharedPrefix) ? member.name.slice(sharedPrefix.length) : member.name
+        rows.push(continuation([fg(theme.faint)(connector), fg(theme.text)(truncate(sanitizeReviewInline(label), Math.max(8, width - labelWidth - 5)))], labelWidth + 2))
+        rows.push(...modelRows(member, labelWidth + 5, width))
+      })
+    }
+    index = end
+  }
+}
+
+function pushAgentStep(rows: StyledText[], step: AgentStep, plan: RunPlan, width: number) {
+  const runner = stepRunnerFor(step.runner)
+  const attempts = step.maxAttempts ?? plan.maxAttempts
+  const engine = runner.id === "opencode" ? "" : `${runner.displayName.toLowerCase()} · `
+  const meta = `${engine}${step.readOnly ? "read-only" : "writable"} · ${attemptsLabel(attempts)}`
+  rows.push(continuation([fg(theme.faint)("○ "), fg(theme.text)(truncate(sanitizeReviewInline(step.name), Math.max(8, width - labelWidth - meta.length - 5))), fg(theme.faint)(` · ${meta}`)]))
+  rows.push(...modelRows(step, labelWidth + 2, width))
+}
+
+function modelRows(step: AgentStep, indent: number, width: number): StyledText[] {
+  const available = Math.max(8, width - indent)
+  const resolved = step.resolvedModel
+  if (!resolved) return [continuation([fg(theme.dim)(truncate(sanitizeReviewInline(plannedStepModel(step)), available))], indent)]
+  const logical = sanitizeReviewInline(resolved.logical)
+  const target = sanitizeReviewInline(resolved.target)
+  if (logical === target) return [continuation([fg(theme.dim)(truncate(target, available))], indent)]
+  if (logical.length + 3 + target.length <= available) {
+    return [continuation([fg(theme.dim)(logical), fg(theme.teal)(" → "), fg(theme.text)(target)], indent)]
+  }
+  return [
+    continuation([fg(theme.dim)(truncate(logical, available))], indent),
+    continuation([fg(theme.teal)("→ "), fg(theme.text)(truncate(target, Math.max(8, available - 2)))], indent),
+  ]
+}
+
+function hookChunks(stage: "pre" | "post", hook: HookSpec, value: number): TextChunk[] {
+  const chunks: TextChunk[] = [fg(theme.teal)(stage.padEnd(4)), fg(theme.faint)("  · "), fg(theme.text)(truncate(sanitizeReviewInline(hook.command), Math.max(8, value - 8)))]
+  if (stage === "post" && hook.when && hook.when !== "success") chunks.push(fg(theme.faint)(` · ${sanitizeReviewInline(hook.when)}`))
+  return chunks
+}
+
+function attemptsLabel(attempts: number) {
+  return `${attempts} attempt${attempts === 1 ? "" : "s"}`
+}
+
+function labelRow(label: string, value: TextChunk[]): StyledText {
+  return new StyledText([fg(theme.faint)(label.padEnd(labelWidth)), ...value])
+}
+
+function continuation(value: TextChunk[], indent = labelWidth): StyledText {
+  return new StyledText([raw(" ".repeat(indent)), ...value])
+}
+
+function displayPath(path: string): string {
+  const home = homedir()
+  if (path === home) return "~"
+  if (path.startsWith(`${home}/`)) return `~/${path.slice(home.length + 1)}`
+  return path
+}
+
+function hardWrap(line: string, width: number): string[] {
+  if (width < 1 || line.length <= width) return [line]
+  const wrapped: string[] = []
+  for (let index = 0; index < line.length; index += width) wrapped.push(line.slice(index, index + width))
+  return wrapped
+}

--- a/src/run-plan.ts
+++ b/src/run-plan.ts
@@ -1,0 +1,83 @@
+import { resolveModel, type ModelGateway, type ModelRoutingOverrides } from "./model-routing"
+import { stepRunnerFor } from "./step-runners"
+import type { AgentStep, Pipeline, RunOptions, RunPlan, Step } from "./types"
+
+export type BuildRunPlanInput = RunOptions & {
+  promptSource?: RunPlan["prompt"]["source"]
+  worktree?: boolean
+}
+
+/** Purely resolves the complete execution shape; it performs no filesystem or process effects. */
+export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
+  const gateway = input.gateway ?? "configured"
+  const overrides = input.modelRoutingOverrides ?? {}
+  const pipeline = routePipeline(filterPipeline(input.pipeline, input.onlySteps, input.skipSteps), gateway, overrides, input.modelOverride)
+  const judge = input.smart
+    ? resolveModel(input.smartJudgeModel, gateway, overrides)
+    : undefined
+  const hooks = hooksForPlan(input, pipeline.name)
+  return deepFreeze({
+    prompt: { source: input.promptSource ?? (input.resumeRunID ? "resume" : "inline"), text: input.prompt },
+    target: {
+      directory: input.targetDir,
+      baseRef: input.baseRef,
+      worktree: input.worktree ?? false,
+      dirty: input.includeDirty,
+    },
+    pipeline,
+    modelRouting: { gateway },
+    ...(judge ? { smartJudge: { model: judge } } : {}),
+    hooks,
+    attachments: [...input.files],
+    permissions: input.yolo ? "yolo" : input.smart ? "smart" : "interactive",
+    maxAttempts: input.maxAttempts,
+    ...(input.resumeRunID ? { resume: { runID: input.resumeRunID } } : {}),
+  })
+}
+
+export function routePipeline(pipeline: Pipeline, gateway: ModelGateway, overrides: ModelRoutingOverrides, modelOverride = ""): Pipeline {
+  return {
+    ...pipeline,
+    steps: pipeline.steps.map((step): Step => {
+      if (step.type !== "agent" || stepRunnerFor(step.runner).id !== "opencode") return structuredClone(step)
+      const configured = modelOverride || `${step.model}${step.variant ? `#${step.variant}` : ""}`
+      const resolvedModel = resolveModel(configured, gateway, overrides)
+      return {
+        ...step,
+        model: `${resolvedModel.providerID}/${resolvedModel.modelID}`,
+        ...(resolvedModel.variant ? { variant: resolvedModel.variant } : { variant: undefined }),
+        resolvedModel,
+      }
+    }),
+  }
+}
+
+function filterPipeline(pipeline: Pipeline, only: string[], skip: string[]): Pipeline {
+  const selected = (step: Step) => {
+    const logicalName = step.type === "agent" ? step.stepName : step.name
+    if (only.length > 0 && !only.includes(step.name) && !only.includes(logicalName)) return false
+    return !skip.includes(step.name) && !skip.includes(logicalName)
+  }
+  return { ...pipeline, steps: pipeline.steps.filter(selected) }
+}
+
+function hooksForPlan(input: RunOptions, pipelineName: string) {
+  const pipeline = input.hooks.pipelines[pipelineName]
+  return {
+    pre: [...input.hooks.pre, ...(pipeline?.pre ?? [])],
+    post: [...input.hooks.post, ...(pipeline?.post ?? [])],
+  }
+}
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value)
+    for (const child of Object.values(value)) deepFreeze(child)
+  }
+  return value
+}
+
+export function plannedStepModel(step: AgentStep): string {
+  if (step.runner === "claude-code") return `claude-code/${step.model || "default"}`
+  return step.resolvedModel?.target ?? `${step.model}${step.variant ? `#${step.variant}` : ""}`
+}

--- a/src/run-plan.ts
+++ b/src/run-plan.ts
@@ -5,6 +5,10 @@ import type { AgentStep, Pipeline, RunOptions, RunPlan, Step } from "./types"
 export type BuildRunPlanInput = RunOptions & {
   promptSource?: RunPlan["prompt"]["source"]
   worktree?: boolean
+  /** Configured branch-naming model; resolved into the plan so the post-confirmation naming call uses the reviewed target. */
+  branchNameModel?: string
+  /** The run's frozen gateway when resuming; recorded in the plan when an explicit --gateway replaces it. */
+  resumeGateway?: ModelGateway
 }
 
 /** Purely resolves the complete execution shape; it performs no filesystem or process effects. */
@@ -16,6 +20,7 @@ export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
   const judge = input.smart
     ? resolveModel(input.smartJudgeModel, gateway, overrides)
     : undefined
+  const branchNamer = input.branchNameModel ? resolveModel(input.branchNameModel, gateway, overrides) : undefined
   const hooks = hooksForPlan(input, pipeline.name)
   return deepFreeze({
     prompt: { source: input.promptSource ?? (input.resumeRunID ? "resume" : "inline"), text: input.prompt },
@@ -28,11 +33,21 @@ export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
     pipeline,
     modelRouting: { gateway },
     ...(judge ? { smartJudge: { model: judge } } : {}),
+    ...(branchNamer ? { branchNamer: { model: branchNamer } } : {}),
     hooks,
     attachments: [...input.files],
     permissions: input.yolo ? "yolo" : input.smart ? "smart" : "interactive",
     maxAttempts: input.maxAttempts,
-    ...(input.resumeRunID ? { resume: { runID: input.resumeRunID } } : {}),
+    ...(input.resumeRunID
+      ? {
+          resume: {
+            runID: input.resumeRunID,
+            ...(input.resumeGateway && input.resumeGateway !== gateway
+              ? { gatewayOverride: { original: input.resumeGateway, pending: gateway } }
+              : {}),
+          },
+        }
+      : {}),
   })
 }
 

--- a/src/run-plan.ts
+++ b/src/run-plan.ts
@@ -11,7 +11,8 @@ export type BuildRunPlanInput = RunOptions & {
 export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
   const gateway = input.gateway ?? "configured"
   const overrides = input.modelRoutingOverrides ?? {}
-  const pipeline = routePipeline(filterPipeline(input.pipeline, input.onlySteps, input.skipSteps), gateway, overrides, input.modelOverride)
+  // The immutable plan must never recursively freeze caller-owned config.
+  const pipeline = routePipeline(filterPipeline(structuredClone(input.pipeline), input.onlySteps, input.skipSteps), gateway, overrides, input.modelOverride)
   const judge = input.smart
     ? resolveModel(input.smartJudgeModel, gateway, overrides)
     : undefined
@@ -63,10 +64,10 @@ function filterPipeline(pipeline: Pipeline, only: string[], skip: string[]): Pip
 
 function hooksForPlan(input: RunOptions, pipelineName: string) {
   const pipeline = input.hooks.pipelines[pipelineName]
-  return {
+  return structuredClone({
     pre: [...input.hooks.pre, ...(pipeline?.pre ?? [])],
     post: [...input.hooks.post, ...(pipeline?.post ?? [])],
-  }
+  })
 }
 
 function deepFreeze<T>(value: T): T {

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -16,24 +16,24 @@ export function renderRunPlan(plan: RunPlan, compact = false): string {
     "",
     `Prompt: ${plan.prompt.source} · ${prompt.length} characters · ${prompt.split("\n").length} lines`,
     `  ${preview}${preview.length < prompt.replace(/\s+/g, " ").length ? "…" : ""}`,
-    `Target: ${plan.target.directory}`,
-    `  Diff base: ${plan.target.baseRef} · working tree: ${plan.target.dirty ? "include dirty" : "clean required"}`,
-    `Pipeline: ${plan.pipeline.name} · ${plan.pipeline.steps.length} steps`,
+    `Target: ${sanitizeInline(plan.target.directory)}`,
+    `  Diff base: ${sanitizeInline(plan.target.baseRef)} · working tree: ${plan.target.dirty ? "include dirty" : "clean required"}`,
+    `Pipeline: ${sanitizeInline(plan.pipeline.name)} · ${plan.pipeline.steps.length} steps`,
     `Gateway: ${gatewayLabel(plan.modelRouting.gateway)}`,
   ]
   if (!compact) {
     plan.pipeline.steps.forEach((step, index) => {
-      if (step.type === "human") lines.push(`  ${index + 1}. ${step.name} · human gate`)
+      if (step.type === "human") lines.push(`  ${index + 1}. ${sanitizeInline(step.name)} · human gate`)
       else {
-        lines.push(`  ${index + 1}. ${step.name} · ${stepRunnerFor(step.runner).displayName} · ${step.readOnly ? "read-only" : "writable"} · ${step.maxAttempts ?? plan.maxAttempts} attempts`)
-        if (step.resolvedModel) lines.push(`     Logical: ${step.resolvedModel.logical}`, `     Target:  ${step.resolvedModel.target}`)
-        else lines.push(`     Model: ${plannedStepModel(step)}`)
+        lines.push(`  ${index + 1}. ${sanitizeInline(step.name)} · ${stepRunnerFor(step.runner).displayName} · ${step.readOnly ? "read-only" : "writable"} · ${step.maxAttempts ?? plan.maxAttempts} attempts`)
+        if (step.resolvedModel) lines.push(`     Logical: ${sanitizeInline(step.resolvedModel.logical)}`, `     Target:  ${sanitizeInline(step.resolvedModel.target)}`)
+        else lines.push(`     Model: ${sanitizeInline(plannedStepModel(step))}`)
       }
     })
     if (plan.hooks.pre.length || plan.hooks.post.length) {
       lines.push("Hooks:")
-      for (const hook of plan.hooks.pre) lines.push(`  pre: ${sanitize(hook.command)}`)
-      for (const hook of plan.hooks.post) lines.push(`  post: ${sanitize(hook.command)}${hook.when ? ` (${hook.when})` : ""}`)
+      for (const hook of plan.hooks.pre) lines.push(`  pre: ${sanitizeInline(hook.command)}`)
+      for (const hook of plan.hooks.post) lines.push(`  post: ${sanitizeInline(hook.command)}${hook.when ? ` (${sanitizeInline(hook.when)})` : ""}`)
     }
     lines.push(`Runtime: ${plan.permissions} permissions · ${plan.attachments.length} attachments`)
   }
@@ -67,6 +67,10 @@ export async function confirmRunPlan(plan: RunPlan): Promise<boolean> {
 
 function sanitize(value: string) {
   return value.replace(ansiSequences, "").replace(controlCharacters, "")
+}
+
+function sanitizeInline(value: string) {
+  return sanitize(value).replace(/\s+/g, " ").trim()
 }
 
 function gatewayLabel(gateway: RunPlan["modelRouting"]["gateway"]) {

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -19,6 +19,7 @@ export function renderRunPlan(plan: RunPlan, compact = false): string {
     `  ${preview}${preview.length < prompt.replace(/\s+/g, " ").length ? "…" : ""}`,
     `Target: ${sanitizeInline(plan.target.directory)}`,
     `  Diff base: ${sanitizeInline(plan.target.baseRef)} · working tree: ${plan.target.dirty ? "include dirty" : "clean required"}`,
+    `  Worktree: ${plan.target.worktree ? "yes (created after confirmation)" : "no"}`,
     `Pipeline: ${sanitizeInline(plan.pipeline.name)} · ${plan.pipeline.steps.length} steps`,
     `Gateway: ${gatewayLabel(plan.modelRouting.gateway)}`,
   ]
@@ -37,6 +38,7 @@ export function renderRunPlan(plan: RunPlan, compact = false): string {
       for (const hook of plan.hooks.post) lines.push(`  post: ${sanitizeInline(hook.command)}${hook.when ? ` (${sanitizeInline(hook.when)})` : ""}`)
     }
     lines.push(`Runtime: ${plan.permissions} permissions · ${plan.attachments.length} attachments`)
+    if (plan.smartJudge) lines.push(`  Judge: ${sanitizeInline(plan.smartJudge.model.target)}`)
   }
   return `${lines.join("\n")}\n`
 }

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -1,6 +1,7 @@
 import { createInterface } from "node:readline/promises"
 import { stdin, stdout } from "node:process"
 
+import { gatewayLabel } from "./model-routing"
 import { plannedStepModel } from "./run-plan"
 import { stepRunnerFor } from "./step-runners"
 import type { RunPlan } from "./types"
@@ -71,8 +72,4 @@ function sanitize(value: string) {
 
 function sanitizeInline(value: string) {
   return sanitize(value).replace(/\s+/g, " ").trim()
-}
-
-function gatewayLabel(gateway: RunPlan["modelRouting"]["gateway"]) {
-  return gateway === "vercel" ? "Vercel AI Gateway" : gateway === "openrouter" ? "OpenRouter" : gateway === "direct" ? "Direct" : "As configured"
 }

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -93,3 +93,13 @@ function sanitize(value: string) {
 function sanitizeInline(value: string) {
   return sanitize(value).replace(/\s+/g, " ").trim()
 }
+
+/** Multi-line sanitize for untrusted plan fields (prompt text), shared with the TUI review. */
+export function sanitizeReviewText(value: string) {
+  return sanitize(value)
+}
+
+/** Single-line sanitize for untrusted plan fields (paths, names, commands), shared with the TUI review. */
+export function sanitizeReviewInline(value: string) {
+  return sanitizeInline(value)
+}

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -43,9 +43,23 @@ export function renderRunPlan(plan: RunPlan, compact = false): string {
 export async function confirmRunPlan(plan: RunPlan): Promise<boolean> {
   stdout.write(renderRunPlan(plan))
   const prompt = createInterface({ input: stdin, output: stdout })
+  const controller = new AbortController()
+  let interrupted = false
+  // In raw-mode terminals readline emits SIGINT instead of process-level SIGINT.
+  // Handle it here so confirmation follows the other interactive prompts.
+  prompt.on("SIGINT", () => {
+    interrupted = true
+    controller.abort()
+  })
   try {
-    const answer = (await prompt.question("Start run? [y/N] ")).trim().toLowerCase()
+    const answer = (await prompt.question("Start run? [y/N] ", { signal: controller.signal })).trim().toLowerCase()
     return answer === "y" || answer === "yes" || answer === "s" || answer === "sí" || answer === "si"
+  } catch (error) {
+    if (interrupted && error instanceof Error && error.name === "AbortError") {
+      stdout.write("\n")
+      return false
+    }
+    throw error
   } finally {
     prompt.close()
   }

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -23,7 +23,17 @@ export function renderRunPlan(plan: RunPlan, compact = false): string {
     `Pipeline: ${sanitizeInline(plan.pipeline.name)} · ${plan.pipeline.steps.length} steps`,
     `Gateway: ${gatewayLabel(plan.modelRouting.gateway)}`,
   ]
+  // A resumed run rerouted by an explicit --gateway must say so in every
+  // review format: pending phases will not use the original gateway.
+  if (plan.resume?.gatewayOverride) {
+    lines.push(
+      "Resume gateway override:",
+      `  original: ${gatewayLabel(plan.resume.gatewayOverride.original)}`,
+      `  pending phases: ${gatewayLabel(plan.resume.gatewayOverride.pending)}`,
+    )
+  }
   if (!compact) {
+    if (plan.branchNamer) lines.push(`Branch naming: ${sanitizeInline(plan.branchNamer.model.target)} (generated after confirmation)`)
     plan.pipeline.steps.forEach((step, index) => {
       if (step.type === "human") lines.push(`  ${index + 1}. ${sanitizeInline(step.name)} · human gate`)
       else {

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -1,0 +1,60 @@
+import { createInterface } from "node:readline/promises"
+import { stdin, stdout } from "node:process"
+
+import { plannedStepModel } from "./run-plan"
+import { stepRunnerFor } from "./step-runners"
+import type { RunPlan } from "./types"
+
+const controlCharacters = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g
+const ansiSequences = /\u001b\[[0-?]*[ -/]*[@-~]/g
+
+export function renderRunPlan(plan: RunPlan, compact = false): string {
+  const prompt = sanitize(plan.prompt.text)
+  const preview = prompt.replace(/\s+/g, " ").slice(0, compact ? 100 : 180)
+  const lines = [
+    compact ? "Convoy run plan" : "Review Convoy run",
+    "",
+    `Prompt: ${plan.prompt.source} · ${prompt.length} characters · ${prompt.split("\n").length} lines`,
+    `  ${preview}${preview.length < prompt.replace(/\s+/g, " ").length ? "…" : ""}`,
+    `Target: ${plan.target.directory}`,
+    `  Diff base: ${plan.target.baseRef} · working tree: ${plan.target.dirty ? "include dirty" : "clean required"}`,
+    `Pipeline: ${plan.pipeline.name} · ${plan.pipeline.steps.length} steps`,
+    `Gateway: ${gatewayLabel(plan.modelRouting.gateway)}`,
+  ]
+  if (!compact) {
+    plan.pipeline.steps.forEach((step, index) => {
+      if (step.type === "human") lines.push(`  ${index + 1}. ${step.name} · human gate`)
+      else {
+        lines.push(`  ${index + 1}. ${step.name} · ${stepRunnerFor(step.runner).displayName} · ${step.readOnly ? "read-only" : "writable"} · ${step.maxAttempts ?? plan.maxAttempts} attempts`)
+        if (step.resolvedModel) lines.push(`     Logical: ${step.resolvedModel.logical}`, `     Target:  ${step.resolvedModel.target}`)
+        else lines.push(`     Model: ${plannedStepModel(step)}`)
+      }
+    })
+    if (plan.hooks.pre.length || plan.hooks.post.length) {
+      lines.push("Hooks:")
+      for (const hook of plan.hooks.pre) lines.push(`  pre: ${sanitize(hook.command)}`)
+      for (const hook of plan.hooks.post) lines.push(`  post: ${sanitize(hook.command)}${hook.when ? ` (${hook.when})` : ""}`)
+    }
+    lines.push(`Runtime: ${plan.permissions} permissions · ${plan.attachments.length} attachments`)
+  }
+  return `${lines.join("\n")}\n`
+}
+
+export async function confirmRunPlan(plan: RunPlan): Promise<boolean> {
+  stdout.write(renderRunPlan(plan))
+  const prompt = createInterface({ input: stdin, output: stdout })
+  try {
+    const answer = (await prompt.question("Start run? [y/N] ")).trim().toLowerCase()
+    return answer === "y" || answer === "yes" || answer === "s" || answer === "sí" || answer === "si"
+  } finally {
+    prompt.close()
+  }
+}
+
+function sanitize(value: string) {
+  return value.replace(ansiSequences, "").replace(controlCharacters, "")
+}
+
+function gatewayLabel(gateway: RunPlan["modelRouting"]["gateway"]) {
+  return gateway === "vercel" ? "Vercel AI Gateway" : gateway === "openrouter" ? "OpenRouter" : gateway === "direct" ? "Direct" : "As configured"
+}

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -9,20 +9,28 @@ import type { RunPlan } from "./types"
 const controlCharacters = /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]/g
 const ansiSequences = /\u001b\[[0-?]*[ -/]*[@-~]/g
 
-export function renderRunPlan(plan: RunPlan, compact = false): string {
+export type RunPlanReviewRenderOptions = {
+  /** Show the complete sanitized prompt rather than its normal terminal-safe excerpt. */
+  fullPrompt?: boolean
+}
+
+export function renderRunPlan(plan: RunPlan, compact = false, options: RunPlanReviewRenderOptions = {}): string {
   const prompt = sanitize(plan.prompt.text)
   const preview = prompt.replace(/\s+/g, " ").slice(0, compact ? 100 : 180)
   const lines = [
     compact ? "Convoy run plan" : "Review Convoy run",
     "",
     `Prompt: ${plan.prompt.source} · ${prompt.length} characters · ${prompt.split("\n").length} lines`,
-    `  ${preview}${preview.length < prompt.replace(/\s+/g, " ").length ? "…" : ""}`,
     `Target: ${sanitizeInline(plan.target.directory)}`,
     `  Diff base: ${sanitizeInline(plan.target.baseRef)} · working tree: ${plan.target.dirty ? "include dirty" : "clean required"}`,
     `  Worktree: ${plan.target.worktree ? "yes (created after confirmation)" : "no"}`,
     `Pipeline: ${sanitizeInline(plan.pipeline.name)} · ${plan.pipeline.steps.length} steps`,
     `Gateway: ${gatewayLabel(plan.modelRouting.gateway)}`,
   ]
+  const promptLines = options.fullPrompt && !compact
+    ? prompt.split("\n").map((line) => `  ${line}`)
+    : [`  ${preview}${preview.length < prompt.replace(/\s+/g, " ").length ? "…" : ""}`]
+  lines.splice(3, 0, ...promptLines)
   // A resumed run rerouted by an explicit --gateway must say so in every
   // review format: pending phases will not use the original gateway.
   if (plan.resume?.gatewayOverride) {
@@ -79,7 +87,7 @@ export async function confirmRunPlan(plan: RunPlan): Promise<boolean> {
 }
 
 function sanitize(value: string) {
-  return value.replace(ansiSequences, "").replace(controlCharacters, "")
+  return value.replace(ansiSequences, "").replace(controlCharacters, "").replace(/\t/g, " ")
 }
 
 function sanitizeInline(value: string) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -287,7 +287,9 @@ export async function run(options: RunOptions) {
     )
     progress.start(workspace.runID, options.targetDir, workspace.dir)
     log.info(`Run ${workspace.runID} - dir: ${workspace.dir}`)
-    const overrideNotice = modelOverrideNotice(pipeline, options.modelOverride)
+    // Use the captured flag: options.modelOverride was already cleared when a
+    // reviewed plan took over, but the Claude Code notice must still fire.
+    const overrideNotice = modelOverrideNotice(pipeline, modelOverride)
     if (overrideNotice) {
       progress.message(overrideNotice)
       log.warn(overrideNotice)

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -218,6 +218,16 @@ function installShutdownSignals(shutdown: RunShutdown) {
 }
 
 export async function run(options: RunOptions) {
+  // CLI callers hand the exact reviewed plan to the runner. Keep accepting
+  // legacy programmatic RunOptions for API/tests, but never re-resolve a plan.
+  if (options.plan) {
+    options.pipeline = options.plan.pipeline
+    options.onlySteps = []
+    options.skipSteps = []
+    options.modelOverride = ""
+    if (options.plan.smartJudge) options.smartJudgeModel = options.plan.smartJudge.model.target
+  }
+  if (options.plan) ensureClaudeAvailable(options.plan.pipeline)
   await ensureRepoReady(options.targetDir, {
     includeDirty: options.includeDirty,
     maxAttempts: options.maxAttempts,
@@ -246,7 +256,7 @@ export async function run(options: RunOptions) {
   const judgeModel = parseModel(splitModelVariant(options.smartJudgeModel).model)
 
   try {
-    metadata = await openRunMetadata(workspace, options.targetDir, options.pipeline)
+    metadata = await openRunMetadata(workspace, options.targetDir, options.pipeline, options.plan?.modelRouting.gateway ?? options.gateway ?? "configured", options.gatewayExplicit ?? false)
     // Resumed runs replay the pipeline frozen in their metadata, so the steps
     // (and thus --only/--skip names and required agents) come from there.
     const pipeline = metadata.pipeline

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -220,6 +220,7 @@ function installShutdownSignals(shutdown: RunShutdown) {
 export async function run(options: RunOptions) {
   // CLI callers hand the exact reviewed plan to the runner. Keep accepting
   // legacy programmatic RunOptions for API/tests, but never re-resolve a plan.
+  const modelOverride = options.modelOverride
   if (options.plan) {
     options.pipeline = options.plan.pipeline
     options.onlySteps = []
@@ -244,7 +245,7 @@ export async function run(options: RunOptions) {
   let progress: ProgressUI = noopProgress
   let permissions: PermissionGate | undefined
   let metadata: RunMetadataStore | undefined
-  let hookSet = hooksForPipeline(options.hooks, options.pipeline.name)
+  let hookSet = options.plan?.hooks ?? hooksForPipeline(options.hooks, options.pipeline.name)
   let pipelineNameForHooks = options.pipeline.name
   let postHooksStarted = false
   const shutdown = new RunShutdown()
@@ -256,12 +257,17 @@ export async function run(options: RunOptions) {
   const judgeModel = parseModel(splitModelVariant(options.smartJudgeModel).model)
 
   try {
-    metadata = await openRunMetadata(workspace, options.targetDir, options.pipeline, options.plan?.modelRouting.gateway ?? options.gateway ?? "configured", options.gatewayExplicit ?? false)
-    // Resumed runs replay the pipeline frozen in their metadata, so the steps
-    // (and thus --only/--skip names and required agents) come from there.
+    metadata = await openRunMetadata(workspace, options.targetDir, options.pipeline, {
+      gateway: options.plan?.modelRouting.gateway ?? options.gateway ?? "configured",
+      gatewayOverride: options.gatewayExplicit ?? false,
+      modelOverride: Boolean(modelOverride),
+      // The plan has already applied --only/--skip. Never re-expand a reviewed
+      // resume back to the entire persisted pipeline.
+      useExecutionPipeline: Boolean(options.resumeRunID && options.plan),
+    })
     const pipeline = metadata.pipeline
     pipelineNameForHooks = pipeline.name
-    hookSet = hooksForPipeline(options.hooks, pipeline.name)
+    hookSet = options.plan?.hooks ?? hooksForPipeline(options.hooks, pipeline.name)
     validateStepFilters(pipeline, options)
     // Parallel/multi-model steps are forced read-only and point at a synthesized
     // "<agent>__ro" variant when their base agent isn't already read-only;
@@ -1794,8 +1800,14 @@ function buildPhasePrompt(workspace: Workspace, phase: AgentStep) {
 export function parseModel(value: string) {
   const [providerID, ...rest] = value.split("/")
   const modelID = rest.join("/")
-  if (!providerID || !modelID) throw new Error(`invalid model: ${value}`)
+  if (!providerID || !modelID || !isSafeModelSegment(providerID) || rest.some((segment) => !isSafeModelSegment(segment))) {
+    throw new Error(`invalid model: ${value}`)
+  }
   return { providerID, modelID }
+}
+
+function isSafeModelSegment(value: string) {
+  return value.length > 0 && !/[\s/#\u0000-\u001f\u007f-\u009f]/u.test(value)
 }
 
 function selectedModel(phase: AgentStep, override: string): ModelSelection {

--- a/src/types.ts
+++ b/src/types.ts
@@ -143,9 +143,15 @@ export type RunPlan = {
   pipeline: Pipeline
   modelRouting: { gateway: ModelGateway }
   smartJudge?: { model: ResolvedModel }
+  /** Resolved branch-naming model for worktree runs: the AI naming call happens after confirmation with exactly this target. */
+  branchNamer?: { model: ResolvedModel }
   hooks: HookSet
   attachments: string[]
   permissions: "interactive" | "smart" | "yolo"
   maxAttempts: number
-  resume?: { runID: string }
+  resume?: {
+    runID: string
+    /** Set when an explicit --gateway reroutes pending phases away from the run's frozen gateway. */
+    gatewayOverride?: { original: ModelGateway; pending: ModelGateway }
+  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { StepRunnerId } from "./step-runners"
+import type { ModelGateway, ModelRoutingOverrides, ResolvedModel } from "./model-routing"
 
 export type RunOptions = {
   prompt: string
@@ -8,6 +9,13 @@ export type RunOptions = {
   resumeRunID: string
   keepRunDir: boolean
   modelOverride: string
+  gateway?: ModelGateway
+  gatewayExplicit?: boolean
+  modelRoutingOverrides?: ModelRoutingOverrides
+  /** The immutable, reviewed execution description. Legacy programmatic callers may omit it. */
+  plan?: RunPlan
+  planOnly?: boolean
+  noConfirm?: boolean
   tui: boolean
   humanReview: boolean
   maxAttempts: number
@@ -98,6 +106,8 @@ export type AgentStep = {
   /** Empty string on claude-code steps that defer to the CLI's default model. */
   model: string
   variant?: string
+  /** Frozen logical and physical OpenCode model. Absent only on legacy metadata and Claude Code steps. */
+  resolvedModel?: ResolvedModel
   /** Absent for OpenCode (the default engine). */
   runner?: StepRunner
   inputFiles: readonly string[]
@@ -125,4 +135,17 @@ export type Pipeline = {
   name: string
   description?: string
   steps: Step[]
+}
+
+export type RunPlan = {
+  prompt: { source: "inline" | "file" | "resume"; text: string }
+  target: { directory: string; baseRef: string; worktree: boolean; dirty: boolean }
+  pipeline: Pipeline
+  modelRouting: { gateway: ModelGateway }
+  smartJudge?: { model: ResolvedModel }
+  hooks: HookSet
+  attachments: string[]
+  permissions: "interactive" | "smart" | "yolo"
+  maxAttempts: number
+  resume?: { runID: string }
 }

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -6,6 +6,7 @@ import type { Config, OpencodeClient } from "@opencode-ai/sdk/v2"
 import { addWorktree } from "./git"
 import { log } from "./log"
 import { startOpencode } from "./opencode"
+import { splitModelVariant } from "./pipeline"
 import { parseModel } from "./runner"
 import { convoyHome } from "./workspace"
 
@@ -110,6 +111,7 @@ export async function askForBranchName(
   model: string,
   signal?: AbortSignal,
 ): Promise<string> {
+  const parsedModel = splitModelVariant(model)
   const session = await client.session.create(
     { directory: targetDir, title: "convoy branch namer" },
     { signal: signal ?? undefined },
@@ -121,7 +123,8 @@ export async function askForBranchName(
       {
         sessionID,
         directory: targetDir,
-        model: parseModel(model),
+        model: parseModel(parsedModel.model),
+        ...(parsedModel.variant ? { variant: parsedModel.variant } : {}),
         system: branchNameSystemPrompt,
         tools: { read: true, list: true, glob: true, grep: true, webfetch: true, write: false, edit: false, bash: false, todoread: false, todowrite: false },
         parts: [{ type: "text", text: `Prompt:\n${truncate(prompt, 1200)}` }],

--- a/test/agents.test.ts
+++ b/test/agents.test.ts
@@ -11,7 +11,7 @@ describe("opencode config", () => {
   test("disables total provider timeouts but keeps idle stream timeouts", () => {
     const config = opencodeConfig("/tmp/convoy-run")
 
-    for (const provider of ["anthropic", "openai", "openrouter"]) {
+    for (const provider of ["anthropic", "openai", "openrouter", "vercel", "zai"]) {
       expect(config.provider?.[provider]?.options?.timeout).toBe(false)
       expect(config.provider?.[provider]?.options?.chunkTimeout).toBe(600_000)
     }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -80,9 +80,25 @@ describe("cli parsing", () => {
   test("requires prompt unless resuming", async () => {
     await expect(parseCommand([])).rejects.toThrow("need a prompt")
 
+    // Building the resumed plan reads the run's frozen metadata, so the run
+    // must exist at parse time.
+    const runDir = join(process.env.CONVOY_HOME!, ".convoy", "runs", "20260519-103045-x7q2")
+    await mkdir(runDir, { recursive: true })
+    await writeFile(
+      join(runDir, "metadata.json"),
+      JSON.stringify({ schemaVersion: 2, runID: "20260519-103045-x7q2", targetDir: "/repo", createdAt: 0, updatedAt: 0, phases: {} }),
+    )
+    await writeFile(join(runDir, "prd.md"), "original prompt")
+
     const command = await parseCommand(["--resume", "20260519-103045-x7q2"])
     expect(command.type).toBe("run")
-    if (command.type === "run") expect(command.options.resumeRunID).toBe("20260519-103045-x7q2")
+    if (command.type === "run") {
+      expect(command.options.resumeRunID).toBe("20260519-103045-x7q2")
+      expect(command.options.prompt).toBe("original prompt")
+      expect(command.options.plan?.prompt.source).toBe("resume")
+    }
+
+    await expect(parseCommand(["--resume", "20260519-103045-zz99"])).rejects.toThrow("doesn't exist")
   })
 
   test("rejects invalid max attempts", () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -48,6 +48,18 @@ describe("cli parsing", () => {
     expect(parsed.prompt).toBe("add onboarding")
   })
 
+  test("parses gateway and review flags and rejects invalid combinations", () => {
+    expect(parseArgs(["--gateway", "vercel", "--plan", "--no-confirm", "prompt"])).toMatchObject({
+      gateway: "vercel",
+      planOnly: true,
+      noConfirm: true,
+      prompt: "prompt",
+    })
+    expect(() => parseArgs(["--gateway", "automatic", "prompt"])).toThrow("--gateway must be")
+    expect(() => parseArgs(["--plan=json", "prompt"])).toThrow("--plan does not take a value")
+    expect(() => parseArgs(["--no-confirm=yes", "prompt"])).toThrow("--no-confirm does not take a value")
+  })
+
   test("returns help as a command", async () => {
     const command = await parseCommand(["--help"])
 
@@ -206,6 +218,27 @@ describe("config precedence", () => {
     expect(command.options.maxAttempts).toBe(1)
     expect(command.options.baseRef).toBe("main")
     expect(command.options.pipeline.name).toBe("implement")
+  })
+
+  test("gateway precedence is CLI, then project, then global", async () => {
+    const dir = await projectWithConfig()
+    await writeFile(join(process.env.CONVOY_HOME!, ".convoy", "config.yaml"), "modelRouting:\n  gateway: openrouter\n")
+    await writeFile(join(dir, ".convoy", "config.yaml"), "modelRouting:\n  gateway: configured\n")
+
+    const project = await parseCommand(["--dir", dir, "prompt"])
+    expect(project.type).toBe("run")
+    if (project.type === "run") {
+      expect(project.options.gateway).toBe("configured")
+      expect(project.options.plan?.modelRouting.gateway).toBe("configured")
+    }
+
+    const cli = await parseCommand(["--dir", dir, "--gateway", "vercel", "prompt"])
+    expect(cli.type).toBe("run")
+    if (cli.type === "run") {
+      expect(cli.options.gateway).toBe("vercel")
+      expect(cli.options.gatewayExplicit).toBe(true)
+      expect(cli.options.plan?.modelRouting.gateway).toBe("vercel")
+    }
   })
 
   test("an unknown pipeline lists what exists", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -448,6 +448,78 @@ describe("config merging", () => {
   })
 })
 
+describe("model routing config", () => {
+  test("parses gateway choices and explicit model targets", () => {
+    const config = parse(
+      [
+        "modelRouting:",
+        "  gateway: vercel",
+        "  overrides:",
+        "    zai/glm-5.2:",
+        "      direct: zai/glm-5.2",
+        "      openrouter: openrouter/z-ai/glm-5.2",
+        "      vercel: vercel/zai/glm-5.2#high",
+      ].join("\n"),
+    )
+
+    expect(config.modelRouting).toEqual({
+      gateway: "vercel",
+      overrides: {
+        "zai/glm-5.2": {
+          direct: "zai/glm-5.2",
+          openrouter: "openrouter/z-ai/glm-5.2",
+          vercel: "vercel/zai/glm-5.2#high",
+        },
+      },
+    })
+    expect(() => parse("modelRouting:\n  gateway: automatic")).toThrow("modelRouting.gateway")
+    expect(() => parse("modelRouting:\n  overrides:\n    missing-provider: {} ")).toThrow("modelRouting.overrides.missing-provider")
+  })
+
+  test("project routing can explicitly return to configured and deep-merges overrides", () => {
+    const global = parse(
+      [
+        "modelRouting:",
+        "  gateway: openrouter",
+        "  overrides:",
+        "    custom/private-model:",
+        "      direct: custom/private-model",
+        "      openrouter: openrouter/acme/private-model",
+      ].join("\n"),
+    )
+    const project = parse(
+      [
+        "modelRouting:",
+        "  gateway: configured",
+        "  overrides:",
+        "    custom/private-model:",
+        "      vercel: vercel/acme/private-model",
+      ].join("\n"),
+    )
+
+    expect(mergeConvoyConfigs(global, project)?.modelRouting).toEqual({
+      gateway: "configured",
+      overrides: {
+        "custom/private-model": {
+          direct: "custom/private-model",
+          openrouter: "openrouter/acme/private-model",
+          vercel: "vercel/acme/private-model",
+        },
+      },
+    })
+  })
+
+  test("serializes routing without dropping gateway targets or variants", () => {
+    const config = parse(
+      "modelRouting:\n  gateway: vercel\n  overrides:\n    custom/private-model:\n      vercel: vercel/acme/private-model#fast",
+    )
+
+    const yaml = serializeConvoyConfig(config)
+    expect(yaml).toContain("modelRouting:")
+    expect(parse(yaml).modelRouting).toEqual(config.modelRouting)
+  })
+})
+
 describe("serialization", () => {
   test("omits empty sections and round-trips through parse", () => {
     const config = parse("defaults:\n  model: openai/gpt-5.5#xhigh\npipelines:\n  default:\n    steps:\n      - implementer\n      - human-review")

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -518,6 +518,29 @@ describe("model routing config", () => {
     expect(yaml).toContain("modelRouting:")
     expect(parse(yaml).modelRouting).toEqual(config.modelRouting)
   })
+
+  test("override keys canonicalize wrapped gateways, aliases, and variants to the logical model", () => {
+    const config = parse(
+      [
+        "modelRouting:",
+        "  overrides:",
+        "    openrouter/z-ai/glm-5.2#high:",
+        "      vercel: vercel/zai/glm-5.2",
+      ].join("\n"),
+    )
+
+    // resolveModel looks up the canonical logical identity "zai/glm-5.2".
+    expect(config.modelRouting?.overrides).toEqual({ "zai/glm-5.2": { vercel: "vercel/zai/glm-5.2" } })
+  })
+
+  test("global and project overrides merge after canonicalization", () => {
+    const global = parse("modelRouting:\n  overrides:\n    z-ai/glm-5.2:\n      openrouter: openrouter/z-ai/glm-5.2")
+    const project = parse("modelRouting:\n  overrides:\n    zai/glm-5.2:\n      vercel: vercel/zai/glm-5.2")
+
+    expect(mergeConvoyConfigs(global, project)?.modelRouting?.overrides).toEqual({
+      "zai/glm-5.2": { openrouter: "openrouter/z-ai/glm-5.2", vercel: "vercel/zai/glm-5.2" },
+    })
+  })
 })
 
 describe("serialization", () => {

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { cursorPosition, hookLines, launcherStepModelLabel, promptEnterAction, reviewActionForKey, sanitizePaste, stepTree, typedText, wrapPromptLines, wrapReviewLine } from "../src/launch-tui"
+import { cursorPosition, hookLines, launcherStepModelLabel, promptEnterAction, reviewActionForKey, sanitizePaste, stepTree, typedText, wrapPromptLines } from "../src/launch-tui"
 
 import type { KeyEvent } from "@opentui/core"
 
@@ -62,15 +62,6 @@ describe("launch TUI review", () => {
     expect(reviewActionForKey(key({ name: "pagedown" }))).toBe("page-forward")
     expect(reviewActionForKey(key({ name: "home" }))).toBe("top")
     expect(reviewActionForKey(key({ name: "end" }))).toBe("bottom")
-  })
-
-  test("wraps long review fields without losing their indentation or overflowing the panel", () => {
-    const lines = wrapReviewLine(`     Target:  ${"vercel/openai/very-long-model/".repeat(3)}`, 30)
-
-    expect(lines.length).toBeGreaterThan(1)
-    expect(lines[0]).toStartWith("     Target:")
-    expect(lines.slice(1).every((line) => line.startsWith("     "))).toBe(true)
-    expect(lines.every((line) => line.length <= 30)).toBe(true)
   })
 })
 

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { cursorPosition, hookLines, launcherStepModelLabel, promptEnterAction, sanitizePaste, stepTree, typedText, wrapPromptLines } from "../src/launch-tui"
+import { cursorPosition, hookLines, launcherStepModelLabel, promptEnterAction, reviewActionForKey, sanitizePaste, stepTree, typedText, wrapPromptLines, wrapReviewLine } from "../src/launch-tui"
 
 import type { KeyEvent } from "@opentui/core"
 
@@ -48,6 +48,29 @@ describe("launch TUI prompt input", () => {
     expect(promptEnterAction(key({ name: "linefeed" }))).toBe("submit")
     expect(promptEnterAction(key({ name: "return", shift: true }))).toBe("newline")
     expect(promptEnterAction(key({ name: "a" }))).toBeUndefined()
+  })
+})
+
+describe("launch TUI review", () => {
+  test("maps review controls to start, back, cancellation, and scrolling actions", () => {
+    expect(reviewActionForKey(key({ name: "return" }))).toBe("start")
+    expect(reviewActionForKey(key({ name: "s" }))).toBe("start")
+    expect(reviewActionForKey(key({ name: "escape" }))).toBe("back")
+    expect(reviewActionForKey(key({ name: "q" }))).toBe("cancel")
+    expect(reviewActionForKey(key({ name: "p" }))).toBe("toggle-prompt")
+    expect(reviewActionForKey(key({ name: "up" }))).toBe("scroll-back")
+    expect(reviewActionForKey(key({ name: "pagedown" }))).toBe("page-forward")
+    expect(reviewActionForKey(key({ name: "home" }))).toBe("top")
+    expect(reviewActionForKey(key({ name: "end" }))).toBe("bottom")
+  })
+
+  test("wraps long review fields without losing their indentation or overflowing the panel", () => {
+    const lines = wrapReviewLine(`     Target:  ${"vercel/openai/very-long-model/".repeat(3)}`, 30)
+
+    expect(lines.length).toBeGreaterThan(1)
+    expect(lines[0]).toStartWith("     Target:")
+    expect(lines.slice(1).every((line) => line.startsWith("     "))).toBe(true)
+    expect(lines.every((line) => line.length <= 30)).toBe(true)
   })
 })
 

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -6,7 +6,7 @@ import { afterAll, describe, expect, test } from "bun:test"
 
 import { openRunMetadata, readRunMetadata } from "../src/metadata"
 import { defaultPipeline } from "../src/pipeline"
-import type { Pipeline } from "../src/types"
+import type { AgentStep, Pipeline } from "../src/types"
 import type { Workspace } from "../src/workspace"
 
 const dirs: string[] = []
@@ -21,23 +21,23 @@ afterAll(async () => {
   await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
+const implementer: AgentStep = {
+  type: "agent",
+  name: "implementer",
+  agentName: "implementer",
+  description: "Implements",
+  model: "openai/gpt-5.5",
+  variant: "xhigh",
+  inputFiles: ["prd.md"],
+  inputDiff: false,
+  reportPath: "reports/implementer.md",
+  groupId: "g1",
+  stepName: "implementer",
+}
+
 const quick: Pipeline = {
   name: "quick",
-  steps: [
-    {
-      type: "agent",
-      name: "implementer",
-      agentName: "implementer",
-      description: "Implements",
-      model: "openai/gpt-5.5",
-      variant: "xhigh",
-      inputFiles: ["prd.md"],
-      inputDiff: false,
-      reportPath: "reports/implementer.md",
-      groupId: "g1",
-      stepName: "implementer",
-    },
-  ],
+  steps: [implementer],
 }
 
 describe("run metadata", () => {
@@ -60,8 +60,8 @@ describe("run metadata", () => {
     const full: Pipeline = {
       ...quick,
       steps: [
-        quick.steps[0]!,
-        { ...quick.steps[0]!, name: "tests", stepName: "tests", agentName: "tests", reportPath: "reports/tests.md", groupId: "g2" },
+        implementer,
+        { ...implementer, name: "tests", stepName: "tests", agentName: "tests", reportPath: "reports/tests.md", groupId: "g2" },
       ],
     }
     const first = await openRunMetadata(ws, "/repo", full, { gateway: "vercel" })
@@ -81,9 +81,9 @@ describe("run metadata", () => {
     const full: Pipeline = {
       ...quick,
       steps: [
-        { ...quick.steps[0]!, resolvedModel: { configured: "openai/gpt-old", logical: "openai/gpt-old", gateway: "vercel", providerID: "vercel", modelID: "openai/gpt-old", target: "vercel/openai/gpt-old" } },
+        { ...implementer, resolvedModel: { configured: "openai/gpt-old", logical: "openai/gpt-old", gateway: "vercel", providerID: "vercel", modelID: "openai/gpt-old", target: "vercel/openai/gpt-old" } },
         {
-          ...quick.steps[0]!,
+          ...implementer,
           name: "tests",
           stepName: "tests",
           agentName: "tests",

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -55,6 +55,69 @@ describe("run metadata", () => {
     expect(resumed.pipeline.steps).toHaveLength(1)
   })
 
+  test("a filtered resume executes its reviewed subset without discarding frozen phases", async () => {
+    const ws = await workspace()
+    const full: Pipeline = {
+      ...quick,
+      steps: [
+        quick.steps[0]!,
+        { ...quick.steps[0]!, name: "tests", stepName: "tests", agentName: "tests", reportPath: "reports/tests.md", groupId: "g2" },
+      ],
+    }
+    const first = await openRunMetadata(ws, "/repo", full, { gateway: "vercel" })
+    await first.flush()
+
+    const reviewed: Pipeline = { ...full, steps: [full.steps[1]!] }
+    const resumed = await openRunMetadata(ws, "/repo", reviewed, { useExecutionPipeline: true })
+    expect(resumed.pipeline.steps.map((step) => step.name)).toEqual(["tests"])
+    await resumed.flush()
+
+    const persisted = await readRunMetadata(join(ws.dir, "metadata.json"))
+    expect(persisted?.pipeline?.steps.map((step) => step.name)).toEqual(["implementer", "tests"])
+  })
+
+  test("a resume model override persists only new targets for unfinished phases", async () => {
+    const ws = await workspace()
+    const full: Pipeline = {
+      ...quick,
+      steps: [
+        { ...quick.steps[0]!, resolvedModel: { configured: "openai/gpt-old", logical: "openai/gpt-old", gateway: "vercel", providerID: "vercel", modelID: "openai/gpt-old", target: "vercel/openai/gpt-old" } },
+        {
+          ...quick.steps[0]!,
+          name: "tests",
+          stepName: "tests",
+          agentName: "tests",
+          reportPath: "reports/tests.md",
+          groupId: "g2",
+          resolvedModel: { configured: "openai/gpt-old", logical: "openai/gpt-old", gateway: "vercel", providerID: "vercel", modelID: "openai/gpt-old", target: "vercel/openai/gpt-old" },
+        },
+      ],
+    }
+    const first = await openRunMetadata(ws, "/repo", full, { gateway: "vercel" })
+    first.phaseEnded("implementer", "completed")
+    await first.flush()
+
+    const overridden: Pipeline = {
+      ...full,
+      steps: full.steps.map((step) =>
+        step.type === "agent"
+          ? {
+              ...step,
+              model: "vercel/openai/gpt-new",
+              resolvedModel: { configured: "openai/gpt-new", logical: "openai/gpt-new", gateway: "vercel", providerID: "vercel", modelID: "openai/gpt-new", target: "vercel/openai/gpt-new" },
+            }
+          : step,
+      ),
+    }
+    const resumed = await openRunMetadata(ws, "/repo", overridden, { gateway: "vercel", modelOverride: true, useExecutionPipeline: true })
+    await resumed.flush()
+
+    const persisted = await readRunMetadata(join(ws.dir, "metadata.json"))
+    const targets = persisted?.pipeline?.steps.map((step) => step.type === "agent" ? step.resolvedModel?.target : undefined)
+    expect(targets).toEqual(["vercel/openai/gpt-old", "vercel/openai/gpt-new"])
+    expect(persisted?.modelRouting?.gateway).toBe("vercel")
+  })
+
   test("fails closed when a repository baseline cannot be persisted", async () => {
     const ws = await workspace()
     const store = await openRunMetadata(ws, "/repo", quick)

--- a/test/model-routing.test.ts
+++ b/test/model-routing.test.ts
@@ -6,15 +6,28 @@ describe("model gateway routing", () => {
   test("routes OpenAI and Anthropic through every gateway", () => {
     expect(resolveModel("openai/gpt-5.6-sol#xhigh", "direct").target).toBe("openai/gpt-5.6-sol#xhigh")
     expect(resolveModel("anthropic/claude-opus-4.8", "openrouter").target).toBe("openrouter/anthropic/claude-opus-4.8")
-    expect(resolveModel("anthropic/claude-opus-4.8", "vercel")).toMatchObject({
+    expect(resolveModel("anthropic/claude-opus-4.8", "vercel")).toEqual({
+      configured: "anthropic/claude-opus-4.8",
+      logical: "anthropic/claude-opus-4.8",
+      gateway: "vercel",
       providerID: "vercel",
       modelID: "anthropic/claude-opus-4.8",
+      target: "vercel/anthropic/claude-opus-4.8",
     })
   })
 
   test("unwraps an existing gateway and does not duplicate prefixes", () => {
     expect(resolveModel("openrouter/anthropic/claude-opus-4.8", "vercel").target).toBe("vercel/anthropic/claude-opus-4.8")
     expect(resolveModel("vercel/openai/gpt-5.6-sol#high", "openrouter").target).toBe("openrouter/openai/gpt-5.6-sol#high")
+  })
+
+  test("keeps nested model IDs and variants intact", () => {
+    expect(resolveModel("openai/gpt/reasoning/preview#high", "vercel")).toMatchObject({
+      logical: "openai/gpt/reasoning/preview#high",
+      providerID: "vercel",
+      modelID: "openai/gpt/reasoning/preview",
+      target: "vercel/openai/gpt/reasoning/preview#high",
+    })
   })
 
   test("normalizes zai and z-ai while preserving the logical identity", () => {
@@ -25,6 +38,12 @@ describe("model gateway routing", () => {
   })
 
   test("configured remains literal", () => {
+    expect(resolveModel("openrouter/z-ai/glm-5.2#high", "configured")).toMatchObject({
+      logical: "zai/glm-5.2#high",
+      providerID: "openrouter",
+      modelID: "z-ai/glm-5.2",
+      target: "openrouter/z-ai/glm-5.2#high",
+    })
     expect(resolveModel("custom/private/model#v2", "configured").target).toBe("custom/private/model#v2")
   })
 
@@ -33,6 +52,17 @@ describe("model gateway routing", () => {
       "vercel/acme/private-model#fast",
     )
     expect(() => resolveModel("custom/private-model", "vercel")).toThrow("modelRouting.overrides")
+  })
+
+  test("retains an override-only variant and rejects a conflicting configured variant", () => {
+    const overrides = { "custom/private-model": { vercel: "vercel/acme/private-model#fast" } }
+
+    expect(resolveModel("custom/private-model", "vercel", overrides)).toMatchObject({
+      logical: "custom/private-model",
+      variant: "fast",
+      target: "vercel/acme/private-model#fast",
+    })
+    expect(() => resolveModel("custom/private-model#slow", "vercel", overrides)).toThrow("must not replace variant #slow")
   })
 
   test("rejects whitespace and terminal controls in model references", () => {

--- a/test/model-routing.test.ts
+++ b/test/model-routing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test"
+
+import { logicalModel, resolveModel } from "../src/model-routing"
+
+describe("model gateway routing", () => {
+  test("routes OpenAI and Anthropic through every gateway", () => {
+    expect(resolveModel("openai/gpt-5.6-sol#xhigh", "direct").target).toBe("openai/gpt-5.6-sol#xhigh")
+    expect(resolveModel("anthropic/claude-opus-4.8", "openrouter").target).toBe("openrouter/anthropic/claude-opus-4.8")
+    expect(resolveModel("anthropic/claude-opus-4.8", "vercel")).toMatchObject({
+      providerID: "vercel",
+      modelID: "anthropic/claude-opus-4.8",
+    })
+  })
+
+  test("unwraps an existing gateway and does not duplicate prefixes", () => {
+    expect(resolveModel("openrouter/anthropic/claude-opus-4.8", "vercel").target).toBe("vercel/anthropic/claude-opus-4.8")
+    expect(resolveModel("vercel/openai/gpt-5.6-sol#high", "openrouter").target).toBe("openrouter/openai/gpt-5.6-sol#high")
+  })
+
+  test("normalizes zai and z-ai while preserving the logical identity", () => {
+    expect(logicalModel("openrouter/z-ai/glm-5.2").model).toBe("zai/glm-5.2")
+    expect(resolveModel("openrouter/z-ai/glm-5.2", "direct").target).toBe("zai/glm-5.2")
+    expect(resolveModel("zai/glm-5.2", "openrouter").target).toBe("openrouter/z-ai/glm-5.2")
+    expect(resolveModel("openrouter/z-ai/glm-5.2", "vercel").target).toBe("vercel/zai/glm-5.2")
+  })
+
+  test("configured remains literal", () => {
+    expect(resolveModel("custom/private/model#v2", "configured").target).toBe("custom/private/model#v2")
+  })
+
+  test("explicit overrides enable otherwise unsafe custom routes", () => {
+    expect(resolveModel("custom/private-model#fast", "vercel", { "custom/private-model": { vercel: "vercel/acme/private-model" } }).target).toBe(
+      "vercel/acme/private-model#fast",
+    )
+    expect(() => resolveModel("custom/private-model", "vercel")).toThrow("modelRouting.overrides")
+  })
+})

--- a/test/model-routing.test.ts
+++ b/test/model-routing.test.ts
@@ -34,4 +34,9 @@ describe("model gateway routing", () => {
     )
     expect(() => resolveModel("custom/private-model", "vercel")).toThrow("modelRouting.overrides")
   })
+
+  test("rejects whitespace and terminal controls in model references", () => {
+    expect(() => resolveModel("openai/gpt-5.6\nforged", "vercel")).toThrow("without whitespace or control characters")
+    expect(() => resolveModel("openai/gpt-5.6#high\u001b[2J", "vercel")).toThrow("without whitespace or control characters")
+  })
 })

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -41,7 +41,7 @@ function plan(): RunPlan {
 }
 
 describe("OpenCode run-plan preflight", () => {
-  test("collects OpenCode steps and smart judge targets, never Claude Code", () => {
+  test("collects OpenCode steps, smart judge, and branch namer targets — never Claude Code", () => {
     const reviewed = plan()
     reviewed.pipeline.steps.push({
       type: "agent",
@@ -67,10 +67,21 @@ describe("OpenCode run-plan preflight", () => {
         target: "vercel/anthropic/claude-haiku-4.5",
       },
     }
+    reviewed.branchNamer = {
+      model: {
+        configured: "anthropic/claude-haiku-4-5",
+        logical: "anthropic/claude-haiku-4-5",
+        gateway: "vercel",
+        providerID: "vercel",
+        modelID: "anthropic/claude-haiku-4-5",
+        target: "vercel/anthropic/claude-haiku-4-5",
+      },
+    }
 
     expect(preflightTargets(reviewed).map((target) => target.target)).toEqual([
       "vercel/openai/gpt-5.6-sol",
       "vercel/anthropic/claude-haiku-4.5",
+      "vercel/anthropic/claude-haiku-4-5",
     ])
   })
 

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+
+import { preflightTargets, validatePreflightTargets } from "../src/preflight-validation"
+import type { RunPlan } from "../src/types"
+
+function plan(): RunPlan {
+  return {
+    prompt: { source: "inline", text: "ship it" },
+    target: { directory: "/repo", baseRef: "main", worktree: false, dirty: false },
+    pipeline: {
+      name: "implement",
+      steps: [
+        {
+          type: "agent",
+          name: "implementer",
+          stepName: "implementer",
+          groupId: "g1",
+          agentName: "implementer",
+          description: "Implements",
+          model: "vercel/openai/gpt-5.6-sol",
+          resolvedModel: {
+            configured: "openai/gpt-5.6-sol",
+            logical: "openai/gpt-5.6-sol",
+            gateway: "vercel",
+            providerID: "vercel",
+            modelID: "openai/gpt-5.6-sol",
+            target: "vercel/openai/gpt-5.6-sol",
+          },
+          inputFiles: ["prd.md"],
+          inputDiff: false,
+          reportPath: "reports/implementer.md",
+        },
+      ],
+    },
+    modelRouting: { gateway: "vercel" },
+    hooks: { pre: [], post: [] },
+    attachments: [],
+    permissions: "interactive",
+    maxAttempts: 2,
+  }
+}
+
+describe("OpenCode run-plan preflight", () => {
+  test("collects OpenCode steps and smart judge targets, never Claude Code", () => {
+    const reviewed = plan()
+    reviewed.pipeline.steps.push({
+      type: "agent",
+      name: "external-audit",
+      stepName: "external-audit",
+      groupId: "g2",
+      agentName: "external-audit",
+      description: "External audit",
+      runner: "claude-code",
+      model: "opus",
+      inputFiles: ["prd.md"],
+      inputDiff: false,
+      reportPath: "reports/external-audit.md",
+      readOnly: true,
+    })
+    reviewed.smartJudge = {
+      model: {
+        configured: "anthropic/claude-haiku-4.5",
+        logical: "anthropic/claude-haiku-4.5",
+        gateway: "vercel",
+        providerID: "vercel",
+        modelID: "anthropic/claude-haiku-4.5",
+        target: "vercel/anthropic/claude-haiku-4.5",
+      },
+    }
+
+    expect(preflightTargets(reviewed).map((target) => target.target)).toEqual([
+      "vercel/openai/gpt-5.6-sol",
+      "vercel/anthropic/claude-haiku-4.5",
+    ])
+  })
+
+  test("accepts discovered providers and physical model IDs", () => {
+    expect(() =>
+      validatePreflightTargets(preflightTargets(plan()), [{ id: "vercel", enabled: true }], [{ providerID: "vercel", id: "openai/gpt-5.6-sol" }]),
+    ).not.toThrow()
+  })
+
+  test("reports Vercel authentication guidance when its provider is disabled", () => {
+    expect(() => validatePreflightTargets(preflightTargets(plan()), [{ id: "vercel", enabled: false }], [])).toThrow(
+      "Missing provider credentials: vercel",
+    )
+    expect(() => validatePreflightTargets(preflightTargets(plan()), [{ id: "vercel", enabled: false }], [])).toThrow(
+      "AI_GATEWAY_API_KEY",
+    )
+  })
+
+  test("reports the logical and exact physical target when a model is unavailable", () => {
+    const targets = preflightTargets(plan())
+
+    expect(() => validatePreflightTargets(targets, [{ id: "vercel", enabled: true }], [])).toThrow("Model unavailable through Vercel AI Gateway")
+    expect(() => validatePreflightTargets(targets, [{ id: "vercel", enabled: true }], [])).toThrow("logical: openai/gpt-5.6-sol")
+    expect(() => validatePreflightTargets(targets, [{ id: "vercel", enabled: true }], [])).toThrow("target:  vercel/openai/gpt-5.6-sol")
+  })
+})

--- a/test/review-tui.test.ts
+++ b/test/review-tui.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test"
+
+import { runReviewLines } from "../src/review-tui"
+
+import type { ModelGateway, ResolvedModel } from "../src/model-routing"
+import type { AgentStep, RunPlan, Step } from "../src/types"
+
+function plain(lines: ReturnType<typeof runReviewLines>): string[] {
+  return lines.map((line) => line.chunks.map((chunk) => chunk.text).join(""))
+}
+
+function agentStep(partial: Partial<AgentStep> & Pick<AgentStep, "name" | "stepName" | "groupId">): AgentStep {
+  return {
+    type: "agent",
+    agentName: partial.name,
+    description: "",
+    model: "openai/gpt-5.6-sol",
+    inputFiles: [],
+    inputDiff: false,
+    reportPath: `reports/${partial.name}.md`,
+    ...partial,
+  }
+}
+
+function resolved(logical: string, target: string, gateway: ModelGateway = "configured"): ResolvedModel {
+  const [providerID, ...rest] = target.split("/")
+  return { configured: logical, logical, gateway, providerID: providerID!, modelID: rest.join("/"), target }
+}
+
+function planWith(steps: Step[], extra: Partial<RunPlan> = {}): RunPlan {
+  return {
+    prompt: { source: "inline", text: "ship the feature" },
+    target: { directory: "/repo", baseRef: "main", worktree: false, dirty: false },
+    pipeline: { name: "implement", steps },
+    modelRouting: { gateway: "configured" },
+    hooks: { pre: [], post: [] },
+    attachments: [],
+    permissions: "interactive",
+    maxAttempts: 2,
+    ...extra,
+  }
+}
+
+describe("run review TUI", () => {
+  test("collapses identical logical/target models and shows routed pairs with an arrow", () => {
+    const plan = planWith([
+      agentStep({ name: "implementer", stepName: "implementer", groupId: "g1", resolvedModel: resolved("openai/gpt-5.6-sol", "openai/gpt-5.6-sol") }),
+      agentStep({ name: "design", stepName: "design", groupId: "g2", resolvedModel: resolved("zai/glm-5.2", "openrouter/z-ai/glm-5.2") }),
+    ])
+
+    const lines = plain(runReviewLines(plan, 100))
+
+    expect(lines.some((line) => line.includes("implementer · writable · 2 attempts"))).toBe(true)
+    const solRows = lines.filter((line) => line.includes("gpt-5.6-sol"))
+    expect(solRows).toHaveLength(1)
+    expect(solRows[0]).not.toContain("→")
+    expect(lines.some((line) => line.includes("zai/glm-5.2 → openrouter/z-ai/glm-5.2"))).toBe(true)
+  })
+
+  test("groups concurrent steps under one node and labels human gates", () => {
+    const plan = planWith([
+      agentStep({ name: "clean-code", stepName: "clean-code", groupId: "audit", readOnly: true, resolvedModel: resolved("openai/gpt-5.6-sol", "openai/gpt-5.6-sol") }),
+      agentStep({ name: "security", stepName: "security", groupId: "audit", readOnly: true, resolvedModel: resolved("anthropic/claude-opus-4-8", "anthropic/claude-opus-4-8") }),
+      { type: "human", name: "approve", description: "" },
+    ])
+
+    const lines = plain(runReviewLines(plan, 100))
+
+    expect(lines.some((line) => line.includes("pipeline implement · 3 steps · 2 read-only · 1 manual"))).toBe(true)
+    expect(lines.some((line) => line.includes("parallel · 2 runs · read-only · 2 attempts"))).toBe(true)
+    expect(lines.some((line) => line.includes("├─ clean-code"))).toBe(true)
+    expect(lines.some((line) => line.includes("└─ security"))).toBe(true)
+    expect(lines.some((line) => line.includes("approve · manual gate"))).toBe(true)
+  })
+
+  test("shows the claude code engine and its CLI model without a resolved target", () => {
+    const plan = planWith([agentStep({ name: "security", stepName: "security", groupId: "g1", runner: "claude-code", model: "opus", readOnly: true })])
+
+    const lines = plain(runReviewLines(plan, 100))
+
+    expect(lines.some((line) => line.includes("security · claude code · read-only · 2 attempts"))).toBe(true)
+    expect(lines.some((line) => line.includes("claude-code/opus"))).toBe(true)
+  })
+
+  test("renders hooks, runtime judge, worktree intent, branch namer, and resume overrides", () => {
+    const plan = planWith([], {
+      target: { directory: "/repo", baseRef: "develop", worktree: true, dirty: false },
+      modelRouting: { gateway: "openrouter" },
+      smartJudge: { model: resolved("openai/gpt-5.6-terra#xhigh", "openrouter/openai/gpt-5.6-terra#xhigh", "openrouter") },
+      branchNamer: { model: resolved("anthropic/claude-haiku-4-5", "openrouter/anthropic/claude-haiku-4-5", "openrouter") },
+      hooks: { pre: [{ command: "pnpm lint" }], post: [{ command: "./notify.sh", when: "always" }] },
+      attachments: ["a.md", "b.md"],
+      permissions: "smart",
+      resume: { runID: "20260720-135802-5bbh", gatewayOverride: { original: "vercel", pending: "openrouter" } },
+    })
+
+    const lines = plain(runReviewLines(plan, 100))
+
+    expect(lines.some((line) => line.includes("gateway  OpenRouter"))).toBe(true)
+    expect(lines.some((line) => line.includes("resume override · original Vercel AI Gateway · pending phases OpenRouter"))).toBe(true)
+    expect(lines.some((line) => line.includes("worktree and branch created after confirmation"))).toBe(true)
+    expect(lines.some((line) => line.includes("branch named by openrouter/anthropic/claude-haiku-4-5 after confirmation"))).toBe(true)
+    expect(lines.some((line) => line.includes("hooks    pre   · pnpm lint"))).toBe(true)
+    expect(lines.some((line) => line.includes("post  · ./notify.sh · always"))).toBe(true)
+    expect(lines.some((line) => line.includes("runtime  smart permissions · 2 attachments · judge openrouter/openai/gpt-5.6-terra#xhigh"))).toBe(true)
+  })
+
+  test("expands the full prompt with hard wrapping and collapses it back to an excerpt", () => {
+    const long = `first ${"requirement ".repeat(30)}\nsecond line`
+    const plan = planWith([], { prompt: { source: "inline", text: long } })
+
+    const excerpt = plain(runReviewLines(plan, 60))
+    const expanded = plain(runReviewLines(plan, 60, { fullPrompt: true }))
+
+    expect(excerpt.filter((line) => line.includes("requirement"))).toHaveLength(1)
+    expect(expanded.length).toBeGreaterThan(excerpt.length)
+    expect(expanded.some((line) => line.includes("second line"))).toBe(true)
+    expect(expanded.every((line) => line.length <= 60)).toBe(true)
+  })
+
+  test("sanitizes untrusted fields and keeps every row within the panel width", () => {
+    const plan = planWith([], {
+      prompt: { source: "inline", text: "do \u001b[31mthings\u0007" },
+      target: { directory: "/repo\nforged", baseRef: "main", worktree: false, dirty: false },
+      pipeline: {
+        name: "impl\nevil",
+        steps: [agentStep({ name: "evil\nstep", stepName: "evil", groupId: "g1", resolvedModel: resolved("openai/gpt-new", "openai/gpt-new") })],
+      },
+      hooks: { pre: [{ command: "rm -rf /\nwhoami" }], post: [] },
+    })
+
+    const width = 72
+    const lines = plain(runReviewLines(plan, width, { fullPrompt: true }))
+
+    for (const line of lines) {
+      expect(line).not.toContain("\u001b")
+      expect(line).not.toContain("\u0007")
+      expect(line).not.toContain("\n")
+      expect(line.length).toBeLessThanOrEqual(width)
+    }
+  })
+})

--- a/test/run-plan.test.ts
+++ b/test/run-plan.test.ts
@@ -41,7 +41,9 @@ test("the immutable plan filters and freezes exact routed targets", () => {
   expect(step?.type === "agent" && step.resolvedModel?.target).toBe("vercel/anthropic/claude-opus-4.8")
   expect(Object.isFrozen(plan)).toBe(true)
   expect(Object.isFrozen(plan.pipeline.steps)).toBe(true)
-  expect(Object.isFrozen(options.pipeline.steps[0]?.inputFiles)).toBe(false)
+  const originalStep = options.pipeline.steps[0]
+  if (originalStep?.type !== "agent") throw new Error("expected an agent step")
+  expect(Object.isFrozen(originalStep.inputFiles)).toBe(false)
   expect(Object.isFrozen(options.hooks.pre[0])).toBe(false)
 })
 
@@ -131,4 +133,46 @@ test("the plan routes fan-out and the smart judge while leaving Claude Code unto
   expect(claude).toMatchObject({ runner: "claude-code", model: "opus" })
   expect(claude).not.toHaveProperty("resolvedModel")
   expect(plan.smartJudge?.model).toMatchObject({ logical: "anthropic/claude-haiku-4.5", target: "vercel/anthropic/claude-haiku-4.5" })
+})
+
+test("the plan freezes the routed branch namer and marks an explicit resume gateway override", () => {
+  const options: RunOptions = {
+    prompt: "review the change",
+    files: [],
+    onlySteps: [],
+    skipSteps: [],
+    resumeRunID: "20260720-135802-5bbh",
+    keepRunDir: true,
+    modelOverride: "",
+    gateway: "openrouter",
+    modelRoutingOverrides: {},
+    tui: false,
+    humanReview: false,
+    maxAttempts: 2,
+    baseRef: "main",
+    targetDir: "/repo",
+    includeDirty: false,
+    yolo: false,
+    smart: false,
+    smartJudgeModel: "openai/gpt-5.6-sol",
+    pipeline: {
+      name: "review",
+      steps: [
+        { type: "agent", name: "audit", stepName: "audit", groupId: "g1", agentName: "audit", description: "Audit", model: "openai/gpt-5.6-sol", inputFiles: ["prd.md"], inputDiff: true, reportPath: "reports/audit.md", readOnly: true },
+      ],
+    },
+    agents: [],
+    permissions: { allow: [], deny: [] },
+    hooks: { pre: [], post: [], pipelines: {} },
+  }
+
+  const overridden = buildRunPlan({ ...options, promptSource: "resume", resumeGateway: "vercel", branchNameModel: "anthropic/claude-haiku-4-5" })
+  expect(overridden.resume).toEqual({ runID: "20260720-135802-5bbh", gatewayOverride: { original: "vercel", pending: "openrouter" } })
+  expect(overridden.branchNamer?.model).toMatchObject({ logical: "anthropic/claude-haiku-4-5", target: "openrouter/anthropic/claude-haiku-4-5" })
+  expect(Object.isFrozen(overridden.branchNamer)).toBe(true)
+
+  // Resuming with the frozen gateway (or no explicit override) leaves no banner.
+  const unchanged = buildRunPlan({ ...options, gateway: "vercel", promptSource: "resume", resumeGateway: "vercel" })
+  expect(unchanged.resume).toEqual({ runID: "20260720-135802-5bbh" })
+  expect(unchanged).not.toHaveProperty("branchNamer")
 })

--- a/test/run-plan.test.ts
+++ b/test/run-plan.test.ts
@@ -31,7 +31,7 @@ test("the immutable plan filters and freezes exact routed targets", () => {
     },
     agents: [],
     permissions: { allow: [], deny: [] },
-    hooks: { pre: [], post: [], pipelines: {} },
+    hooks: { pre: [{ command: "bun test" }], post: [], pipelines: {} },
   }
   const plan = buildRunPlan(options)
   expect(plan.pipeline.steps).toHaveLength(1)
@@ -39,4 +39,6 @@ test("the immutable plan filters and freezes exact routed targets", () => {
   expect(step?.type === "agent" && step.resolvedModel?.target).toBe("vercel/anthropic/claude-opus-4.8")
   expect(Object.isFrozen(plan)).toBe(true)
   expect(Object.isFrozen(plan.pipeline.steps)).toBe(true)
+  expect(Object.isFrozen(options.pipeline.steps[0]?.inputFiles)).toBe(false)
+  expect(Object.isFrozen(options.hooks.pre[0])).toBe(false)
 })

--- a/test/run-plan.test.ts
+++ b/test/run-plan.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+
+import { buildRunPlan } from "../src/run-plan"
+import type { RunOptions } from "../src/types"
+
+test("the immutable plan filters and freezes exact routed targets", () => {
+  const options: RunOptions = {
+    prompt: "ship it",
+    files: [],
+    onlySteps: ["build"],
+    skipSteps: [],
+    resumeRunID: "",
+    keepRunDir: true,
+    modelOverride: "anthropic/claude-opus-4.8",
+    gateway: "vercel",
+    tui: false,
+    humanReview: false,
+    maxAttempts: 2,
+    baseRef: "main",
+    targetDir: "/repo",
+    includeDirty: false,
+    yolo: false,
+    smart: false,
+    smartJudgeModel: "openai/gpt-5.6-sol",
+    pipeline: {
+      name: "p",
+      steps: [
+        { type: "agent", name: "build", stepName: "build", groupId: "g1", agentName: "a", description: "a", model: "openai/gpt-5.6-sol", inputFiles: ["prd.md"], inputDiff: false, reportPath: "reports/build.md" },
+        { type: "agent", name: "audit", stepName: "audit", groupId: "g2", agentName: "a", description: "a", model: "openai/gpt-5.6-sol", inputFiles: ["prd.md"], inputDiff: true, reportPath: "reports/audit.md" },
+      ],
+    },
+    agents: [],
+    permissions: { allow: [], deny: [] },
+    hooks: { pre: [], post: [], pipelines: {} },
+  }
+  const plan = buildRunPlan(options)
+  expect(plan.pipeline.steps).toHaveLength(1)
+  const step = plan.pipeline.steps[0]
+  expect(step?.type === "agent" && step.resolvedModel?.target).toBe("vercel/anthropic/claude-opus-4.8")
+  expect(Object.isFrozen(plan)).toBe(true)
+  expect(Object.isFrozen(plan.pipeline.steps)).toBe(true)
+})

--- a/test/run-plan.test.ts
+++ b/test/run-plan.test.ts
@@ -1,14 +1,16 @@
 import { expect, test } from "bun:test"
 
-import { buildRunPlan } from "../src/run-plan"
-import type { RunOptions } from "../src/types"
+import { builtInAgents, builtInPipelines, resolvePipeline } from "../src/pipeline"
+import { logicalModel } from "../src/model-routing"
+import { buildRunPlan, routePipeline } from "../src/run-plan"
+import type { AgentStep, RunOptions } from "../src/types"
 
 test("the immutable plan filters and freezes exact routed targets", () => {
   const options: RunOptions = {
     prompt: "ship it",
     files: [],
     onlySteps: ["build"],
-    skipSteps: [],
+    skipSteps: ["audit"],
     resumeRunID: "",
     keepRunDir: true,
     modelOverride: "anthropic/claude-opus-4.8",
@@ -41,4 +43,92 @@ test("the immutable plan filters and freezes exact routed targets", () => {
   expect(Object.isFrozen(plan.pipeline.steps)).toBe(true)
   expect(Object.isFrozen(options.pipeline.steps[0]?.inputFiles)).toBe(false)
   expect(Object.isFrozen(options.hooks.pre[0])).toBe(false)
+})
+
+test("routing preserves every built-in pipeline's execution structure", () => {
+  for (const [name, spec] of Object.entries(builtInPipelines)) {
+    const original = resolvePipeline({ name, spec, agents: builtInAgents })
+    const shape = (step: AgentStep) => ({
+      name: step.name,
+      stepName: step.stepName,
+      groupId: step.groupId,
+      reportPath: step.reportPath,
+      inputFiles: step.inputFiles,
+      readOnly: step.readOnly,
+    })
+    const originalAgents = original.steps.filter((step): step is AgentStep => step.type === "agent")
+
+    for (const gateway of ["configured", "direct", "openrouter", "vercel"] as const) {
+      const routed = routePipeline(original, gateway, {})
+      const routedAgents = routed.steps.filter((step): step is AgentStep => step.type === "agent")
+
+      expect(routedAgents.map(shape)).toEqual(originalAgents.map(shape))
+      for (const [index, step] of routedAgents.entries()) {
+        const originalStep = originalAgents[index]!
+        const configured = `${originalStep.model}${originalStep.variant ? `#${originalStep.variant}` : ""}`
+        const recovered = logicalModel(configured)
+        const logical = `${recovered.model}${recovered.variant ? `#${recovered.variant}` : ""}`
+        const expectedTarget =
+          gateway === "configured"
+            ? configured
+            : gateway === "direct"
+              ? logical
+              : gateway === "openrouter"
+                ? `openrouter/${logical.replace(/^zai\//, "z-ai/")}`
+                : `vercel/${logical}`
+
+        expect(step.resolvedModel?.gateway).toBe(gateway)
+        expect(step.resolvedModel?.target).toBe(expectedTarget)
+      }
+    }
+  }
+})
+
+test("the plan routes fan-out and the smart judge while leaving Claude Code untouched", () => {
+  const options: RunOptions = {
+    prompt: "review the change",
+    files: ["docs/architecture.md"],
+    onlySteps: [],
+    skipSteps: [],
+    resumeRunID: "20260720-135802-5bbh",
+    keepRunDir: true,
+    modelOverride: "",
+    gateway: "vercel",
+    modelRoutingOverrides: {},
+    tui: false,
+    humanReview: true,
+    maxAttempts: 3,
+    baseRef: "main",
+    targetDir: "/repo",
+    includeDirty: true,
+    yolo: false,
+    smart: true,
+    smartJudgeModel: "anthropic/claude-haiku-4.5",
+    pipeline: {
+      name: "review",
+      steps: [
+        { type: "agent", name: "audit__openai", stepName: "audit", groupId: "parallel", agentName: "audit", description: "Audit", model: "openai/gpt-5.6-sol", inputFiles: ["prd.md"], inputDiff: true, reportPath: "reports/audit__openai.md", readOnly: true },
+        { type: "agent", name: "audit__anthropic", stepName: "audit", groupId: "parallel", agentName: "audit", description: "Audit", model: "anthropic/claude-opus-4.8", inputFiles: ["prd.md"], inputDiff: true, reportPath: "reports/audit__anthropic.md", readOnly: true },
+        { type: "agent", name: "external", stepName: "external", groupId: "g2", agentName: "external", description: "External audit", runner: "claude-code", model: "opus", inputFiles: ["prd.md"], inputDiff: false, reportPath: "reports/external.md", readOnly: true },
+      ],
+    },
+    agents: [],
+    permissions: { allow: [], deny: [] },
+    hooks: { pre: [{ command: "bun test" }], post: [], pipelines: { review: { pre: [], post: [{ command: "bun run lint", when: "always" }] } } },
+  }
+
+  const plan = buildRunPlan({ ...options, promptSource: "resume", worktree: true })
+  const [openai, anthropic, claude] = plan.pipeline.steps
+
+  expect(plan.prompt).toEqual({ source: "resume", text: "review the change" })
+  expect(plan.target).toEqual({ directory: "/repo", baseRef: "main", worktree: true, dirty: true })
+  expect(plan.resume).toEqual({ runID: "20260720-135802-5bbh" })
+  expect(plan.permissions).toBe("smart")
+  expect(plan.attachments).toEqual(["docs/architecture.md"])
+  expect(plan.hooks).toEqual({ pre: [{ command: "bun test" }], post: [{ command: "bun run lint", when: "always" }] })
+  expect(openai).toMatchObject({ name: "audit__openai", stepName: "audit", groupId: "parallel", resolvedModel: { logical: "openai/gpt-5.6-sol", target: "vercel/openai/gpt-5.6-sol" } })
+  expect(anthropic).toMatchObject({ name: "audit__anthropic", stepName: "audit", groupId: "parallel", resolvedModel: { logical: "anthropic/claude-opus-4.8", target: "vercel/anthropic/claude-opus-4.8" } })
+  expect(claude).toMatchObject({ runner: "claude-code", model: "opus" })
+  expect(claude).not.toHaveProperty("resolvedModel")
+  expect(plan.smartJudge?.model).toMatchObject({ logical: "anthropic/claude-haiku-4.5", target: "vercel/anthropic/claude-haiku-4.5" })
 })

--- a/test/run-review.test.ts
+++ b/test/run-review.test.ts
@@ -45,3 +45,62 @@ test("run review renders untrusted plan fields without terminal or layout inject
   expect(rendered).toContain("audit forged")
   expect(rendered).toContain("bun test rm -rf /")
 })
+
+test("review renders the exact target, worktree intent, and routed smart judge", () => {
+  const plan: RunPlan = {
+    prompt: { source: "file", text: "Audit the checkout flow" },
+    target: { directory: "/repo", baseRef: "main", worktree: true, dirty: false },
+    pipeline: {
+      name: "audit",
+      steps: [
+        {
+          type: "agent",
+          name: "security",
+          stepName: "security",
+          groupId: "g1",
+          agentName: "security-auditor",
+          description: "Security audit",
+          model: "vercel/openai/gpt-5.6-sol",
+          resolvedModel: {
+            configured: "openai/gpt-5.6-sol",
+            logical: "openai/gpt-5.6-sol",
+            gateway: "vercel",
+            providerID: "vercel",
+            modelID: "openai/gpt-5.6-sol",
+            target: "vercel/openai/gpt-5.6-sol",
+          },
+          inputFiles: ["prd.md"],
+          inputDiff: true,
+          reportPath: "reports/security.md",
+          maxAttempts: 3,
+        },
+      ],
+    },
+    modelRouting: { gateway: "vercel" },
+    smartJudge: {
+      model: {
+        configured: "anthropic/claude-haiku-4.5",
+        logical: "anthropic/claude-haiku-4.5",
+        gateway: "vercel",
+        providerID: "vercel",
+        modelID: "anthropic/claude-haiku-4.5",
+        target: "vercel/anthropic/claude-haiku-4.5",
+      },
+    },
+    hooks: { pre: [{ command: "bun run lint" }], post: [] },
+    attachments: ["docs/architecture.md"],
+    permissions: "smart",
+    maxAttempts: 2,
+  }
+
+  const detailed = renderRunPlan(plan)
+  const compact = renderRunPlan(plan, true)
+
+  expect(detailed).toContain("Worktree: yes (created after confirmation)")
+  expect(detailed).toContain("Logical: openai/gpt-5.6-sol")
+  expect(detailed).toContain("Target:  vercel/openai/gpt-5.6-sol")
+  expect(detailed).toContain("Judge: vercel/anthropic/claude-haiku-4.5")
+  expect(detailed).toContain("pre: bun run lint")
+  expect(compact).toContain("Convoy run plan")
+  expect(compact).not.toContain("Target:  vercel/openai/gpt-5.6-sol")
+})

--- a/test/run-review.test.ts
+++ b/test/run-review.test.ts
@@ -104,3 +104,39 @@ test("review renders the exact target, worktree intent, and routed smart judge",
   expect(compact).toContain("Convoy run plan")
   expect(compact).not.toContain("Target:  vercel/openai/gpt-5.6-sol")
 })
+
+test("review marks a resume gateway override in every format and shows the routed branch namer", () => {
+  const plan: RunPlan = {
+    prompt: { source: "resume", text: "continue the work" },
+    target: { directory: "/repo", baseRef: "main", worktree: true, dirty: false },
+    pipeline: { name: "implement", steps: [] },
+    modelRouting: { gateway: "openrouter" },
+    branchNamer: {
+      model: {
+        configured: "anthropic/claude-haiku-4-5",
+        logical: "anthropic/claude-haiku-4-5",
+        gateway: "openrouter",
+        providerID: "openrouter",
+        modelID: "anthropic/claude-haiku-4-5",
+        target: "openrouter/anthropic/claude-haiku-4-5",
+      },
+    },
+    hooks: { pre: [], post: [] },
+    attachments: [],
+    permissions: "interactive",
+    maxAttempts: 2,
+    resume: { runID: "20260720-135802-5bbh", gatewayOverride: { original: "vercel", pending: "openrouter" } },
+  }
+
+  const detailed = renderRunPlan(plan)
+  const compact = renderRunPlan(plan, true)
+
+  expect(detailed).toContain("Resume gateway override:")
+  expect(detailed).toContain("original: Vercel AI Gateway")
+  expect(detailed).toContain("pending phases: OpenRouter")
+  expect(compact).toContain("Resume gateway override:")
+  expect(compact).toContain("pending phases: OpenRouter")
+
+  expect(detailed).toContain("Branch naming: openrouter/anthropic/claude-haiku-4-5 (generated after confirmation)")
+  expect(compact).not.toContain("Branch naming:")
+})

--- a/test/run-review.test.ts
+++ b/test/run-review.test.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "bun:test"
+
+import { renderRunPlan } from "../src/run-review"
+import type { RunPlan } from "../src/types"
+
+test("run review renders untrusted plan fields without terminal or layout injection", () => {
+  const plan: RunPlan = {
+    prompt: { source: "inline", text: "normal\u001b[31mprompt\nwith details" },
+    target: { directory: "/repo\nStart run? [y/N] y", baseRef: "main\u001b]52;c;clipboard\u0007", worktree: false, dirty: false },
+    pipeline: {
+      name: "audit\nforged",
+      steps: [
+        {
+          type: "agent",
+          name: "security",
+          stepName: "security",
+          groupId: "g1",
+          agentName: "security-auditor",
+          description: "Security",
+          model: "vercel/openai/gpt-new",
+          resolvedModel: {
+            configured: "openai/gpt-new",
+            logical: "openai/gpt-new\nforged",
+            gateway: "vercel",
+            providerID: "vercel",
+            modelID: "openai/gpt-new",
+            target: "vercel/openai/gpt-new\u001b[2J",
+          },
+          inputFiles: ["prd.md"],
+          inputDiff: false,
+          reportPath: "reports/security.md",
+        },
+      ],
+    },
+    modelRouting: { gateway: "vercel" },
+    hooks: { pre: [{ command: "bun test\nrm -rf /" }], post: [] },
+    attachments: [],
+    permissions: "interactive",
+    maxAttempts: 1,
+  }
+
+  const rendered = renderRunPlan(plan)
+  expect(rendered).not.toContain("\u001b")
+  expect(rendered).toContain("/repo Start run? [y/N] y")
+  expect(rendered).toContain("audit forged")
+  expect(rendered).toContain("bun test rm -rf /")
+})

--- a/test/run-review.test.ts
+++ b/test/run-review.test.ts
@@ -140,3 +140,23 @@ test("review marks a resume gateway override in every format and shows the route
   expect(detailed).toContain("Branch naming: openrouter/anthropic/claude-haiku-4-5 (generated after confirmation)")
   expect(compact).not.toContain("Branch naming:")
 })
+
+test("review can expand the complete sanitized prompt for the launcher", () => {
+  const plan: RunPlan = {
+    prompt: { source: "inline", text: "first requirement\nsecond\trequirement\u001b[31m" },
+    target: { directory: "/repo", baseRef: "main", worktree: false, dirty: false },
+    pipeline: { name: "quick", steps: [] },
+    modelRouting: { gateway: "configured" },
+    hooks: { pre: [], post: [] },
+    attachments: [],
+    permissions: "interactive",
+    maxAttempts: 1,
+  }
+
+  const excerpt = renderRunPlan(plan)
+  const expanded = renderRunPlan(plan, false, { fullPrompt: true })
+
+  expect(excerpt).toContain("first requirement second requirement")
+  expect(expanded).toContain("  first requirement\n  second requirement")
+  expect(expanded).not.toContain("\u001b")
+})

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -108,6 +108,7 @@ describe("runner helpers", () => {
     })
     expect(parseModel("custom/provider/model")).toEqual({ providerID: "custom", modelID: "provider/model" })
     expect(() => parseModel("claude-sonnet-4-6")).toThrow("invalid model")
+    expect(() => parseModel("openai/gpt-5.6\nforged")).toThrow("invalid model")
   })
 
   test("applies only and skip phase filters", () => {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -16,6 +16,7 @@ type NamerPromptInput = {
   sessionID: string
   directory: string
   model: { providerID: string; modelID: string }
+  variant?: string
   tools: Record<string, boolean>
   parts: Array<{ type: string; text: string }>
 }
@@ -114,6 +115,16 @@ describe("askForBranchName", () => {
     const sent = promptInput?.parts[0]?.text ?? ""
     expect(sent.length).toBe("Prompt:\n".length + 1_200)
     expect(sent.endsWith("…")).toBe(true)
+  })
+
+  test("preserves a reviewed branch-namer model variant", async () => {
+    let promptInput: NamerPromptInput | undefined
+    const client = fakeNamerClient({ promptText: "add-onboarding", onPrompt: (input) => (promptInput = input as NamerPromptInput) })
+
+    await askForBranchName(client, "build onboarding", "/repo", "vercel/openai/gpt-5.6-sol#xhigh")
+
+    expect(promptInput?.model).toEqual({ providerID: "vercel", modelID: "openai/gpt-5.6-sol" })
+    expect(promptInput?.variant).toBe("xhigh")
   })
 
   test("cleans up the throwaway session when the provider call fails", async () => {


### PR DESCRIPTION
## Summary
- add configurable direct, OpenRouter, and Vercel AI Gateway model routing
- introduce immutable pre-run plans, review/confirmation, provider preflight, and frozen resume routing
- document routing and add coverage for configuration, planning, review, metadata, and preflight

## Validation
- `bun run typecheck`
- `bun test` (407 passing)