### PR TITLE
fix(tui): settle the finish screen and offer push or push-and-PR as one fork

### DIFF
--- a/src/tui.ts
+++ b/src/tui.ts
@@ -164,7 +164,19 @@ type FinishModal =
   | { kind: "working"; message: string }
   | { kind: "blocked"; message: string }
   | { kind: "edit"; proposal: FinishProposal; subject: string; cursor: number }
-  | { kind: "done"; outcome: FinishOutcome; message: { subject: string; body: string[] }; pushed: boolean; note?: string }
+  | {
+      kind: "done"
+      outcome: FinishOutcome
+      message: { subject: string; body: string[] }
+      /**
+       * What the screen still offers. "choose" is the fork right after the
+       * commit; "retry-pr" is the push having landed with `gh` having failed;
+       * "settled" is terminal — the branch has left the machine and there is
+       * nothing left to press.
+       */
+      stage: "choose" | "retry-pr" | "settled"
+      note?: string
+    }
 
 function clipboardStatusLabel(status?: ClipboardResult): string {
   if (status === "copied-native" || status === "copied-osc52") return " · copied"
@@ -1815,9 +1827,11 @@ export class TuiProgress implements ProgressUI {
 
     if (modal.kind === "done") {
       // The commit is already made; these only offer what comes after it, and
-      // anything else closes the modal.
-      if (key.name === "p" && !modal.pushed) void this.runFinishFollowUp(modal, "push")
-      else if (key.name === "r" && modal.pushed && this.finishSeam?.canOpenPullRequest()) void this.runFinishFollowUp(modal, "pr")
+      // anything else closes the modal. Once settled nothing matches, so `r`
+      // closes rather than asking gh for a pull request that already exists.
+      const canPr = this.finishSeam?.canOpenPullRequest() ?? false
+      if (key.name === "p" && modal.stage === "choose") void this.runFinishFollowUp(modal, "push")
+      else if (key.name === "r" && canPr && modal.stage !== "settled") void this.runFinishFollowUp(modal, "pr")
       else this.finishModal = undefined
       this.render()
       return
@@ -1916,7 +1930,7 @@ export class TuiProgress implements ProgressUI {
     try {
       const message = { subject, body: proposal.body }
       const outcome = await seam.apply(message)
-      this.finishModal = { kind: "done", outcome, message, pushed: false }
+      this.finishModal = { kind: "done", outcome, message, stage: "choose" }
       this.addEvent("convoy", "system", `finished ${outcome.branch} as ${outcome.sha.slice(0, 8)} (${outcome.replaced} commits squashed)`)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
@@ -1930,38 +1944,46 @@ export class TuiProgress implements ProgressUI {
   }
 
   /**
-   * Push and pull request, each asked for explicitly after the commit exists.
-   * Neither ever runs as part of [f] itself: the squash is local and undoable,
-   * while these leave the machine.
+   * Push and pull request, chosen once after the commit exists. Neither ever
+   * runs as part of [f] itself: the squash is local and undoable, while these
+   * leave the machine. "pr" is the whole trip — the push it needs and then the
+   * pull request — so the two are one decision rather than two prompts.
    */
   private async runFinishFollowUp(modal: Extract<FinishModal, { kind: "done" }>, action: "push" | "pr") {
     const seam = this.finishSeam
     if (!seam || this.inSubshell) return
-    this.finishModal = { kind: "working", message: action === "push" ? `pushing ${modal.outcome.branch}…` : "opening a pull request…" }
+    const needsPush = modal.stage === "choose"
+    const working = action === "push" ? `pushing ${modal.outcome.branch}…` : needsPush ? "pushing and opening a pull request…" : "opening a pull request…"
+    this.finishModal = { kind: "working", message: working }
     this.render()
 
     this.inSubshell = true
     this.suspend()
-    let note: string | undefined
-    let pushed = modal.pushed
+    const notes: string[] = []
+    // The stage reached is also what says where a throw came from, and it never
+    // advances to "settled" on failure: the action row stays up to be retried.
+    let stage = modal.stage
     try {
-      if (action === "push") {
+      if (needsPush) {
         await seam.push(modal.outcome.branch)
-        pushed = true
-        note = `pushed to origin/${modal.outcome.branch}`
-      } else {
+        notes.push(`pushed to origin/${modal.outcome.branch}`)
+        stage = action === "push" ? "settled" : "retry-pr"
+      }
+      if (action === "pr") {
         await seam.openPullRequest(modal.message)
-        note = "pull request opened"
+        notes.push("pull request opened")
+        stage = "settled"
       }
     } catch (error) {
-      note = `${action === "push" ? "push" : "gh pr create"} failed: ${error instanceof Error ? error.message : String(error)}`
+      notes.push(`${stage === "choose" ? "push" : "gh pr create"} failed: ${error instanceof Error ? error.message : String(error)}`)
     } finally {
       this.inSubshell = false
       this.resume()
     }
 
-    if (note) this.addEvent("convoy", "system", note)
-    this.finishModal = { ...modal, pushed, ...(note ? { note } : {}) }
+    for (const note of notes) this.addEvent("convoy", "system", note)
+    const note = notes.join(" · ")
+    this.finishModal = { ...modal, stage, ...(note ? { note } : {}) }
     this.render()
   }
 
@@ -3367,9 +3389,21 @@ export class TuiProgress implements ProgressUI {
       lines.push(plain(""))
 
       const actions: TextChunk[] = []
-      if (!modal.pushed) actions.push(fg(theme.accent)("p"), fg(theme.dim)(" push · "))
-      else if (this.finishSeam?.canOpenPullRequest()) actions.push(fg(theme.accent)("r"), fg(theme.dim)(" pull request · "))
-      actions.push(fg(theme.faint)("any other key closes"))
+      const canPr = this.finishSeam?.canOpenPullRequest() ?? false
+      if (modal.stage === "choose") {
+        actions.push(fg(theme.accent)("p"), fg(theme.dim)(" push"))
+        if (canPr) actions.push(fg(theme.dim)(" · "), fg(theme.accent)("r"), fg(theme.dim)(" push and PR"))
+      } else if (modal.stage === "retry-pr" && canPr) {
+        actions.push(fg(theme.accent)("r"), fg(theme.dim)(" retry pull request"))
+      } else {
+        // Settled: the branch is where the user asked for it, so the only thing
+        // left is dismissing the modal.
+        actions.push(fg(theme.faint)("press any key to close"))
+      }
+      // The row is one unwrapped line, so the hint — not an action — is what
+      // gives way when the terminal is too narrow to hold both.
+      const keysWidth = actions.reduce((total, chunk) => total + chunk.text.length, 0)
+      if (modal.stage !== "settled" && keysWidth + 23 <= width) actions.push(fg(theme.dim)(" · "), fg(theme.faint)("any other key closes"))
       lines.push(new StyledText(actions))
     } else {
       const { proposal } = modal

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -7,7 +7,7 @@ import { formatMoney, limitsRow } from "../src/tui-theme"
 
 import type { ClipboardResult } from "../src/clipboard"
 import type { LimitsSnapshot } from "../src/limits"
-import type { ProgressPhase } from "../src/progress"
+import type { FinishSeam, ProgressPhase } from "../src/progress"
 import type { AdvisorEvent } from "../src/advisor-events"
 
 type DashboardInternals = {
@@ -41,20 +41,29 @@ type DashboardInternals = {
     preventDefault(): void
     stopPropagation(): void
   }): void
+  finishModal?: { kind: string; stage?: string; note?: string }
+  handleFinishKey(key: { name: string; preventDefault(): void; stopPropagation(): void }): void
+  openFinishModal(): Promise<void>
 }
 
 async function createDashboard(
   width = 120,
   height = 40,
   phases: ProgressPhase[] = [{ name: "implement", description: "" }],
-  options: { observer?: boolean; onPauseToggle?: () => void; onKeepAwakeToggle?: () => void; copyResult?: ClipboardResult } = {},
+  options: {
+    observer?: boolean
+    onPauseToggle?: () => void
+    onKeepAwakeToggle?: () => void
+    copyResult?: ClipboardResult
+    finishSeam?: FinishSeam
+  } = {},
 ) {
   const testRenderer = await createTestRenderer({ width, height })
   const copied: string[] = []
   const dashboard = new TuiProgress(testRenderer.renderer, phases, undefined, undefined, false, options.observer ?? false, "session", async (text) => {
     copied.push(text)
     return options.copyResult ?? "copied-native"
-  }, options.onPauseToggle, options.onKeepAwakeToggle)
+  }, options.onPauseToggle, options.onKeepAwakeToggle, options.finishSeam)
   testRenderer.renderer.copyToClipboardOSC52 = (text) => {
     copied.push(text)
     return true
@@ -896,6 +905,178 @@ describe("dashboard content selection", () => {
       expect(renderer.listenerCount("selection")).toBe(0)
     } finally {
       if (!renderer.isDestroyed) dashboard.stop()
+    }
+  })
+})
+
+describe("finish modal follow-ups", () => {
+  type SeamOptions = { canPr?: boolean; pushFails?: boolean; prFails?: boolean }
+
+  function fakeSeam(options: SeamOptions = {}) {
+    const calls = { push: 0, pr: 0 }
+    const seam: FinishSeam = {
+      async prepare() {
+        return {
+          ok: true as const,
+          proposal: { branch: "convoy/run", commitCount: 3, subject: "feat: a thing", body: ["did a thing"], notes: [] },
+        }
+      },
+      async apply() {
+        return { sha: "abcdef1234567890", branch: "convoy/run", backupRef: "refs/convoy/finish-backup", replaced: 3 }
+      },
+      async edit() {
+        return undefined
+      },
+      async push() {
+        calls.push++
+        if (options.pushFails) throw new Error("no write access")
+      },
+      canOpenPullRequest: () => options.canPr ?? true,
+      async openPullRequest() {
+        calls.pr++
+        if (options.prFails) throw new Error("gh pr create didn't complete")
+      },
+    }
+    return { seam, calls }
+  }
+
+  const press = (name: string) => ({ name, preventDefault() {}, stopPropagation() {} })
+  // The handlers fire their follow-ups with `void`, so the awaits inside them
+  // need a turn of the loop before the modal is asserted on.
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+  /** Drives [f] through prepare and the commit, landing on the "done" screen. */
+  async function commit(options: SeamOptions & { width?: number } = {}) {
+    const { seam, calls } = fakeSeam(options)
+    const harness = await createDashboard(options.width ?? 120, 40, [{ name: "implement", description: "" }], { finishSeam: seam })
+    const internals = harness.dashboard as unknown as DashboardInternals
+    await internals.openFinishModal()
+    internals.handleFinishKey(press("return"))
+    await settle()
+    return { ...harness, internals, calls }
+  }
+
+  test("offers push and push-and-PR as one fork after the commit", async () => {
+    const { internals, dashboard, calls } = await commit()
+    try {
+      expect(internals.finishModal).toMatchObject({ kind: "done", stage: "choose" })
+      const text = internals.modalText.plainText
+      // Both branches are visible at once rather than push unlocking the PR.
+      expect(text).toContain("p push")
+      expect(text).toContain("r push and PR")
+      expect(calls).toEqual({ push: 0, pr: 0 })
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("push alone settles without ever offering a pull request", async () => {
+    const { internals, dashboard, calls } = await commit()
+    try {
+      internals.handleFinishKey(press("p"))
+      await settle()
+
+      expect(calls).toEqual({ push: 1, pr: 0 })
+      expect(internals.finishModal).toMatchObject({ kind: "done", stage: "settled" })
+      const text = internals.modalText.plainText
+      expect(text).toContain("pushed to origin/convoy/run")
+      expect(text).toContain("press any key to close")
+      expect(text).not.toContain("pull request")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("push and PR settles, and a second r closes instead of re-creating it", async () => {
+    const { internals, dashboard, calls } = await commit()
+    try {
+      internals.handleFinishKey(press("r"))
+      await settle()
+
+      expect(calls).toEqual({ push: 1, pr: 1 })
+      expect(internals.finishModal).toMatchObject({ kind: "done", stage: "settled" })
+      const text = internals.modalText.plainText
+      expect(text).toContain("pull request opened")
+      expect(text).toContain("press any key to close")
+
+      // The regression: the settled screen used to keep offering the PR, so a
+      // second r ran `gh pr create` again on a branch that already had one.
+      internals.handleFinishKey(press("r"))
+      await settle()
+      expect(calls).toEqual({ push: 1, pr: 1 })
+      expect(internals.finishModal).toBeUndefined()
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("a failed push keeps the fork up and never reaches the pull request", async () => {
+    const { internals, dashboard, calls } = await commit({ pushFails: true })
+    try {
+      internals.handleFinishKey(press("r"))
+      await settle()
+
+      expect(calls).toEqual({ push: 1, pr: 0 })
+      expect(internals.finishModal).toMatchObject({ kind: "done", stage: "choose" })
+      const text = internals.modalText.plainText
+      expect(text).toContain("push failed: no write access")
+      expect(text).toContain("p push")
+      expect(text).toContain("r push and PR")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("a failed gh keeps the push and offers just the retry", async () => {
+    const { internals, dashboard, calls } = await commit({ prFails: true })
+    try {
+      internals.handleFinishKey(press("r"))
+      await settle()
+
+      expect(calls).toEqual({ push: 1, pr: 1 })
+      expect(internals.finishModal).toMatchObject({ kind: "done", stage: "retry-pr" })
+      // Both halves are reported: the push landed even though gh didn't. Read
+      // off the state, since the rendered note wraps at the modal's width.
+      expect(internals.finishModal?.note).toBe("pushed to origin/convoy/run · gh pr create failed: gh pr create didn't complete")
+      const text = internals.modalText.plainText
+      expect(text).toContain("pushed to origin/convoy/run")
+      expect(text).toContain("r retry pull request")
+      // The push is done, so re-offering it would only fail on an up-to-date ref.
+      expect(text).not.toContain("p push")
+
+      internals.handleFinishKey(press("r"))
+      await settle()
+      expect(calls).toEqual({ push: 1, pr: 2 })
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("keeps both keys on a narrow terminal by dropping the hint", async () => {
+    const { internals, dashboard } = await commit({ width: 48 })
+    try {
+      const row = internals.modalText.plainText.split("\n").at(-1)
+      // The row is one unwrapped line, so the hint gives way before the keys do.
+      expect(row).toBe("p push · r push and PR")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("without gh the fork is push only", async () => {
+    const { internals, dashboard, calls } = await commit({ canPr: false })
+    try {
+      const text = internals.modalText.plainText
+      expect(text).toContain("p push")
+      expect(text).not.toContain("push and PR")
+
+      // r is not on offer, so it falls through to closing the modal.
+      internals.handleFinishKey(press("r"))
+      await settle()
+      expect(calls).toEqual({ push: 0, pr: 0 })
+      expect(internals.finishModal).toBeUndefined()
+    } finally {
+      dashboard.stop()
     }
   })
 })


### PR DESCRIPTION
## Context

Two problems on the `[f]` finish modal, both reported from real use:

1. **The PR kept being offered after it was created.** The `done` state only carried `pushed: boolean` and nothing recorded that the pull request had opened, so the follow-up rebuilt the same state on its way out and the screen kept painting `r pull request`. Pressing it again re-ran `gh pr create` on a branch that already had one.
2. **The step before it had only one option.** The action row was an `if / else if`, so `r` was invisible until a push had landed and `p` vanished once it had. The two were never on offer together.

## What changed

- `FinishModal["done"]` now carries an explicit `stage: "choose" | "retry-pr" | "settled"`. Once settled no key branch matches, so `r` closes the modal instead of asking `gh` for a duplicate PR.
- After the commit the screen presents a single fork — `p push · r push and PR` — and `r` does the whole trip (the push it needs, then the pull request). Both paths end on a terminal success screen.
- Failures stay actionable: a failed push returns to the fork, and a failed `gh` keeps the push and offers only `r retry pull request`. When a push lands and `gh` doesn't, the note reports both.
- The action row is one unwrapped line, so on a narrow terminal the closing hint gives way before the keys do.

The CLI `convoy finish` is untouched — its nested `y/N` prompts are single-shot and never repeated.

## Verification

- 7 new tests in `test/tui.test.ts` covering the fork, both terminal paths, both failure modes, the no-`gh` case, the narrow-terminal row, and specifically the reported regression: a second `r` after success closes the modal and leaves `openPullRequest` at one call.
- `bun test` — 707 pass, 0 fail. `bun run typecheck` clean.
- Rendered every stage through the real renderer to check the copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013J8yJekSzkuhiwC8MBA7na