### PR TITLE
feat(worktree): confirm branch names before creating the worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This leaves `convoy` in `~/.local/bin/convoy` and creates `~/.convoy/config.yaml
 From the root of the target repo, ideally on a working branch:
 
 ```bash
-# interactive launcher: choose a pipeline, enter the prompt, set options, then review
+# interactive launcher: choose a pipeline, enter the prompt, set options, name the branch, then review
 convoy
 
 # inline prompt
@@ -253,7 +253,7 @@ defaults:
   baseRef: main                    # optional; auto-detected when unset (origin default branch, else main/master/develop/trunk, else current branch)
   pipeline: quick                  # pipeline used when -p/--pipeline is not given
   autoAcceptJudgeModel: anthropic/claude-haiku-4-5   # model for smart auto-accept (--smart); defaults to the run's model
-  branchNameModel: anthropic/claude-haiku-4-5        # model that names worktree branches (may look up referenced issues)
+  branchNameModel: anthropic/claude-haiku-4-5        # proposes worktree branch names (may look up referenced issues); you confirm the name
 
 # Project agents: the prompt lives at .convoy/agents/<name>.md (required).
 # Naming a built-in agent here overrides its model/temperature/readOnly instead.
@@ -501,3 +501,14 @@ modelRouting:
 Unknown model namespaces require an explicit override when rerouting; `configured` always remains literal. Authenticate Vercel through `opencode providers login` (choose Vercel AI Gateway) or set `AI_GATEWAY_API_KEY`; Convoy never stores gateway credentials.
 
 Every interactive manual run now displays its fully resolved plan before repository effects. The launcher has a native **Review** step after Options: use Enter or `s` to start, Escape to return to Options, `q` to cancel, arrow/page keys or the mouse wheel to scroll, and `p` to expand the complete prompt. `--plan` prints that plan and exits without creating a run, running hooks, or starting OpenCode. `--no-confirm` prints a compact plan and starts immediately. Non-TTY environments continue automatically after the compact summary.
+
+### Isolating a run in a worktree
+
+The **Isolate in a worktree** option runs Convoy on a new branch checked out under `~/.convoy/worktrees/<branch>`, leaving your current checkout untouched. The branch is always agreed with you first, in a **Branch** step between Options and Review:
+
+- `defaults.branchNameModel` (Haiku by default) reads your prompt and proposes a conventional name — `feat/runtime-guard-limits`, `fix/login-redirect` — always in English, even when the prompt is not. Prompts that only reference an issue (`#123`, `DEV-1339`, a URL) are looked up first, so the branch is named after what the issue is about.
+- The proposed name is shown in an editable field together with the worktree path it would take. Enter accepts it and moves on to Review; nothing is created until you confirm the run there.
+- `tab` moves to the **hint** box: describe how you want it named ("name it after the budget limits") and press Enter or `ctrl+R` to re-name it. This is also what you get when the prompt is too thin to name anything, or when the naming model is unavailable — the step still opens, with a name derived from the prompt, ready to be edited.
+- Names already taken by a branch or an existing worktree are suffixed (`-2`, `-3`) instead of failing `git worktree add` after the run has been confirmed.
+
+The new branch is created from `HEAD`, so it starts from whatever you have checked out.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,7 +16,7 @@ import type { Pipeline, RunOptions } from "./types"
 import { isValidRunID, resumeWorkspace } from "./workspace"
 import { readRunMetadata } from "./metadata"
 import { preflightRunPlan } from "./preflight"
-import type { LaunchRunPreparation, LaunchRunSelection } from "./launch-tui"
+import type { LaunchBranchCheck, LaunchBranchProposal, LaunchRunPreparation, LaunchRunSelection } from "./launch-tui"
 
 /**
  * Flags as written: every scalar stays undefined until the user sets it, so
@@ -130,6 +130,8 @@ async function launchInteractiveRun(targetDir: string) {
   const selection = await launchRunTui({
     targetDir,
     prepareRun: (runSelection) => prepareInteractiveRun(targetDir, runSelection),
+    proposeBranchName: (input) => proposeInteractiveBranchName(targetDir, input),
+    checkBranchName: (name) => checkInteractiveBranchName(targetDir, name),
   })
   if (!selection) return
   if (selection.action === "runs") {
@@ -162,9 +164,9 @@ async function launchInteractiveRun(targetDir: string) {
   })
   if (runSelection.isolateWorktree) {
     const { createIsolatedWorktree } = await import("./worktree")
-    const namer = plan.branchNamer?.model.target
-    if (!namer) throw new Error("worktree plan is missing its branch-namer model")
-    const worktree = await createIsolatedWorktree({ targetDir, prompt: runSelection.prompt, model: namer })
+    const branch = plan.target.branch
+    if (!branch) throw new Error("worktree plan is missing its confirmed branch name")
+    const worktree = await createIsolatedWorktree({ targetDir, branch })
     options = { ...options, targetDir: worktree.dir, includeDirty: false }
     log.info(`running in isolated worktree (branch: ${worktree.branch})`)
     log.info(`  dir: ${worktree.dir}`)
@@ -188,21 +190,35 @@ async function prepareInteractiveRun(targetDir: string, selection: LaunchRunSele
   if (selection.includeDirty) parsed.maxAttempts = 1
 
   let options = { ...(await resolveRunOptions(parsed)), prompt: selection.prompt }
-  // Resolve the branch namer before the review so the exact routed target is
-  // part of the confirmed plan; the AI naming call itself stays behind the
-  // confirmation gate.
-  let branchNameModel: string | undefined
-  if (selection.isolateWorktree) {
-    const { defaultBranchNameModel } = await import("./worktree")
-    const config = await loadMergedConvoyConfig(targetDir)
-    branchNameModel = config?.defaults.branchNameModel ?? defaultBranchNameModel
-  }
+  // The branch was named and confirmed in the launcher's branch step, so the
+  // plan the user reviews already names the branch the run will create.
   const plan = buildRunPlan({
     ...options,
     worktree: Boolean(selection.isolateWorktree),
-    ...(branchNameModel ? { branchNameModel } : {}),
+    ...(selection.branchName ? { branch: selection.branchName } : {}),
+    ...(selection.worktreeDir ? { worktreeDir: selection.worktreeDir } : {}),
   })
   return { options, plan }
+}
+
+/** Asks the configured naming model for a branch name for the launcher's branch step. */
+async function proposeInteractiveBranchName(targetDir: string, input: { prompt: string; guidance?: string }): Promise<LaunchBranchProposal> {
+  const { defaultBranchNameModel, proposeBranchName } = await import("./worktree")
+  const config = await loadMergedConvoyConfig(targetDir)
+  const model = config?.defaults.branchNameModel ?? defaultBranchNameModel
+  const proposal = await proposeBranchName({ ...input, targetDir, model })
+  return { ...proposal, model }
+}
+
+/** Sanitizes a candidate branch name and reports the free name it would take, plus its worktree path. */
+async function checkInteractiveBranchName(targetDir: string, name: string): Promise<LaunchBranchCheck> {
+  const { cleanBranchName, ensureFreeBranchName, worktreeDirFor } = await import("./worktree")
+  // A hand-written name keeps whatever prefix (or none) the user chose; only
+  // the model's proposals are held to the conventional `type/` shape.
+  const cleaned = cleanBranchName(name, { authored: true })
+  if (!cleaned) return { branch: "", dir: "" }
+  const free = await ensureFreeBranchName(cleaned, targetDir)
+  return { branch: free, dir: worktreeDirFor(free), ...(free === cleaned ? {} : { suffixed: true }) }
 }
 
 async function openRunsBrowser(initialRunID?: string) {

--- a/src/git.ts
+++ b/src/git.ts
@@ -233,6 +233,17 @@ export async function describeRepoSnapshotDifference(snapshot: RepoSnapshot, cwd
  * (a commit/ref in `cwd`'s repo). Used by the launcher's "isolate in a worktree"
  * flow so Convoy runs against a clean checkout on a new branch.
  */
+/**
+ * Whether `<name>` is already a local branch. Used before `git worktree add -b`
+ * so a name collision is caught (and suffixed) while the user can still see it,
+ * instead of failing the run after it has been confirmed.
+ */
+export async function branchExists(name: string, cwd: string): Promise<boolean> {
+  if (!name) return false
+  const result = await execFile("git", ["show-ref", "--verify", "--quiet", `refs/heads/${name}`], { cwd, allowFailure: true })
+  return result.exitCode === 0
+}
+
 export async function addWorktree(dir: string, branch: string, baseRef: string, cwd: string) {
   // `--` terminates option parsing so a `dir`/`baseRef` starting with `-`
   // (e.g. a caller-supplied ref like `--detach`) can't be misread as a flag.

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os"
 import { basename } from "node:path"
 
 import { BoxRenderable, StyledText, TextRenderable, bg, bold, createCliRenderer, decodePasteBytes, fg, stripAnsiSequences, t } from "@opentui/core"
@@ -30,8 +31,32 @@ export type LaunchRunSelection = {
   gateway: ModelGateway
   /** Worktree creation is intentionally deferred until after plan confirmation. */
   isolateWorktree?: boolean
+  /** The branch confirmed in the branch step; the worktree is created with exactly this name. */
+  branchName?: string
+  /** Where that branch will be checked out. */
+  worktreeDir?: string
   /** Empty repositories are initialized only after the review is confirmed. */
   initializeGit?: boolean
+}
+
+/** A branch name suggested for the run, plus where it came from so the step can say so. */
+export type LaunchBranchProposal = {
+  branch: string
+  /** "model" when the namer answered, "prompt" when it was derived locally, "fallback" for the timestamp. */
+  source: "model" | "prompt" | "fallback"
+  /** Why the model call didn't produce the name; shown as a hint, never as a blocker. */
+  error?: string
+  /** The naming model that was asked, for attribution in the UI. */
+  model?: string
+}
+
+/** Whether a candidate branch name can still be created, and where it would live. */
+export type LaunchBranchCheck = {
+  /** The name after sanitizing plus any collision suffix; may differ from what was passed in. */
+  branch: string
+  dir: string
+  /** Set when the passed name was already taken and had to be suffixed. */
+  suffixed?: boolean
 }
 
 export type LaunchNavigationSelection =
@@ -55,6 +80,10 @@ export type LaunchRunTuiOptions = {
   targetDir: string
   /** Resolves the run without effects so Review and the runner share one frozen plan. */
   prepareRun(selection: LaunchRunSelection): Promise<LaunchRunPreparation>
+  /** Asks the naming model for a branch name. Injected so the launcher stays free of the worktree/opencode modules. */
+  proposeBranchName(input: { prompt: string; guidance?: string }): Promise<LaunchBranchProposal>
+  /** Sanitizes a candidate and reports where it would live, suffixing it when the name is taken. */
+  checkBranchName(name: string): Promise<LaunchBranchCheck>
 }
 
 // One resolved step, flattened for the preview: `groupId` ties concurrent
@@ -101,7 +130,10 @@ type ToggleSpec = {
   description: string
 }
 
-type Mode = "pipelines" | "prompt" | "options" | "review"
+type Mode = "pipelines" | "prompt" | "options" | "branch" | "review"
+
+/** The two editable fields of the branch step. */
+type BranchField = "name" | "guidance"
 
 type Modal =
   | { kind: "message"; title: string; message: string; footer?: string }
@@ -172,7 +204,7 @@ export async function launchRunTui(options: LaunchRunTuiOptions): Promise<Launch
   })
   const mode = await renderer.waitForThemeMode(1_000).catch(() => null)
   setTheme(paletteForTerminal(mode, terminalBackgroundHex(renderer)))
-  return new LaunchPicker(renderer, options.targetDir, choices, config?.modelRouting?.gateway ?? "configured", options.prepareRun).result
+  return new LaunchPicker(renderer, options.targetDir, choices, config?.modelRouting?.gateway ?? "configured", options).result
 }
 
 function pipelineChoices(config: ConvoyConfig | undefined, agents: readonly AgentSpec[]): PipelineChoice[] {
@@ -256,6 +288,22 @@ class LaunchPicker {
   private reviewTotalLines = 0
   private reviewFullPrompt = false
 
+  // Branch step state. `branchDir` is the worktree path for the current name,
+  // and `branchEdited` flips as soon as the user types: a proposed name may be
+  // auto-suffixed on collision, a hand-written one never is.
+  private branchName = ""
+  /** The prompt the current name was proposed for, so editing the prompt re-names the branch. */
+  private branchPrompt = ""
+  private branchCursor = 0
+  private branchGuidance = ""
+  private branchGuidanceCursor = 0
+  private branchField: BranchField = "name"
+  private branchDir = ""
+  private branchSource: LaunchBranchProposal["source"] | "manual" = "manual"
+  private branchNote = ""
+  private branchError = ""
+  private branchChecking = false
+
   private readonly toggleState: Record<ToggleKey, boolean> = {
     smart: true,
     yolo: false,
@@ -293,11 +341,16 @@ class LaunchPicker {
   }
 
   private readonly handlePaste = (event: PasteEvent) => {
-    if (this.mode !== "prompt") return
+    if (this.mode !== "prompt" && this.mode !== "branch") return
     event.preventDefault()
     event.stopPropagation()
     const text = sanitizePaste(stripAnsiSequences(decodePasteBytes(event.bytes)))
     if (!text) return
+    if (this.mode === "branch") {
+      // Branch fields are single-line; a pasted newline would desync the cursor.
+      this.insertBranchText(text.replace(/\n+/g, " ").trim())
+      return
+    }
     this.insertPromptText(text)
     this.promptError = ""
     this.render()
@@ -342,6 +395,9 @@ class LaunchPicker {
       case "options":
         this.handleOptionsKey(key)
         break
+      case "branch":
+        this.handleBranchKey(key)
+        break
       case "review":
         this.handleReviewKey(key)
         break
@@ -353,7 +409,8 @@ class LaunchPicker {
     private readonly targetDir: string,
     private readonly choices: PipelineChoice[],
     private gateway: ModelGateway,
-    private readonly prepareRun: (selection: LaunchRunSelection) => Promise<LaunchRunPreparation>,
+    // Named `callbacks` rather than `hooks`: this file already uses "hooks" for the pipeline's shell hooks.
+    private readonly callbacks: Pick<LaunchRunTuiOptions, "prepareRun" | "proposeBranchName" | "checkBranchName">,
   ) {
     const defaultIndex = choices.findIndex((choice) => choice.isDefault)
     this.selected = defaultIndex >= 0 ? defaultIndex : 0
@@ -662,6 +719,97 @@ class LaunchPicker {
     }
   }
 
+  private handleBranchKey(key: KeyEvent) {
+    switch (branchActionForKey(key)) {
+      case "next-field":
+        this.branchField = this.branchField === "name" ? "guidance" : "name"
+        this.render()
+        return
+      case "previous-field":
+        this.branchField = this.branchField === "guidance" ? "name" : "guidance"
+        this.render()
+        return
+      case "regenerate":
+        void this.proposeBranch({ guidance: this.branchGuidance })
+        return
+      case "submit":
+        // Enter on the hint box means "name it with this", which is the whole
+        // point of the box when the prompt was too thin to name anything.
+        if (this.branchField === "guidance" && this.branchGuidance.trim()) void this.proposeBranch({ guidance: this.branchGuidance })
+        else void this.acceptBranch()
+        return
+      case "clear":
+        this.setBranchField("")
+        return
+      case "line-start":
+        this.setBranchCursor(0)
+        return
+      case "line-end":
+        this.setBranchCursor(this.branchFieldValue().length)
+        return
+      case "cursor-left":
+        this.setBranchCursor(this.branchFieldCursor() - 1)
+        return
+      case "cursor-right":
+        this.setBranchCursor(this.branchFieldCursor() + 1)
+        return
+      case "delete-back": {
+        const value = this.branchFieldValue()
+        const at = this.branchFieldCursor()
+        if (at > 0) this.setBranchField(value.slice(0, at - 1) + value.slice(at), at - 1)
+        else this.render()
+        return
+      }
+      case "back":
+        this.mode = "options"
+        this.branchError = ""
+        this.render()
+        return
+    }
+
+    const text = typedText(key)
+    if (text) this.insertBranchText(text)
+  }
+
+  private branchFieldValue() {
+    return this.branchField === "name" ? this.branchName : this.branchGuidance
+  }
+
+  private branchFieldCursor() {
+    return this.branchField === "name" ? this.branchCursor : this.branchGuidanceCursor
+  }
+
+  private setBranchField(value: string, cursor = value.length) {
+    if (this.branchField === "name") {
+      this.branchName = value
+      this.branchCursor = clamp(cursor, 0, value.length)
+      // The typed name owns the outcome from here: no silent collision suffix,
+      // and no conventional prefix forced onto it. The proposal's attribution
+      // and its checked path no longer describe what's in the field.
+      this.branchSource = "manual"
+      this.branchDir = ""
+      this.branchNote = ""
+      this.branchError = ""
+    } else {
+      this.branchGuidance = value
+      this.branchGuidanceCursor = clamp(cursor, 0, value.length)
+    }
+    this.render()
+  }
+
+  private setBranchCursor(cursor: number) {
+    const value = this.branchFieldValue()
+    if (this.branchField === "name") this.branchCursor = clamp(cursor, 0, value.length)
+    else this.branchGuidanceCursor = clamp(cursor, 0, value.length)
+    this.render()
+  }
+
+  private insertBranchText(text: string) {
+    const value = this.branchFieldValue()
+    const at = this.branchFieldCursor()
+    this.setBranchField(value.slice(0, at) + text + value.slice(at), at + text.length)
+  }
+
   private handleReviewKey(key: KeyEvent) {
     switch (reviewActionForKey(key)) {
       case "scroll-back":
@@ -694,7 +842,7 @@ class LaunchPicker {
         return
       case "back":
         this.prepared = undefined
-        this.mode = "options"
+        this.mode = this.toggleState.worktree ? "branch" : "options"
         this.reviewScroll = 0
         this.reviewTotalLines = 0
         this.render()
@@ -732,7 +880,95 @@ class LaunchPicker {
       this.render()
       return
     }
+    // Worktree runs stop to agree on a branch name first; everything else goes
+    // straight to the review as before.
+    if (this.toggleState.worktree) {
+      // A name already agreed for this exact prompt is kept; a rewritten prompt
+      // gets a fresh proposal rather than a stale name.
+      if (this.branchName && this.branchPrompt === this.prompt) {
+        this.mode = "branch"
+        this.render()
+        return
+      }
+      void this.proposeBranch({})
+      return
+    }
     void this.prepareReview(choice.name)
+  }
+
+  /**
+   * Asks for a name and lands on the branch step. A failure never blocks: the
+   * step opens with whatever could be derived (or empty), so the user can type
+   * the name or describe it and regenerate.
+   */
+  private async proposeBranch(input: { guidance?: string }) {
+    this.mode = "branch"
+    this.branchField = "name"
+    this.modal = { kind: "loading", title: "naming the branch", message: "Asking the namer for a branch name…" }
+    this.render()
+    try {
+      const proposal = await this.callbacks.proposeBranchName({ prompt: this.prompt, guidance: input.guidance?.trim() || undefined })
+      const checked = await this.callbacks.checkBranchName(proposal.branch)
+      if (!checked.branch) throw new Error("the proposed name had nothing usable in it")
+      this.branchPrompt = this.prompt
+      this.branchName = checked.branch
+      this.branchCursor = checked.branch.length
+      this.branchDir = checked.dir
+      this.branchSource = proposal.source
+      this.branchError = ""
+      this.branchNote = branchProposalNote(proposal, checked)
+    } catch (error) {
+      this.branchName = ""
+      this.branchCursor = 0
+      this.branchDir = ""
+      this.branchSource = "manual"
+      this.branchNote = ""
+      this.branchError = `Couldn't propose a name (${error instanceof Error ? error.message : String(error)}). Write one, or describe it below and press ctrl+R.`
+      this.branchField = "guidance"
+    } finally {
+      this.modal = undefined
+      this.render()
+    }
+  }
+
+  /** Validates the current name and moves on to the review with it frozen in. */
+  private async acceptBranch() {
+    const typed = this.branchName.trim()
+    if (!typed) {
+      this.branchError = "Write a branch name, or describe it below and press ctrl+R."
+      this.render()
+      return
+    }
+    if (this.branchChecking) return
+    this.branchChecking = true
+    try {
+      const checked = await this.callbacks.checkBranchName(typed)
+      if (!checked.branch) {
+        this.branchError = "That name has no usable characters for a git branch."
+        this.render()
+        return
+      }
+      // A hand-written name is never silently renamed: show the free name it
+      // would become and let the next Enter confirm it.
+      if (checked.suffixed && this.branchSource === "manual" && checked.branch !== typed) {
+        this.branchName = checked.branch
+        this.branchCursor = checked.branch.length
+        this.branchDir = checked.dir
+        this.branchError = `"${typed}" already exists — press enter again to use ${checked.branch}.`
+        this.render()
+        return
+      }
+      this.branchName = checked.branch
+      this.branchCursor = checked.branch.length
+      this.branchDir = checked.dir
+      this.branchError = ""
+      await this.prepareReview(this.currentChoice().name)
+    } catch (error) {
+      this.branchError = error instanceof Error ? error.message : String(error)
+      this.render()
+    } finally {
+      this.branchChecking = false
+    }
   }
 
   private async prepareReview(pipelineName: string) {
@@ -742,7 +978,7 @@ class LaunchPicker {
       const { repoBootstrapStatus } = await import("./git")
       const status = await repoBootstrapStatus(this.targetDir)
       const selection = this.runSelection(pipelineName, status !== "ready")
-      const preparation = await this.prepareRun(selection)
+      const preparation = await this.callbacks.prepareRun(selection)
       this.prepared = { action: "run", selection, ...preparation }
       this.mode = "review"
       this.reviewScroll = 0
@@ -770,6 +1006,7 @@ class LaunchPicker {
       smart: this.toggleState.smart,
       gateway: this.gateway,
       isolateWorktree: this.toggleState.worktree,
+      ...(this.toggleState.worktree && this.branchName ? { branchName: this.branchName, worktreeDir: this.branchDir } : {}),
       ...(initializeGit ? { initializeGit: true } : {}),
     }
   }
@@ -897,11 +1134,19 @@ class LaunchPicker {
   private headerContent(width: number) {
     const project = basename(this.targetDir) || this.targetDir
     const title: TextChunk[] = [fg(theme.faint)("target "), bold(fg(theme.text)(truncate(project, Math.max(12, width - 32))))]
+    // The branch step only exists for worktree runs, so the stage row grows and
+    // shrinks with the toggle instead of showing a step that can't be reached.
+    const steps: Array<{ label: string; mode: Mode }> = [
+      { label: "pipeline", mode: "pipelines" },
+      { label: "prompt", mode: "prompt" },
+      { label: "options", mode: "options" },
+      ...(this.toggleState.worktree ? [{ label: "branch", mode: "branch" as Mode }] : []),
+      { label: "review", mode: "review" },
+    ]
     const stage: TextChunk[] = []
-    for (const [index, step] of ["pipeline", "prompt", "options", "review"].entries()) {
+    for (const [index, step] of steps.entries()) {
       if (index > 0) stage.push(fg(theme.faint)(" → "))
-      const active = (this.mode === "pipelines" && index === 0) || (this.mode === "prompt" && index === 1) || (this.mode === "options" && index === 2) || (this.mode === "review" && index === 3)
-      stage.push(active ? bold(fg(theme.accent)(step)) : fg(theme.dim)(step))
+      stage.push(this.mode === step.mode ? bold(fg(theme.accent)(step.label)) : fg(theme.dim)(step.label))
     }
     const line1 = padBetween(title, stage, width)
     return joinLines([line1, limitsRow(this.limits, Date.now(), width)])
@@ -951,6 +1196,8 @@ class LaunchPicker {
         return this.promptDetail(width)
       case "options":
         return this.optionsDetail(width)
+      case "branch":
+        return this.branchDetail(width)
       case "review":
         return this.reviewDetail(width)
     }
@@ -1081,6 +1328,38 @@ class LaunchPicker {
     return joinLines(lines)
   }
 
+  private branchDetail(width: number) {
+    const lines: StyledText[] = []
+    lines.push(new StyledText([fg(theme.faint)("pipeline "), bold(fg(theme.text)(this.currentChoice().name))]))
+    lines.push(plain(""))
+    lines.push(t`${fg(theme.dim)("Name the branch and worktree for this run. Nothing is created until you confirm.")}`)
+    lines.push(plain(""))
+
+    const fieldWidth = Math.max(10, Math.min(width - 2, 60))
+    lines.push(new StyledText([fg(theme.faint)("branch")]))
+    lines.push(...textField(this.branchName, this.branchCursor, fieldWidth, this.branchField === "name", "feat/short-name"))
+
+    if (this.branchDir) {
+      lines.push(new StyledText([fg(theme.faint)("worktree "), fg(theme.dim)(truncate(displayHome(this.branchDir), Math.max(8, width - 9)))]))
+    } else if (this.branchName) {
+      lines.push(new StyledText([fg(theme.faint)("worktree "), fg(theme.dim)("checked when you press enter")]))
+    } else {
+      lines.push(plain(""))
+    }
+    if (this.branchNote) lines.push(new StyledText([fg(theme.faint)(truncate(this.branchNote, width))]))
+    else lines.push(plain(""))
+
+    lines.push(plain(""))
+    lines.push(new StyledText([fg(theme.faint)("hint "), fg(theme.dim)("optional — say how you want it named, then enter")]))
+    lines.push(...textField(this.branchGuidance, this.branchGuidanceCursor, fieldWidth, this.branchField === "guidance", "e.g. name it after the budget limits"))
+
+    if (this.branchError) {
+      lines.push(plain(""))
+      for (const line of wrapWords(this.branchError, width)) lines.push(t`${fg(theme.red)(line)}`)
+    }
+    return joinLines(lines)
+  }
+
   private reviewDetail(width: number) {
     const prepared = this.prepared
     if (!prepared) return joinLines([t`${fg(theme.red)("Unable to load the run review.")}`])
@@ -1122,6 +1401,22 @@ class LaunchPicker {
       return padBetween(
         [fg(theme.dim)("type/paste · "), fg(theme.accent)("shift+enter"), fg(theme.dim)(" newline · "), fg(theme.accent)("enter"), fg(theme.dim)(" options · "), fg(theme.accent)("esc"), fg(theme.dim)(" back")],
         [fg(theme.faint)(`${this.prompt.length} char${this.prompt.length === 1 ? "" : "s"}`)],
+        width,
+      )
+    }
+    if (this.mode === "branch") {
+      return padBetween(
+        [
+          fg(theme.accent)("enter"),
+          fg(theme.dim)(this.branchField === "guidance" ? " name it from the hint · " : " review · "),
+          fg(theme.accent)("tab"),
+          fg(theme.dim)(" field · "),
+          fg(theme.accent)("ctrl+R"),
+          fg(theme.dim)(" rename · "),
+          fg(theme.accent)("esc"),
+          fg(theme.dim)(" options"),
+        ],
+        [fg(theme.faint)(this.branchField === "name" ? "branch" : "hint")],
         width,
       )
     }
@@ -1168,6 +1463,113 @@ class LaunchPicker {
 
 function clamp(value: number, min: number, max: number) {
   return Math.max(min, Math.min(max, value))
+}
+
+/** A boxed single-line input, styled like the prompt editor's field. */
+function textField(value: string, cursor: number, width: number, focused: boolean, placeholder: string): StyledText[] {
+  const border = focused ? theme.accent : theme.faint
+  const inner = Math.max(1, width)
+  // Scroll the window so the cursor stays visible in a value longer than the box.
+  const start = Math.max(0, Math.min(cursor - inner + 1, Math.max(0, value.length - inner + 1)))
+  const visible = value.slice(start, start + inner)
+  const column = clamp(cursor - start, 0, inner - 1)
+
+  const chunks: TextChunk[] = [fg(border)("│")]
+  if (!value) {
+    const text = truncate(placeholder, Math.max(0, inner - 1))
+    if (focused) chunks.push(cursorChunk(" "), fg(theme.faint)(text), fg(theme.faint)(" ".repeat(Math.max(0, inner - 1 - text.length))))
+    else chunks.push(fg(theme.faint)(text), raw(" ".repeat(Math.max(0, inner - text.length))))
+  } else if (focused) {
+    const before = visible.slice(0, column)
+    const at = visible[column] ?? " "
+    const after = visible.slice(column + 1)
+    chunks.push(fg(theme.text)(before), cursorChunk(at), fg(theme.text)(after))
+    chunks.push(raw(" ".repeat(Math.max(0, inner - before.length - 1 - after.length))))
+  } else {
+    chunks.push(fg(theme.text)(visible), raw(" ".repeat(Math.max(0, inner - visible.length))))
+  }
+  chunks.push(fg(border)("│"))
+
+  return [
+    new StyledText([fg(border)("┌" + "─".repeat(inner) + "┐")]),
+    new StyledText(chunks),
+    new StyledText([fg(border)("└" + "─".repeat(inner) + "┘")]),
+  ]
+}
+
+/** Attribution line under the branch field: who proposed the name, and whether it had to move. */
+export function branchProposalNote(proposal: LaunchBranchProposal, check: LaunchBranchCheck): string {
+  const origin =
+    proposal.source === "model"
+      ? `proposed by ${proposal.model || "the naming model"}`
+      : proposal.source === "prompt"
+        ? "derived from your prompt (the naming model didn't answer)"
+        : "generic name (nothing to derive it from)"
+  return check.suffixed ? `${origin} · renamed, the original was taken` : origin
+}
+
+function displayHome(path: string): string {
+  const home = homedir()
+  if (path === home) return "~"
+  return path.startsWith(`${home}/`) ? `~/${path.slice(home.length + 1)}` : path
+}
+
+export type BranchAction =
+  | "next-field"
+  | "previous-field"
+  | "regenerate"
+  | "submit"
+  | "clear"
+  | "line-start"
+  | "line-end"
+  | "cursor-left"
+  | "cursor-right"
+  | "delete-back"
+  | "back"
+
+/**
+ * Keyboard contract for the branch step. Plain letters are never bound here —
+ * both fields are text inputs, so anything printable must reach them.
+ */
+export function branchActionForKey(key: Pick<KeyEvent, "name" | "ctrl" | "shift">): BranchAction | undefined {
+  if (key.ctrl) {
+    switch (key.name) {
+      case "r":
+        return "regenerate"
+      case "u":
+        return "clear"
+      case "a":
+        return "line-start"
+      case "e":
+        return "line-end"
+      case "h":
+        return "delete-back"
+    }
+    return undefined
+  }
+  switch (key.name) {
+    case "tab":
+      return key.shift ? "previous-field" : "next-field"
+    // Some terminals report shift+tab as its own key rather than a modifier.
+    case "backtab":
+      return "previous-field"
+    case "return":
+    case "linefeed":
+      return "submit"
+    case "home":
+      return "line-start"
+    case "end":
+      return "line-end"
+    case "left":
+      return "cursor-left"
+    case "right":
+      return "cursor-right"
+    case "backspace":
+      return "delete-back"
+    case "escape":
+      return "back"
+  }
+  return undefined
 }
 
 export type ReviewAction = "scroll-back" | "scroll-forward" | "page-back" | "page-forward" | "top" | "bottom" | "toggle-prompt" | "start" | "back" | "cancel"

--- a/src/preflight-validation.ts
+++ b/src/preflight-validation.ts
@@ -11,7 +11,8 @@ export function preflightTargets(plan: RunPlan): ResolvedModel[] {
     step.type === "agent" && step.runner !== "claude-code" && step.resolvedModel ? [step.resolvedModel] : [],
   )
   if (plan.smartJudge) targets.push(plan.smartJudge.model)
-  if (plan.branchNamer) targets.push(plan.branchNamer.model)
+  // No branch namer here: naming happens in the launcher, before the plan is
+  // built, so nothing is left to call once the run is confirmed.
   return targets
 }
 

--- a/src/review-tui.ts
+++ b/src/review-tui.ts
@@ -44,15 +44,13 @@ export function runReviewLines(plan: RunPlan, width: number, options: RunReviewR
 
   rows.push(labelRow("target", [fg(theme.text)(truncate(displayPath(sanitizeReviewInline(plan.target.directory)), value))]))
   rows.push(continuation([fg(theme.dim)(`diff base ${sanitizeReviewInline(plan.target.baseRef)} · ${plan.target.dirty ? "dirty tree included" : "clean tree required"}`)]))
-  rows.push(continuation([fg(theme.dim)(plan.target.worktree ? "worktree and branch created after confirmation" : "runs in the current checkout")]))
-  if (plan.branchNamer) {
-    rows.push(
-      continuation([
-        fg(theme.faint)("branch named by "),
-        fg(theme.text)(truncate(sanitizeReviewInline(plan.branchNamer.model.target), Math.max(8, value - 34))),
-        fg(theme.faint)(" after confirmation"),
-      ]),
-    )
+  if (plan.target.worktree) {
+    rows.push(continuation([fg(theme.faint)("branch "), fg(theme.text)(truncate(sanitizeReviewInline(plan.target.branch ?? "?"), Math.max(8, value - 7)))]))
+    if (plan.target.worktreeDir) {
+      rows.push(continuation([fg(theme.faint)("worktree "), fg(theme.dim)(truncate(displayPath(sanitizeReviewInline(plan.target.worktreeDir)), Math.max(8, value - 9)))]))
+    }
+  } else {
+    rows.push(continuation([fg(theme.dim)("runs in the current checkout")]))
   }
   rows.push(plain(""))
 

--- a/src/run-plan.ts
+++ b/src/run-plan.ts
@@ -5,8 +5,10 @@ import type { AgentStep, Pipeline, RunOptions, RunPlan, Step } from "./types"
 export type BuildRunPlanInput = RunOptions & {
   promptSource?: RunPlan["prompt"]["source"]
   worktree?: boolean
-  /** Configured branch-naming model; resolved into the plan so the post-confirmation naming call uses the reviewed target. */
-  branchNameModel?: string
+  /** Worktree runs: the branch name confirmed in the launcher, frozen into the plan the user reviews. */
+  branch?: string
+  /** Worktree runs: the directory that branch will be checked out in. */
+  worktreeDir?: string
   /** The run's frozen gateway when resuming; recorded in the plan when an explicit --gateway replaces it. */
   resumeGateway?: ModelGateway
 }
@@ -20,7 +22,6 @@ export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
   const judge = input.smart
     ? resolveModel(input.smartJudgeModel, gateway, overrides)
     : undefined
-  const branchNamer = input.branchNameModel ? resolveModel(input.branchNameModel, gateway, overrides) : undefined
   const hooks = hooksForPlan(input, pipeline.name)
   return deepFreeze({
     prompt: { source: input.promptSource ?? (input.resumeRunID ? "resume" : "inline"), text: input.prompt },
@@ -29,11 +30,12 @@ export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
       baseRef: input.baseRef,
       worktree: input.worktree ?? false,
       dirty: input.includeDirty,
+      ...(input.branch ? { branch: input.branch } : {}),
+      ...(input.worktreeDir ? { worktreeDir: input.worktreeDir } : {}),
     },
     pipeline,
     modelRouting: { gateway },
     ...(judge ? { smartJudge: { model: judge } } : {}),
-    ...(branchNamer ? { branchNamer: { model: branchNamer } } : {}),
     hooks,
     attachments: [...input.files],
     permissions: input.yolo ? "yolo" : input.smart ? "smart" : "interactive",

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -23,7 +23,7 @@ export function renderRunPlan(plan: RunPlan, compact = false, options: RunPlanRe
     `Prompt: ${plan.prompt.source} · ${prompt.length} characters · ${prompt.split("\n").length} lines`,
     `Target: ${sanitizeInline(plan.target.directory)}`,
     `  Diff base: ${sanitizeInline(plan.target.baseRef)} · working tree: ${plan.target.dirty ? "include dirty" : "clean required"}`,
-    `  Worktree: ${plan.target.worktree ? "yes (created after confirmation)" : "no"}`,
+    `  Worktree: ${plan.target.worktree ? `yes · branch ${sanitizeInline(plan.target.branch ?? "?")}` : "no"}`,
     `Pipeline: ${sanitizeInline(plan.pipeline.name)} · ${plan.pipeline.steps.length} steps`,
     `Gateway: ${gatewayLabel(plan.modelRouting.gateway)}`,
   ]
@@ -41,7 +41,7 @@ export function renderRunPlan(plan: RunPlan, compact = false, options: RunPlanRe
     )
   }
   if (!compact) {
-    if (plan.branchNamer) lines.push(`Branch naming: ${sanitizeInline(plan.branchNamer.model.target)} (generated after confirmation)`)
+    if (plan.target.worktreeDir) lines.push(`Worktree directory: ${sanitizeInline(plan.target.worktreeDir)}`)
     plan.pipeline.steps.forEach((step, index) => {
       if (step.type === "human") lines.push(`  ${index + 1}. ${sanitizeInline(step.name)} · human gate`)
       else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,12 +141,19 @@ export type Pipeline = {
 
 export type RunPlan = {
   prompt: { source: "inline" | "file" | "resume"; text: string }
-  target: { directory: string; baseRef: string; worktree: boolean; dirty: boolean }
+  target: {
+    directory: string
+    baseRef: string
+    worktree: boolean
+    dirty: boolean
+    /** Worktree runs only: the branch name the user confirmed in the launcher's branch step. */
+    branch?: string
+    /** Worktree runs only: where that branch will be checked out. */
+    worktreeDir?: string
+  }
   pipeline: Pipeline
   modelRouting: { gateway: ModelGateway }
   smartJudge?: { model: ResolvedModel }
-  /** Resolved branch-naming model for worktree runs: the AI naming call happens after confirmation with exactly this target. */
-  branchNamer?: { model: ResolvedModel }
   hooks: HookSet
   attachments: string[]
   permissions: "interactive" | "smart" | "yolo"

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,9 +1,9 @@
-import { mkdir } from "node:fs/promises"
+import { mkdir, stat } from "node:fs/promises"
 import { join } from "node:path"
 
-import type { Config, OpencodeClient } from "@opencode-ai/sdk/v2"
+import type { AgentConfig, Config, OpencodeClient } from "@opencode-ai/sdk/v2"
 
-import { addWorktree } from "./git"
+import { addWorktree, branchExists } from "./git"
 import { log } from "./log"
 import { startOpencode } from "./opencode"
 import { splitModelVariant } from "./pipeline"
@@ -19,29 +19,76 @@ export type WorktreeResult = {
 
 export type WorktreeInput = {
   targetDir: string
-  prompt: string
+  /** The confirmed branch name; naming happens before the run is confirmed, never here. */
+  branch: string
   /** Commit/ref to base the new branch on; defaults to HEAD. */
   baseRef?: string
+}
+
+export type BranchNameInput = {
+  prompt: string
+  targetDir: string
   /** Override the model used to name the branch (provider/model[#variant]). */
   model?: string
+  /** Free-text steer from the user, e.g. "call it after the budget limits". Outranks the prompt. */
+  guidance?: string
   signal?: AbortSignal
+}
+
+/** Where a proposed name came from, so the launcher can say who suggested it. */
+export type BranchNameSource = "model" | "prompt" | "fallback"
+
+export type BranchNameProposal = {
+  branch: string
+  source: BranchNameSource
+  /** Set when the model call failed; shown in the launcher so the user knows why it's a guess. */
+  error?: string
 }
 
 /** Cheap, fast model used to synthesize a branch name from the prompt. */
 export const defaultBranchNameModel = "anthropic/claude-haiku-4-5"
 
+/** Registered so the namer replaces opencode's default coding agent instead of merely appending to it. */
+const namerAgentName = "convoy-branch-namer"
+
 // Generous enough for the namer to look up a referenced issue before answering;
 // the deterministic fallback still guards the whole thing.
 const branchNameTimeoutMs = 60_000
-const maxBranchNameLength = 40
+const maxBranchNameLength = 48
+
+/** Conventional-commit types; the branch prefix is always one of these. */
+const branchTypes = ["feat", "fix", "refactor", "perf", "docs", "test", "chore", "build", "ci"] as const
+type BranchType = (typeof branchTypes)[number]
+const defaultBranchType: BranchType = "feat"
 
 /**
- * Read-only permission set for the naming session, mirroring the read-only
- * agent shape in agents.ts. MCP tools from the user's opencode setup are left
- * untouched so issue trackers (Linear, GitHub) stay reachable.
+ * The namer is a registered read-only agent, not a bare `system` string on the
+ * default agent: an extra system message leaves opencode's conversational
+ * coding persona in charge, which is how a reply ending in "¿Cuál es tu
+ * siguiente paso?" once became a branch name. MCP tools from the user's
+ * opencode setup are left untouched so issue trackers (Linear, GitHub) stay
+ * reachable.
  */
 function namerOpencodeConfig(): Config {
-  return {
+  const agent: AgentConfig = {
+    description: "Names git branches for convoy worktrees",
+    mode: "primary",
+    temperature: 0,
+    prompt: branchNameSystemPrompt,
+    tools: {
+      read: true,
+      list: true,
+      glob: true,
+      grep: true,
+      webfetch: true,
+      write: false,
+      edit: false,
+      bash: false,
+      task: false,
+      todoread: false,
+      todowrite: false,
+      websearch: false,
+    },
     permission: {
       read: "allow",
       list: "allow",
@@ -55,124 +102,325 @@ function namerOpencodeConfig(): Config {
       websearch: "deny",
     },
   }
+  return {
+    agent: { [namerAgentName]: agent },
+    permission: { question: "deny" },
+  }
 }
 
 /**
  * Creates a new git branch checked out in a dedicated worktree under
  * `~/.convoy/worktrees/<slug>`, so Convoy runs against an isolated checkout
- * instead of the user's current working tree. The branch name is synthesized
- * from the prompt by a cheap model (Haiku by default), falling back to a
- * timestamped slug when the model is unavailable.
+ * instead of the user's current working tree. The branch name is decided (and
+ * confirmed by the user) before this is called.
  */
 export async function createIsolatedWorktree(input: WorktreeInput): Promise<WorktreeResult> {
   const base = input.baseRef ?? "HEAD"
-  const branch = await generateBranchName(input.prompt, input.targetDir, input.model, input.signal)
-  const slug = slugifyBranch(branch)
-  const dir = join(convoyHome(), "worktrees", slug)
+  // Re-check right before creating: the name was validated in the launcher, and
+  // anything could have claimed it since (a parallel convoy, a manual branch).
+  const branch = await ensureFreeBranchName(input.branch, input.targetDir)
+  const dir = worktreeDirFor(branch)
   await mkdir(join(convoyHome(), "worktrees"), { recursive: true })
   await addWorktree(dir, branch, base, input.targetDir)
   log.info(`created worktree at ${dir} on branch ${branch}`)
   return { dir, branch }
 }
 
+/** Where the worktree for `branch` lives; the directory slug flattens the `type/` prefix. */
+export function worktreeDirFor(branch: string): string {
+  return join(convoyHome(), "worktrees", slugifyBranch(branch))
+}
+
 /**
  * Asks a cheap, read-only model for a short kebab-case branch name derived
  * from the prompt — it may look up referenced issues/tickets first. Any
- * failure (no auth, timeout, unparseable reply) falls back to a deterministic
- * slug so the worktree is always created.
+ * failure (no auth, timeout, unparseable reply) degrades to a name derived
+ * from the prompt itself, so the proposal always says something about the work.
  */
-export async function generateBranchName(
-  prompt: string,
-  targetDir: string,
-  model = defaultBranchNameModel,
-  signal?: AbortSignal,
-): Promise<string> {
-  const trimmed = prompt.trim()
-  if (!trimmed) return fallbackBranchName()
+export async function proposeBranchName(input: BranchNameInput): Promise<BranchNameProposal> {
+  const trimmed = input.prompt.trim()
+  if (!trimmed && !input.guidance?.trim()) return { branch: fallbackBranchName(), source: "fallback" }
+
+  let error: string | undefined
   try {
     const handle = await startOpencode(namerOpencodeConfig(), AbortSignal.timeout(branchNameTimeoutMs))
     try {
-      const name = await askForBranchName(handle.client, trimmed, targetDir, model, signal)
-      const cleaned = cleanBranchName(name)
-      return cleaned || fallbackBranchName()
+      const reply = await askForBranchName(handle.client, {
+        ...input,
+        prompt: trimmed,
+        model: input.model ?? defaultBranchNameModel,
+      })
+      const branch = readBranchName(reply)
+      if (branch) return { branch, source: "model" }
+      // Quote the reply like the safety judge does: an unusable answer is the
+      // one failure mode that can't be diagnosed from the message alone.
+      error = `the namer's reply had no usable branch name: ${truncate(reply, 160)}`
     } finally {
       handle.close()
     }
-  } catch (error) {
-    log.warn(`worktree: couldn't generate an AI branch name (${error instanceof Error ? error.message : String(error)}); using fallback`)
-    return fallbackBranchName()
+  } catch (cause) {
+    error = cause instanceof Error ? cause.message : String(cause)
   }
+
+  log.warn(`worktree: couldn't generate an AI branch name (${error}); deriving one from the prompt`)
+  const heuristic = heuristicBranchName(input.guidance?.trim() || trimmed)
+  if (heuristic) return { branch: heuristic, source: "prompt", error }
+  return { branch: fallbackBranchName(), source: "fallback", error }
 }
 
-export async function askForBranchName(
-  client: OpencodeClient,
-  prompt: string,
-  targetDir: string,
-  model: string,
-  signal?: AbortSignal,
-): Promise<string> {
-  const parsedModel = splitModelVariant(model)
-  const session = await client.session.create(
-    { directory: targetDir, title: "convoy branch namer" },
-    { signal: signal ?? undefined },
-  )
-  if (session.error || !session.data?.id) throw new Error("couldn't open a naming session")
-  const sessionID = session.data.id
+export async function askForBranchName(client: OpencodeClient, input: BranchNameInput & { model: string }): Promise<string> {
+  const parsedModel = splitModelVariant(input.model)
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(new Error("branch namer timed out")), branchNameTimeoutMs)
+  const onParentAbort = () => controller.abort(input.signal?.reason)
+  if (input.signal) {
+    if (input.signal.aborted) controller.abort(input.signal.reason)
+    else input.signal.addEventListener("abort", onParentAbort, { once: true })
+  }
+
+  let sessionID: string | undefined
   try {
+    const session = await client.session.create(
+      { directory: input.targetDir, title: "convoy branch namer" },
+      { signal: controller.signal },
+    )
+    if (session.error || !session.data?.id) throw new Error("couldn't open a naming session")
+    sessionID = session.data.id
+
     const response = await client.session.prompt(
       {
         sessionID,
-        directory: targetDir,
+        directory: input.targetDir,
         model: parseModel(parsedModel.model),
         ...(parsedModel.variant ? { variant: parsedModel.variant } : {}),
+        agent: namerAgentName,
+        // Sent as well as the agent prompt: if the agent name ever fails to
+        // resolve, the reply must still follow the contract rather than be a
+        // free-form answer from opencode's default persona.
         system: branchNameSystemPrompt,
         tools: { read: true, list: true, glob: true, grep: true, webfetch: true, write: false, edit: false, bash: false, todoread: false, todowrite: false },
-        parts: [{ type: "text", text: `Prompt:\n${truncate(prompt, 1200)}` }],
+        parts: [{ type: "text", text: namerMessage(input.prompt, input.guidance) }],
       },
-      { signal: signal ?? undefined },
+      { signal: controller.signal },
     )
     if (response.error || !response.data) throw new Error("branch namer returned no answer")
     return collectText(response.data.parts)
   } finally {
-    try {
-      await client.session.delete({ sessionID, directory: targetDir })
-    } catch {
-      // best-effort
+    clearTimeout(timeout)
+    input.signal?.removeEventListener("abort", onParentAbort)
+    if (sessionID) {
+      try {
+        await client.session.delete({ sessionID, directory: input.targetDir })
+      } catch {
+        // best-effort
+      }
     }
   }
 }
 
+/** The user's own steer outranks the prompt — it's the whole point of the guidance box. */
+export function namerMessage(prompt: string, guidance?: string): string {
+  const parts: string[] = []
+  const steer = guidance?.trim()
+  if (steer) parts.push(`How the user wants it named (this outranks everything below):\n${steer}`)
+  if (prompt.trim()) parts.push(`Prompt:\n${excerpt(prompt.trim())}`)
+  return parts.join("\n\n")
+}
+
 const branchNameSystemPrompt = [
-  "You name git branches. Read the user's prompt and reply with ONE short, lowercase, kebab-case",
-  "branch name that captures what the work does. 2-5 words. No leading 'feature/', no quotes,",
-  "no punctuation except hyphens, no explanation, no markdown. Examples:",
-  "add-onboarding-flow, fix-login-redirect, refactor-config-tui, dark-mode-toggle.",
-  "If the prompt references an issue, ticket, or PR (#123, ABC-123, a URL) instead of describing",
-  "the work, first look it up with the tools available to you (issue-tracker tools, webfetch,",
-  "repo files) and name the branch after what the issue is actually about. If the reference",
-  "can't be resolved, use the issue ID itself as the name (e.g. dev-1339) — never transcribe",
-  "the sentence around it. The last line of your reply must be the branch name alone.",
+  "You name git branches. Read the user's prompt and reply with ONE branch name for the work it",
+  "describes. Reply with nothing but a single line of JSON:",
+  '{"type": "feat", "name": "add-onboarding-flow"}',
+  "",
+  `"type" is one of: ${branchTypes.join(", ")}.`,
+  '"name" is lowercase kebab-case, 2-5 words, ASCII letters/digits/hyphens only, no slashes.',
+  "",
+  "Rules:",
+  "- When the message opens with a \"How the user wants it named\" block, that instruction wins over",
+  "  everything else, including the prompt. Build the name around what it asks for.",
+  "- Always name it in ENGLISH, even when the prompt is written in another language.",
+  "- Name what the work DOES. Never transcribe a sentence, heading, or question from the prompt.",
+  "- Never ask the user anything. There is no follow-up turn; a question is a failed answer.",
+  "- Never refuse and never explain what you couldn't find. If something the user mentions can't be",
+  "  verified from the repo or the tools, name the branch from what they told you anyway — the user",
+  "  knows what they meant, and a name you can improve beats no name at all.",
+  "- If the prompt references an issue, ticket, or PR (#123, ABC-123, a URL) instead of describing",
+  "  the work, look it up first with the tools available to you (issue-tracker tools, webfetch,",
+  "  repo files) and name the branch after what the issue is actually about. If the reference",
+  "  can't be resolved, use the issue ID itself as the name (e.g. dev-1339).",
+  "- You may investigate before answering, but the LAST line of your reply must be the JSON object",
+  "  and nothing else.",
 ].join("\n")
 
 /**
- * Keeps the model's reply within git's branch-name rules: lowercase,
- * kebab-case, <=40 chars. Reads the last non-empty line — a namer that
- * investigated an issue first may narrate before answering.
+ * Pulls the branch name out of the namer's reply. The JSON object is the
+ * contract; the loose fallbacks below exist because a model that investigated
+ * first sometimes narrates, and a narration line is only accepted when it
+ * actually looks like a branch name rather than prose.
  */
-export function cleanBranchName(raw: string): string {
+export function readBranchName(raw: string): string {
   const lines = raw
     .split("\n")
     .map((line) => line.trim())
     .filter(Boolean)
-  const line = lines[lines.length - 1] ?? ""
-  const kebab = line
+
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const parsed = parseNameObject(lines[index]!)
+    if (parsed) return parsed
+  }
+  // A fenced or pretty-printed object spans several lines; try the whole reply.
+  const whole = parseNameObject(raw)
+  if (whole) return whole
+
+  for (let index = lines.length - 1; index >= 0; index--) {
+    const line = lines[index]!.replace(/^[`'"]+|[`'"]+$/g, "")
+    if (/^[a-z0-9][a-z0-9/_-]*$/i.test(line)) {
+      const cleaned = cleanBranchName(line)
+      if (cleaned) return cleaned
+    }
+  }
+  return cleanBranchName(lines[lines.length - 1] ?? "")
+}
+
+function parseNameObject(text: string): string {
+  const start = text.indexOf("{")
+  const end = text.lastIndexOf("}")
+  if (start === -1 || end <= start) return ""
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(text.slice(start, end + 1))
+  } catch {
+    return ""
+  }
+  if (!parsed || typeof parsed !== "object") return ""
+  const name = (parsed as { name?: unknown }).name
+  if (typeof name !== "string") return ""
+  const type = (parsed as { type?: unknown }).type
+  const prefix = typeof type === "string" && isBranchType(normalizeBranchType(type)) ? normalizeBranchType(type) : defaultBranchType
+  // A namer that ignored "no slashes" and answered "feat/add-x" must not end up
+  // as "feat/feat-add-x": the `type` field wins over an embedded prefix.
+  const bare = splitBranchType(name.trim()).rest
+  return cleanBranchName(`${prefix}/${bare}`)
+}
+
+/**
+ * Coerces a candidate into a git-safe branch name, or returns "" when there is
+ * nothing usable in it.
+ *
+ * `authored` marks a name a human typed: it keeps whatever prefix (or none)
+ * they chose and is never second-guessed. Model output gets the opposite
+ * treatment — a conventional `type/` prefix is enforced, and anything that
+ * reads like prose is rejected so a conversational reply falls through to the
+ * next fallback instead of turning a sentence into a branch.
+ */
+export function cleanBranchName(raw: string, options: { authored?: boolean } = {}): string {
+  const candidate = raw.trim().replace(/^[`'"]+|[`'"]+$/g, "")
+  if (!candidate) return ""
+  if (!options.authored && looksLikeProse(candidate)) return ""
+
+  const { type, rest } = splitBranchType(candidate)
+  const body = kebab(rest)
+  if (!body) return ""
+
+  const prefix = type ?? (options.authored ? undefined : defaultBranchType)
+  const name = prefix ? `${prefix}/${body}` : body
+  const capped = capBranchName(name)
+  if (!capped) return ""
+  // A leading digit in the name confuses some tooling; the type prefix already
+  // covers the prefixed form, so only bare names need the guard.
+  return /^[0-9]/.test(capped) ? `task-${capped}` : capped
+}
+
+/** Splits an optional leading conventional-commit type off the candidate. */
+function splitBranchType(candidate: string): { type?: BranchType; rest: string } {
+  const match = /^([a-z]+)\s*[/:]\s*(.+)$/is.exec(candidate)
+  if (!match) return { rest: candidate }
+  const type = normalizeBranchType(match[1]!)
+  if (!isBranchType(type)) return { rest: candidate }
+  return { type, rest: match[2]! }
+}
+
+/** Common spellings people (and models) actually write, mapped onto the canonical types. */
+const branchTypeAliases: Record<string, BranchType> = {
+  feature: "feat",
+  features: "feat",
+  bug: "fix",
+  bugfix: "fix",
+  hotfix: "fix",
+  ref: "refactor",
+  doc: "docs",
+  tests: "test",
+  chores: "chore",
+}
+
+function normalizeBranchType(value: string): string {
+  const lowered = value.trim().toLowerCase()
+  return branchTypeAliases[lowered] ?? lowered
+}
+
+function isBranchType(value: string): value is BranchType {
+  return (branchTypes as readonly string[]).includes(value)
+}
+
+/**
+ * Prose is anything that reads like a sentence rather than a name: questions
+ * are the giveaway (the namer must never ask), and so is a long word count.
+ */
+function looksLikeProse(candidate: string): boolean {
+  if (/[?¿]/.test(candidate)) return true
+  return candidate.split(/\s+/).filter(Boolean).length > 8
+}
+
+/** Accents survive as letters instead of collapsing into hyphens: "español" → "espanol". */
+function kebab(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
-    .slice(0, maxBranchNameLength)
-  if (!kebab) return ""
-  // Avoid a leading digit which can confuse some git/tooling; prefix "task-".
-  return /^[0-9]/.test(kebab) ? `task-${kebab}` : kebab
+}
+
+/** Caps the length on a hyphen boundary so names never end mid-word. */
+function capBranchName(name: string): string {
+  if (name.length <= maxBranchNameLength) return name
+  const slash = name.indexOf("/")
+  const prefix = slash === -1 ? "" : name.slice(0, slash + 1)
+  const body = slash === -1 ? name : name.slice(slash + 1)
+  const room = maxBranchNameLength - prefix.length
+  if (room <= 0) return prefix.slice(0, maxBranchNameLength).replace(/[-/]+$/, "")
+  const clipped = body.slice(0, room)
+  const lastHyphen = clipped.lastIndexOf("-")
+  // Keep the partial word only when there is no earlier boundary to cut on.
+  const trimmed = lastHyphen > 0 ? clipped.slice(0, lastHyphen) : clipped
+  return `${prefix}${trimmed}`.replace(/[-/]+$/, "")
+}
+
+const stopWords = new Set([
+  "the", "a", "an", "of", "to", "and", "or", "for", "in", "on", "with", "we", "i", "it", "is", "are", "be",
+  "that", "this", "should", "would", "must", "new", "add", "make",
+  "el", "la", "los", "las", "un", "una", "unos", "unas", "de", "del", "que", "y", "o", "para", "por", "con",
+  "en", "al", "se", "su", "sus", "lo", "es", "son", "ser", "como", "mas", "pero", "nos", "me", "te",
+])
+
+/**
+ * Last resort before a timestamp: names the branch after the prompt's own
+ * opening — its first heading or first line — so a failed model call still
+ * produces something recognizable instead of `convoy-20260726-a4f2`.
+ */
+export function heuristicBranchName(prompt: string): string {
+  const lines = prompt
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+  const heading = lines.find((line) => line.startsWith("#"))
+  const source = (heading ?? lines[0] ?? "").replace(/^#+\s*/, "")
+  const words = kebab(source)
+    .split("-")
+    .filter((word) => word && !stopWords.has(word))
+    .slice(0, 4)
+  if (words.length === 0) return ""
+  return cleanBranchName(words.join("-"))
 }
 
 /** Deterministic fallback so worktree creation never depends on a model being available. */
@@ -182,13 +430,35 @@ export function fallbackBranchName(): string {
   return `convoy-${stamp.getFullYear()}${pad(stamp.getMonth() + 1)}${pad(stamp.getDate())}-${randomSlug(4)}`
 }
 
-/** Filesystem-safe directory name for the worktree (mirrors the branch slug). */
+/**
+ * Appends `-2`, `-3`… until neither the branch nor its worktree directory is
+ * taken, so re-running a similar prompt doesn't fail `git worktree add` after
+ * the run has already been confirmed.
+ */
+export async function ensureFreeBranchName(branch: string, targetDir: string, limit = 50): Promise<string> {
+  for (let suffix = 1; suffix <= limit; suffix++) {
+    const candidate = suffix === 1 ? branch : `${branch}-${suffix}`
+    if (!(await branchNameTaken(candidate, targetDir))) return candidate
+  }
+  return `${branch}-${randomSlug(4)}`
+}
+
+/** True when the branch exists or its worktree directory is already on disk. */
+export async function branchNameTaken(branch: string, targetDir: string): Promise<boolean> {
+  if (await branchExists(branch, targetDir)) return true
+  // `git worktree add` refuses a path that already exists, so an orphaned
+  // directory from an earlier run counts as taken even without a branch.
+  try {
+    await stat(worktreeDirFor(branch))
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Filesystem-safe directory name for the worktree (flattens the `type/` prefix). */
 export function slugifyBranch(branch: string): string {
-  const slug = branch
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-  return slug || `convoy-${randomSlug(6)}`
+  return kebab(branch) || `convoy-${randomSlug(6)}`
 }
 
 function collectText(parts: ReadonlyArray<{ type: string; text?: string }>): string {
@@ -197,6 +467,18 @@ function collectText(parts: ReadonlyArray<{ type: string; text?: string }>): str
     .map((part) => part.text as string)
     .join("\n")
     .trim()
+}
+
+const excerptHead = 900
+const excerptTail = 500
+
+/**
+ * Long PRDs bury the actual ask in their closing recommendation, so the namer
+ * gets both ends of the document rather than only its opening context.
+ */
+export function excerpt(value: string): string {
+  if (value.length <= excerptHead + excerptTail) return value
+  return `${value.slice(0, excerptHead)}\n…\n${value.slice(-excerptTail)}`
 }
 
 function truncate(value: string, max: number): string {

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { addAllAndCommit, addWorktree, detectBaseRef, ensureRepoReady, findSuspiciousStagedFiles, initializeRepoWithInitialCommit, repoBootstrapStatus } from "../src/git"
+import { addAllAndCommit, addWorktree, branchExists, detectBaseRef, ensureRepoReady, findSuspiciousStagedFiles, initializeRepoWithInitialCommit, repoBootstrapStatus } from "../src/git"
 
 describe("findSuspiciousStagedFiles", () => {
   test("flags common secret filenames", () => {
@@ -368,6 +368,21 @@ describe("addWorktree", () => {
     })
     if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")}: ${await new Response(proc.stderr).text()}`)
   }
+
+  test("branchExists tells a taken branch name from a free one", async () => {
+    const repo = await mkdtemp(join(tmpdir(), "convoy-branch-exists-"))
+    dirs.push(repo)
+
+    await git(["init", "-q"], repo)
+    await writeFile(join(repo, "README.md"), "base\n")
+    await git(["add", "README.md"], repo)
+    await git(["commit", "-q", "-m", "init"], repo)
+    await git(["branch", "feat/add-onboarding"], repo)
+
+    expect(await branchExists("feat/add-onboarding", repo)).toBe(true)
+    expect(await branchExists("feat/add-onboarding-2", repo)).toBe(false)
+    expect(await branchExists("", repo)).toBe(false)
+  })
 
   test("creates a branch checked out in a separate worktree", async () => {
     const repo = await mkdtemp(join(tmpdir(), "convoy-worktree-repo-"))

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { cursorPosition, hookLines, launcherStepModelLabel, promptEnterAction, reviewActionForKey, sanitizePaste, stepTree, typedText, wrapPromptLines } from "../src/launch-tui"
+import { branchActionForKey, branchProposalNote, cursorPosition, hookLines, launcherStepModelLabel, promptEnterAction, reviewActionForKey, sanitizePaste, stepTree, typedText, wrapPromptLines } from "../src/launch-tui"
 
 import type { KeyEvent } from "@opentui/core"
 
@@ -62,6 +62,39 @@ describe("launch TUI review", () => {
     expect(reviewActionForKey(key({ name: "pagedown" }))).toBe("page-forward")
     expect(reviewActionForKey(key({ name: "home" }))).toBe("top")
     expect(reviewActionForKey(key({ name: "end" }))).toBe("bottom")
+  })
+})
+
+describe("launch TUI branch step", () => {
+  test("maps branch controls to editing, regeneration, and navigation", () => {
+    expect(branchActionForKey(key({ name: "return" }))).toBe("submit")
+    expect(branchActionForKey(key({ name: "tab" }))).toBe("next-field")
+    expect(branchActionForKey(key({ name: "tab", shift: true }))).toBe("previous-field")
+    expect(branchActionForKey(key({ name: "backtab" }))).toBe("previous-field")
+    expect(branchActionForKey(key({ name: "r", ctrl: true }))).toBe("regenerate")
+    expect(branchActionForKey(key({ name: "u", ctrl: true }))).toBe("clear")
+    expect(branchActionForKey(key({ name: "backspace" }))).toBe("delete-back")
+    expect(branchActionForKey(key({ name: "left" }))).toBe("cursor-left")
+    expect(branchActionForKey(key({ name: "escape" }))).toBe("back")
+  })
+
+  test("leaves printable keys unbound so both fields stay typable", () => {
+    // "s", "q", "p" and "r" are review/options shortcuts; here they are just letters.
+    for (const name of ["s", "q", "p", "r", "j", "k", "space"]) {
+      expect(branchActionForKey(key({ name }))).toBeUndefined()
+    }
+  })
+
+  test("attributes the proposal and says when the name had to move", () => {
+    expect(branchProposalNote({ branch: "feat/x", source: "model", model: "anthropic/claude-haiku-4-5" }, { branch: "feat/x", dir: "/w/feat-x" })).toBe(
+      "proposed by anthropic/claude-haiku-4-5",
+    )
+    expect(branchProposalNote({ branch: "feat/x", source: "prompt" }, { branch: "feat/x-2", dir: "/w/feat-x-2", suffixed: true })).toBe(
+      "derived from your prompt (the naming model didn't answer) · renamed, the original was taken",
+    )
+    expect(branchProposalNote({ branch: "convoy-20260726-a4f2", source: "fallback" }, { branch: "convoy-20260726-a4f2", dir: "/w/c" })).toBe(
+      "generic name (nothing to derive it from)",
+    )
   })
 })
 

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -103,21 +103,13 @@ describe("OpenCode run-plan preflight", () => {
         target: "vercel/anthropic/claude-haiku-4.5",
       },
     }
-    reviewed.branchNamer = {
-      model: {
-        configured: "anthropic/claude-haiku-4-5",
-        logical: "anthropic/claude-haiku-4-5",
-        gateway: "vercel",
-        providerID: "vercel",
-        modelID: "anthropic/claude-haiku-4-5",
-        target: "vercel/anthropic/claude-haiku-4-5",
-      },
-    }
+    // A worktree run has nothing extra to preflight: the branch was named in
+    // the launcher, so no naming call is left once the plan is confirmed.
+    reviewed.target = { ...reviewed.target, worktree: true, branch: "feat/add-onboarding" }
 
     expect(preflightTargets(reviewed).map((target) => target.target)).toEqual([
       "vercel/openai/gpt-5.6-sol",
       "vercel/anthropic/claude-haiku-4.5",
-      "vercel/anthropic/claude-haiku-4-5",
     ])
   })
 

--- a/test/review-tui.test.ts
+++ b/test/review-tui.test.ts
@@ -82,12 +82,11 @@ describe("run review TUI", () => {
     expect(lines.some((line) => line.includes("claude-code/opus"))).toBe(true)
   })
 
-  test("renders hooks, runtime judge, worktree intent, branch namer, and resume overrides", () => {
+  test("renders hooks, runtime judge, the confirmed branch, and resume overrides", () => {
     const plan = planWith([], {
-      target: { directory: "/repo", baseRef: "develop", worktree: true, dirty: false },
+      target: { directory: "/repo", baseRef: "develop", worktree: true, dirty: false, branch: "feat/runtime-guard-limits", worktreeDir: "/home/dev/.convoy/worktrees/feat-runtime-guard-limits" },
       modelRouting: { gateway: "openrouter" },
       smartJudge: { model: resolved("openai/gpt-5.6-terra#xhigh", "openrouter/openai/gpt-5.6-terra#xhigh", "openrouter") },
-      branchNamer: { model: resolved("anthropic/claude-haiku-4-5", "openrouter/anthropic/claude-haiku-4-5", "openrouter") },
       hooks: { pre: [{ command: "pnpm lint" }], post: [{ command: "./notify.sh", when: "always" }] },
       attachments: ["a.md", "b.md"],
       permissions: "smart",
@@ -98,8 +97,8 @@ describe("run review TUI", () => {
 
     expect(lines.some((line) => line.includes("gateway  OpenRouter"))).toBe(true)
     expect(lines.some((line) => line.includes("resume override · original Vercel AI Gateway · pending phases OpenRouter"))).toBe(true)
-    expect(lines.some((line) => line.includes("worktree and branch created after confirmation"))).toBe(true)
-    expect(lines.some((line) => line.includes("branch named by openrouter/anthropic/claude-haiku-4-5 after confirmation"))).toBe(true)
+    expect(lines.some((line) => line.includes("branch feat/runtime-guard-limits"))).toBe(true)
+    expect(lines.some((line) => line.includes("worktree /home/dev/.convoy/worktrees/feat-runtime-guard-limits"))).toBe(true)
     expect(lines.some((line) => line.includes("hooks    pre   · pnpm lint"))).toBe(true)
     expect(lines.some((line) => line.includes("post  · ./notify.sh · always"))).toBe(true)
     expect(lines.some((line) => line.includes("runtime  smart permissions · 2 attachments · judge openrouter/openai/gpt-5.6-terra#xhigh"))).toBe(true)

--- a/test/run-plan.test.ts
+++ b/test/run-plan.test.ts
@@ -174,13 +174,22 @@ test("the plan freezes the routed branch namer and marks an explicit resume gate
     hooks: { pre: [], post: [], pipelines: {} },
   }
 
-  const overridden = buildRunPlan({ ...options, promptSource: "resume", resumeGateway: "vercel", branchNameModel: "anthropic/claude-haiku-4-5" })
+  const overridden = buildRunPlan({
+    ...options,
+    promptSource: "resume",
+    resumeGateway: "vercel",
+    worktree: true,
+    branch: "feat/runtime-guard-limits",
+    worktreeDir: "/home/dev/.convoy/worktrees/feat-runtime-guard-limits",
+  })
   expect(overridden.resume).toEqual({ runID: "20260720-135802-5bbh", gatewayOverride: { original: "vercel", pending: "openrouter" } })
-  expect(overridden.branchNamer?.model).toMatchObject({ logical: "anthropic/claude-haiku-4-5", target: "openrouter/anthropic/claude-haiku-4-5" })
-  expect(Object.isFrozen(overridden.branchNamer)).toBe(true)
+  // The branch the user confirmed in the launcher is frozen into the plan.
+  expect(overridden.target.branch).toBe("feat/runtime-guard-limits")
+  expect(overridden.target.worktreeDir).toBe("/home/dev/.convoy/worktrees/feat-runtime-guard-limits")
+  expect(Object.isFrozen(overridden.target)).toBe(true)
 
   // Resuming with the frozen gateway (or no explicit override) leaves no banner.
   const unchanged = buildRunPlan({ ...options, gateway: "vercel", promptSource: "resume", resumeGateway: "vercel" })
   expect(unchanged.resume).toEqual({ runID: "20260720-135802-5bbh" })
-  expect(unchanged).not.toHaveProperty("branchNamer")
+  expect(unchanged.target).not.toHaveProperty("branch")
 })

--- a/test/run-review.test.ts
+++ b/test/run-review.test.ts
@@ -49,7 +49,7 @@ test("run review renders untrusted plan fields without terminal or layout inject
 test("review renders the exact target, worktree intent, and routed smart judge", () => {
   const plan: RunPlan = {
     prompt: { source: "file", text: "Audit the checkout flow" },
-    target: { directory: "/repo", baseRef: "main", worktree: true, dirty: false },
+    target: { directory: "/repo", baseRef: "main", worktree: true, dirty: false, branch: "feat/audit-checkout-flow" },
     pipeline: {
       name: "audit",
       steps: [
@@ -96,7 +96,7 @@ test("review renders the exact target, worktree intent, and routed smart judge",
   const detailed = renderRunPlan(plan)
   const compact = renderRunPlan(plan, true)
 
-  expect(detailed).toContain("Worktree: yes (created after confirmation)")
+  expect(detailed).toContain("Worktree: yes · branch feat/audit-checkout-flow")
   expect(detailed).toContain("Logical: openai/gpt-5.6-sol")
   expect(detailed).toContain("Target:  vercel/openai/gpt-5.6-sol")
   expect(detailed).toContain("Judge: vercel/anthropic/claude-haiku-4.5")
@@ -105,22 +105,19 @@ test("review renders the exact target, worktree intent, and routed smart judge",
   expect(compact).not.toContain("Target:  vercel/openai/gpt-5.6-sol")
 })
 
-test("review marks a resume gateway override in every format and shows the routed branch namer", () => {
+test("review marks a resume gateway override in every format and shows the confirmed branch", () => {
   const plan: RunPlan = {
     prompt: { source: "resume", text: "continue the work" },
-    target: { directory: "/repo", baseRef: "main", worktree: true, dirty: false },
+    target: {
+      directory: "/repo",
+      baseRef: "main",
+      worktree: true,
+      dirty: false,
+      branch: "feat/runtime-guard-limits",
+      worktreeDir: "/home/dev/.convoy/worktrees/feat-runtime-guard-limits",
+    },
     pipeline: { name: "implement", steps: [] },
     modelRouting: { gateway: "openrouter" },
-    branchNamer: {
-      model: {
-        configured: "anthropic/claude-haiku-4-5",
-        logical: "anthropic/claude-haiku-4-5",
-        gateway: "openrouter",
-        providerID: "openrouter",
-        modelID: "anthropic/claude-haiku-4-5",
-        target: "openrouter/anthropic/claude-haiku-4-5",
-      },
-    },
     hooks: { pre: [], post: [] },
     attachments: [],
     permissions: "interactive",
@@ -137,8 +134,10 @@ test("review marks a resume gateway override in every format and shows the route
   expect(compact).toContain("Resume gateway override:")
   expect(compact).toContain("pending phases: OpenRouter")
 
-  expect(detailed).toContain("Branch naming: openrouter/anthropic/claude-haiku-4-5 (generated after confirmation)")
-  expect(compact).not.toContain("Branch naming:")
+  expect(detailed).toContain("Worktree: yes · branch feat/runtime-guard-limits")
+  expect(detailed).toContain("Worktree directory: /home/dev/.convoy/worktrees/feat-runtime-guard-limits")
+  expect(compact).toContain("Worktree: yes · branch feat/runtime-guard-limits")
+  expect(compact).not.toContain("Worktree directory:")
 })
 
 test("review can expand the complete sanitized prompt for the launcher", () => {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,8 +1,22 @@
-import { describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 
-import { askForBranchName, cleanBranchName, fallbackBranchName, slugifyBranch } from "../src/worktree"
+import {
+  askForBranchName,
+  branchNameTaken,
+  cleanBranchName,
+  ensureFreeBranchName,
+  excerpt,
+  fallbackBranchName,
+  heuristicBranchName,
+  namerMessage,
+  readBranchName,
+  slugifyBranch,
+} from "../src/worktree"
 
 type FakeNamerOptions = {
   promptText?: string
@@ -17,6 +31,8 @@ type NamerPromptInput = {
   directory: string
   model: { providerID: string; modelID: string }
   variant?: string
+  agent?: string
+  system?: string
   tools: Record<string, boolean>
   parts: Array<{ type: string; text: string }>
 }
@@ -41,87 +57,174 @@ function fakeNamerClient(opts: FakeNamerOptions): OpencodeClient {
   } as unknown as OpencodeClient
 }
 
-describe("worktree branch name helpers", () => {
-  test("cleanBranchName coerces model replies into git-safe kebab-case", () => {
-    expect(cleanBranchName("Add onboarding flow")).toBe("add-onboarding-flow")
-    expect(cleanBranchName("Fix bug #123 (login redirect)")).toBe("fix-bug-123-login-redirect")
-    expect(cleanBranchName("`refactor-config-tui`")).toBe("refactor-config-tui")
-    expect(cleanBranchName("  FEATURE: dark mode!!  ")).toBe("feature-dark-mode")
-    expect(cleanBranchName("implementar onboarding en español")).toBe("implementar-onboarding-en-espa-ol")
+describe("cleanBranchName", () => {
+  test("coerces candidates into git-safe type/kebab-case", () => {
+    expect(cleanBranchName("Add onboarding flow")).toBe("feat/add-onboarding-flow")
+    expect(cleanBranchName("fix/login redirect")).toBe("fix/login-redirect")
+    expect(cleanBranchName("`refactor/config-tui`")).toBe("refactor/config-tui")
+    expect(cleanBranchName("chore: bump deps")).toBe("chore/bump-deps")
   })
 
-  test("cleanBranchName reads the last non-empty line so investigation chatter is ignored", () => {
-    expect(cleanBranchName("Looking up DEV-1339…\nThe issue is about push reminders.\n\nadd-push-reminders\n")).toBe("add-push-reminders")
-    expect(cleanBranchName("add-onboarding-flow\n")).toBe("add-onboarding-flow")
+  test("maps the conventional-type spellings people actually write", () => {
+    expect(cleanBranchName("feature/dark mode")).toBe("feat/dark-mode")
+    expect(cleanBranchName("bugfix: login redirect")).toBe("fix/login-redirect")
+    expect(cleanBranchName("hotfix/crash on start")).toBe("fix/crash-on-start")
   })
 
-  test("cleanBranchName prefixes a leading digit so the name isn't ambiguous", () => {
-    expect(cleanBranchName("123 fix login")).toBe("task-123-fix-login")
-    expect(cleanBranchName("404-page")).toBe("task-404-page")
+  test("keeps accented letters as letters instead of collapsing them into hyphens", () => {
+    expect(cleanBranchName("implementar onboarding en español")).toBe("feat/implementar-onboarding-en-espanol")
+    expect(cleanBranchName("límites de ejecución")).toBe("feat/limites-de-ejecucion")
   })
 
-  test("cleanBranchName rejects empty / punctuation-only replies", () => {
+  test("rejects prose so a conversational reply can never become a branch", () => {
+    // The regression that produced ~/.convoy/worktrees/cu-l-es-tu-siguiente-paso.
+    expect(cleanBranchName("¿Cuál es tu siguiente paso?")).toBe("")
+    expect(cleanBranchName("What would you like me to do next?")).toBe("")
+    expect(cleanBranchName("I have read the PRD and I am ready to start working on it")).toBe("")
+  })
+
+  test("rejects empty and punctuation-only candidates", () => {
     expect(cleanBranchName("")).toBe("")
     expect(cleanBranchName("--- !!! ---")).toBe("")
-    expect(cleanBranchName("a")).toBe("a")
   })
 
-  test("cleanBranchName caps overly long names", () => {
-    const long = "fix-" + "a".repeat(60)
-    const cleaned = cleanBranchName(long)
-    expect(cleaned.length).toBeLessThanOrEqual(40)
-    expect(cleaned.startsWith("fix-")).toBe(true)
+  test("an authored name keeps the shape the user typed, prose check included", () => {
+    expect(cleanBranchName("my-own-branch", { authored: true })).toBe("my-own-branch")
+    expect(cleanBranchName("fix/login", { authored: true })).toBe("fix/login")
+    expect(cleanBranchName("404 page", { authored: true })).toBe("task-404-page")
+    // Long-winded, but the user typed it on purpose: never silently discarded.
+    expect(cleanBranchName("the branch about the budget limits and the runtime guard", { authored: true })).toBe("the-branch-about-the-budget-limits-and-the")
   })
 
+  test("caps long names on a hyphen boundary, keeping the prefix", () => {
+    const cleaned = cleanBranchName("feat/improve-first-routine-recommendation-payload-for-new-users")
+    expect(cleaned.length).toBeLessThanOrEqual(48)
+    expect(cleaned.startsWith("feat/improve-first-routine")).toBe(true)
+    // Never ends mid-word the way the old 40-char slice did ("…-pay").
+    expect(cleaned.endsWith("-")).toBe(false)
+    expect("feat/improve-first-routine-recommendation-payload-for-new-users".startsWith(cleaned)).toBe(true)
+  })
+})
+
+describe("readBranchName", () => {
+  test("reads the JSON contract from the last line", () => {
+    expect(readBranchName('{"type": "feat", "name": "add-onboarding-flow"}')).toBe("feat/add-onboarding-flow")
+    expect(readBranchName('Looking up DEV-1339…\nIt is about push reminders.\n\n{"type":"fix","name":"dev-1339-push-reminders"}')).toBe("fix/dev-1339-push-reminders")
+  })
+
+  test("reads a pretty-printed or fenced object too", () => {
+    expect(readBranchName('```json\n{\n  "type": "refactor",\n  "name": "config-tui"\n}\n```')).toBe("refactor/config-tui")
+  })
+
+  test("falls back to an unknown type rather than dropping the answer", () => {
+    expect(readBranchName('{"type": "banana", "name": "dark-mode-toggle"}')).toBe("feat/dark-mode-toggle")
+  })
+
+  test("does not double the prefix when the name already carries one", () => {
+    expect(readBranchName('{"type": "fix", "name": "fix/login-redirect"}')).toBe("fix/login-redirect")
+  })
+
+  test("salvages a bare slug when the model ignored the JSON contract", () => {
+    expect(readBranchName("I checked the repo.\nadd-push-reminders")).toBe("feat/add-push-reminders")
+  })
+
+  test("returns nothing when the reply is conversation, so naming falls through", () => {
+    expect(readBranchName("He leído el PRD sobre los límites.\n\n¿Cuál es tu siguiente paso?")).toBe("")
+    expect(readBranchName("")).toBe("")
+  })
+})
+
+describe("heuristicBranchName", () => {
+  test("names the branch after the prompt's opening heading", () => {
+    expect(heuristicBranchName("# Propuesta de implementación\n\nLa solución debería tener tres capas")).toBe("feat/propuesta-implementacion")
+  })
+
+  test("uses the first line when there is no heading, dropping stop words", () => {
+    expect(heuristicBranchName("Add a budget limit to the execution supervisor")).toBe("feat/budget-limit-execution-supervisor")
+  })
+
+  test("returns nothing when there is nothing to derive", () => {
+    expect(heuristicBranchName("")).toBe("")
+    expect(heuristicBranchName("!!! ???")).toBe("")
+  })
+})
+
+describe("fallbackBranchName / slugifyBranch", () => {
   test("fallbackBranchName is deterministic in shape and git-safe", () => {
     const name = fallbackBranchName()
     expect(name).toMatch(/^convoy-\d{8}-[a-z0-9]{4}$/)
-    expect(name.length).toBeLessThanOrEqual(40)
+    expect(name.length).toBeLessThanOrEqual(48)
   })
 
-  test("slugifyBranch mirrors cleanBranchName rules for the worktree directory", () => {
+  test("slugifyBranch flattens the type prefix into the directory name", () => {
+    expect(slugifyBranch("feat/add-onboarding-flow")).toBe("feat-add-onboarding-flow")
     expect(slugifyBranch("Add Onboarding Flow")).toBe("add-onboarding-flow")
-    expect(slugifyBranch("feature/foo bar")).toBe("feature-foo-bar")
-    // Always returns something, even for garbage input.
+    expect(slugifyBranch("límites")).toBe("limites")
     expect(slugifyBranch("!!!")).toMatch(/^convoy-[a-z0-9]{6}$/)
   })
 })
 
+describe("namer payload", () => {
+  test("excerpt keeps both ends of a long PRD so the closing ask survives", () => {
+    const prd = `${"a".repeat(2_000)}RECOMENDACION FINAL`
+    const sent = excerpt(prd)
+    expect(sent.length).toBeLessThan(prd.length)
+    expect(sent.startsWith("aaa")).toBe(true)
+    expect(sent.endsWith("RECOMENDACION FINAL")).toBe(true)
+    expect(sent).toContain("\n…\n")
+  })
+
+  test("excerpt leaves a short prompt untouched", () => {
+    expect(excerpt("build onboarding")).toBe("build onboarding")
+  })
+
+  test("namerMessage puts the user's guidance above the prompt", () => {
+    const message = namerMessage("build onboarding", "call it after the budget limits")
+    expect(message.indexOf("budget limits")).toBeLessThan(message.indexOf("build onboarding"))
+    expect(namerMessage("build onboarding")).toBe("Prompt:\nbuild onboarding")
+  })
+})
+
 describe("askForBranchName", () => {
-  test("asks a read-only session for a branch name and collects text parts", async () => {
+  test("asks a read-only namer agent and collects text parts", async () => {
     let createInput: unknown
     let promptInput: NamerPromptInput | undefined
     const client = fakeNamerClient({
-      promptText: "add-onboarding-flow",
+      promptText: '{"type":"feat","name":"add-onboarding-flow"}',
       onCreate: (input) => (createInput = input),
       onPrompt: (input) => (promptInput = input as NamerPromptInput),
     })
 
-    await expect(askForBranchName(client, "build onboarding", "/repo", "openai/gpt-5.5")).resolves.toBe("add-onboarding-flow")
+    const reply = await askForBranchName(client, { prompt: "build onboarding", targetDir: "/repo", model: "openai/gpt-5.5" })
+
+    expect(readBranchName(reply)).toBe("feat/add-onboarding-flow")
     expect(createInput).toEqual({ directory: "/repo", title: "convoy branch namer" })
     expect(promptInput?.sessionID).toBe("namer-session")
     expect(promptInput?.directory).toBe("/repo")
     expect(promptInput?.model).toEqual({ providerID: "openai", modelID: "gpt-5.5" })
+    // The registered agent is what replaces opencode's conversational default.
+    expect(promptInput?.agent).toBe("convoy-branch-namer")
+    expect(promptInput?.system).toContain("ENGLISH")
     expect(promptInput?.tools).toEqual({ read: true, list: true, glob: true, grep: true, webfetch: true, write: false, edit: false, bash: false, todoread: false, todowrite: false })
     expect(promptInput?.parts).toEqual([{ type: "text", text: "Prompt:\nbuild onboarding" }])
   })
 
-  test("truncates long prompts before sending them to the naming model", async () => {
+  test("sends both ends of a long prompt to the naming model", async () => {
     let promptInput: NamerPromptInput | undefined
     const client = fakeNamerClient({ promptText: "long-prompt-work", onPrompt: (input) => (promptInput = input as NamerPromptInput) })
 
-    await askForBranchName(client, "x".repeat(1_300), "/repo", "anthropic/claude-haiku-4-5")
+    await askForBranchName(client, { prompt: `${"x".repeat(2_000)}CLOSING ASK`, targetDir: "/repo", model: "anthropic/claude-haiku-4-5" })
 
     const sent = promptInput?.parts[0]?.text ?? ""
-    expect(sent.length).toBe("Prompt:\n".length + 1_200)
-    expect(sent.endsWith("…")).toBe(true)
+    expect(sent.endsWith("CLOSING ASK")).toBe(true)
+    expect(sent).toContain("\n…\n")
   })
 
   test("preserves a reviewed branch-namer model variant", async () => {
     let promptInput: NamerPromptInput | undefined
     const client = fakeNamerClient({ promptText: "add-onboarding", onPrompt: (input) => (promptInput = input as NamerPromptInput) })
 
-    await askForBranchName(client, "build onboarding", "/repo", "vercel/openai/gpt-5.6-sol#xhigh")
+    await askForBranchName(client, { prompt: "build onboarding", targetDir: "/repo", model: "vercel/openai/gpt-5.6-sol#xhigh" })
 
     expect(promptInput?.model).toEqual({ providerID: "vercel", modelID: "openai/gpt-5.6-sol" })
     expect(promptInput?.variant).toBe("xhigh")
@@ -131,7 +234,53 @@ describe("askForBranchName", () => {
     let deleted: unknown
     const client = fakeNamerClient({ promptThrows: true, onDelete: (input) => (deleted = input) })
 
-    await expect(askForBranchName(client, "fix login", "/repo", "openai/gpt-5.5")).rejects.toThrow("provider unavailable")
+    await expect(askForBranchName(client, { prompt: "fix login", targetDir: "/repo", model: "openai/gpt-5.5" })).rejects.toThrow("provider unavailable")
     expect(deleted).toEqual({ sessionID: "namer-session", directory: "/repo" })
+  })
+})
+
+describe("ensureFreeBranchName", () => {
+  const dirs: string[] = []
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  async function git(args: string[], cwd: string) {
+    const proc = Bun.spawn(["git", "-c", "commit.gpgsign=false", ...args], {
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "convoy-test",
+        GIT_AUTHOR_EMAIL: "convoy-test@example.invalid",
+        GIT_COMMITTER_NAME: "convoy-test",
+        GIT_COMMITTER_EMAIL: "convoy-test@example.invalid",
+      },
+    })
+    if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")}: ${await new Response(proc.stderr).text()}`)
+  }
+
+  async function repoWithBranches(branches: string[]): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-free-branch-"))
+    dirs.push(dir)
+    await git(["init", "-q"], dir)
+    await writeFile(join(dir, "README.md"), "base\n")
+    await git(["add", "README.md"], dir)
+    await git(["commit", "-q", "-m", "init"], dir)
+    for (const branch of branches) await git(["branch", branch], dir)
+    return dir
+  }
+
+  test("keeps a free name as it is", async () => {
+    const dir = await repoWithBranches([])
+    expect(await ensureFreeBranchName("feat/add-onboarding", dir)).toBe("feat/add-onboarding")
+    expect(await branchNameTaken("feat/add-onboarding", dir)).toBe(false)
+  })
+
+  test("suffixes until the branch name is free", async () => {
+    const dir = await repoWithBranches(["feat/add-onboarding", "feat/add-onboarding-2"])
+    expect(await branchNameTaken("feat/add-onboarding", dir)).toBe(true)
+    expect(await ensureFreeBranchName("feat/add-onboarding", dir)).toBe("feat/add-onboarding-3")
   })
 })


### PR DESCRIPTION
## The bug

The branch namer ran as OpenCode's **default agent**: `session.prompt` got an extra `system:` string but never an `agent:`, so it kept the conversational coding persona and narrated instead of answering. `cleanBranchName` then took the **last non-empty line** of that narration.

Evidence from a real run (`~/.convoy/runs/20260726-112024-9h3y`): a 13 KB Spanish PRD about runtime guards and execution budgets produced `~/.convoy/worktrees/cu-l-es-tu-siguiente-paso`. The phrase "siguiente paso" appears nowhere in the PRD — the model ended its reply with "¿Cuál es tu siguiente paso?" and that question became the branch.

Four more defects stacked on top:

- **Accents collapsed into hyphens** — `[^a-z0-9]+` turned `á`/`ñ` into `-` (`cu-l-es`, `espa-ol`), and a test enshrined it. Every Spanish PRD hit this.
- **Truncation cut mid-word** — `improve-first-routine-recommendation-pay`.
- **Only the first 1200 chars reached the model** — in these PRDs the actual ask lives in the closing "Recomendación final".
- **The name was generated after the confirmation gate**, so it was only ever seen once the worktree existed. Collisions failed `git worktree add` at that same point, after the run was already confirmed.

## The fix

**Namer** — registered `convoy-branch-namer` read-only agent (the pattern `runner.ts` already uses for every phase) answering a JSON contract, parsed like `safety-judge`. Prose is rejected: a candidate with `?`/`¿` or more than eight words falls through instead of becoming a branch. Diacritics survive as letters, the length cap cuts on a hyphen boundary, and the model sees head+tail of long PRDs. A failed call derives the name from the prompt rather than a timestamp.

**Branch step** — worktree runs now stop between Options and Review: editable name, worktree path, attribution, and a hint box that re-names on demand (`ctrl+R` or Enter). It opens even when the model fails or the prompt is too thin, so there is always a way forward. Taken names are suffixed while the user can still see it.

**Plan** — `target.branch` / `target.worktreeDir` are frozen into the plan, so Review shows the real branch and path. No model call remains after confirmation, so `branchNamer` leaves the plan and the preflight.

## Verification

- 543 tests pass, `tsc --noEmit` clean.
- The exact PRD that produced `cu-l-es-tu-siguiente-paso` now yields `feat/implement-execution-guardrails`.
- Unavailable model → `feat/propuesta-implementacion` (derived from the PRD), not a timestamp.
- Collision in a scratch repo → `feat/runtime-guard-limits-2` instead of failing.
- Launcher driven through a pty: Branch step renders, Review shows the branch and path, and hints steer the name (`"name it after the runtime guard, not the budget"` → `feat/add-runtime-guard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKNkehnWftSu2ZBZW5m9oX