### PR TITLE
feat(release): add GitHub Releases distribution with SemVer versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out tag
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        # Pinned: the compiled binaries embed this Bun runtime, so the release
+        # must ship the version the test suite ran against, not "latest".
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Verify tag matches package version
+        run: |
+          VERSION="$(bun -e 'const pkg = await Bun.file("package.json").json(); process.stdout.write(pkg.version)')"
+          if [ "$GITHUB_REF_NAME" != "v$VERSION" ]; then
+            echo "tag $GITHUB_REF_NAME does not match package.json version $VERSION" >&2
+            exit 1
+          fi
+
+      - name: Install locked dependencies
+        run: bun install --frozen-lockfile --os='*' --cpu='*'
+
+      - name: Verify cross-platform native dependencies
+        # OpenTUI resolves `@opentui/core-<platform>-<arch>` through a dynamic
+        # import that bun build embeds per target. If a target's package is
+        # missing, the binary still passes `--version` but crashes on the TUI,
+        # so fail here instead of publishing a broken release.
+        run: |
+          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            if [ ! -f "node_modules/@opentui/core-$target/package.json" ]; then
+              echo "missing @opentui/core-$target; cannot build a working $target binary" >&2
+              exit 1
+            fi
+          done
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build release binaries
+        run: bun run build:release
+
+      - name: Smoke-test Linux binary
+        run: ./dist/convoy-linux-x64 --version
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          shasum -a 256 convoy-darwin-arm64 convoy-darwin-x64 convoy-linux-arm64 convoy-linux-x64 > SHA256SUMS
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          fail_on_unmatched_files: true
+          files: |
+            dist/convoy-darwin-arm64
+            dist/convoy-darwin-x64
+            dist/convoy-linux-arm64
+            dist/convoy-linux-x64
+            dist/SHA256SUMS

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 convoy
+dist/
 .*.bun-build
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ uninstall:
 	@echo "✓ Uninstalled $(INSTALL_DIR)/$(BIN)"
 
 clean:
-	@rm -f $(BIN) src/$(BIN)
+	@rm -f $(BIN) src/$(BIN) dist/$(BIN)-*
 
 test:
 	bun run typecheck

--- a/README.md
+++ b/README.md
@@ -72,7 +72,17 @@ Convoy ships these pipelines; select one with `-p/--pipeline` (no config needed)
 
 ## Requirements
 
-- Bun 1.0+
+### Release binary
+
+- macOS (Apple Silicon or Intel), or Linux (ARM64 or x64)
+- `opencode` installed and authenticated (`opencode auth login`)
+- `git`
+
+Bun is included in the release binary; it is **not** a user requirement.
+
+### Development
+
+- Bun 1.3+ (the release build pins 1.3.14)
 - `opencode` installed and authenticated (`opencode auth login`)
 - `git`
 
@@ -94,16 +104,60 @@ To use different providers, authenticate them in OpenCode and select models as `
 
 ## Installation
 
+### Release binary (recommended)
+
+GitHub Releases are the distribution source and preserve every published version. Download the binary for your platform into `~/.local/bin`, then make it executable:
+
 ```bash
-git clone <this-repo> convoy
+mkdir -p ~/.local/bin
+
+# macOS on Apple Silicon
+curl -fL https://github.com/Inakitajes/convoy/releases/latest/download/convoy-darwin-arm64 -o ~/.local/bin/convoy
+
+# macOS on Intel
+# curl -fL https://github.com/Inakitajes/convoy/releases/latest/download/convoy-darwin-x64 -o ~/.local/bin/convoy
+
+# Linux on ARM64
+# curl -fL https://github.com/Inakitajes/convoy/releases/latest/download/convoy-linux-arm64 -o ~/.local/bin/convoy
+
+# Linux on x64
+# curl -fL https://github.com/Inakitajes/convoy/releases/latest/download/convoy-linux-x64 -o ~/.local/bin/convoy
+
+chmod 755 ~/.local/bin/convoy
+convoy --version
+```
+
+Make sure `~/.local/bin` is on your `PATH`. To install an exact version, replace `/releases/latest/download/` with `/releases/download/v0.1.0/` (or another tag). The [Releases page](https://github.com/Inakitajes/convoy/releases) lists all available versions and their `SHA256SUMS` files.
+
+### Development install
+
+Use the source flow only when developing Convoy itself:
+
+```bash
+git clone https://github.com/Inakitajes/convoy.git
 cd convoy
 bun install
 make install
 ```
 
-This leaves `convoy` in `~/.local/bin/convoy` and creates `~/.convoy/config.yaml` plus `~/.convoy/agents/*.md` with Convoy's default configuration if they do not already exist. Make sure `~/.local/bin` is in your `PATH`.
+This builds a local binary in `~/.local/bin/convoy` and creates `~/.convoy/config.yaml` plus `~/.convoy/agents/*.md` with Convoy's default configuration if they do not already exist.
 
 ## Usage
+
+### Version and updates
+
+```bash
+# Show the release version, build commit, and target platform
+convoy --version
+
+# Check the latest stable GitHub Release without changing files
+convoy update --check
+
+# Download, verify (GitHub SHA-256 digest + SHA256SUMS), and atomically install a newer release
+convoy update
+```
+
+Updates are explicit: Convoy does not make network calls when it starts. `convoy update` only changes official standalone release binaries; it never modifies a source checkout, `~/.convoy`, project configuration, runs, or worktrees.
 
 From the root of the target repo, ideally on a working branch:
 
@@ -495,9 +549,13 @@ convoy/
 │   ├── config.ts        # config loader/validation, global+project merge, YAML writer
 │   ├── config-tui.ts    # interactive config editor (convoy config)
 │   ├── model-catalog.ts # available-model list via OpenCode SDK, models.dev fallback
+│   ├── version.ts       # injected version/commit/platform + --version formatting
+│   ├── update.ts        # GitHub Releases update check + verified atomic self-install
 │   └── pipeline.ts      # built-in agents/pipeline and pipeline-spec resolution
+├── scripts/             # build.ts: local + multi-target release binary compilation
 ├── prompts/             # built-in agent prompts and runtime safety guard rails
 ├── test/                # unit tests for CLI/orchestration
+├── .github/workflows/   # release.yml: tag-triggered build, test, and GitHub Release publish
 ├── package.json
 ├── tsconfig.json
 └── Makefile

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "dev": "bun run src/main.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
-    "build": "bun build --compile src/main.ts --outfile convoy"
+    "build": "bun run scripts/build.ts",
+    "build:release": "bun run scripts/build.ts --release"
   },
   "dependencies": {
     "@opencode-ai/sdk": "1.18.4",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,56 @@
+import { mkdir } from "node:fs/promises"
+import { resolve } from "node:path"
+
+type PackageManifest = { version?: unknown }
+
+type BuildTarget = {
+  bunTarget: Bun.Build.CompileTarget
+  platform: string
+  output: string
+}
+
+const localTarget: BuildTarget = {
+  bunTarget: `bun-${process.platform}-${process.arch}` as Bun.Build.CompileTarget,
+  platform: `${process.platform}-${process.arch}`,
+  output: "convoy",
+}
+
+const releaseTargets: BuildTarget[] = [
+  { bunTarget: "bun-darwin-arm64", platform: "darwin-arm64", output: "dist/convoy-darwin-arm64" },
+  { bunTarget: "bun-darwin-x64", platform: "darwin-x64", output: "dist/convoy-darwin-x64" },
+  { bunTarget: "bun-linux-arm64", platform: "linux-arm64", output: "dist/convoy-linux-arm64" },
+  { bunTarget: "bun-linux-x64", platform: "linux-x64", output: "dist/convoy-linux-x64" },
+]
+
+const release = process.argv.slice(2).join(" ") === "--release"
+if (!release && process.argv.length > 2) throw new Error("usage: bun run scripts/build.ts [--release]")
+
+const manifest = (await Bun.file("package.json").json()) as PackageManifest
+if (typeof manifest.version !== "string" || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(manifest.version)) {
+  throw new Error("package.json must contain a valid SemVer version")
+}
+
+const commit = await gitCommit()
+if (release) await mkdir("dist", { recursive: true })
+for (const target of release ? releaseTargets : [localTarget]) {
+  const result = await Bun.build({
+    entrypoints: [resolve("src/main.ts")],
+    compile: { target: target.bunTarget, outfile: resolve(target.output) },
+    define: {
+      __CONVOY_VERSION__: JSON.stringify(manifest.version),
+      __CONVOY_COMMIT__: JSON.stringify(commit),
+      __CONVOY_PLATFORM__: JSON.stringify(target.platform),
+    },
+  })
+  if (!result.success) {
+    throw new Error(`failed to build ${target.output}:\n${result.logs.map((log) => log.message).join("\n")}`)
+  }
+  process.stdout.write(`built ${target.output} (${target.platform})\n`)
+}
+
+async function gitCommit() {
+  const child = Bun.spawn(["git", "rev-parse", "HEAD"], { stdout: "pipe", stderr: "pipe" })
+  if ((await child.exited) !== 0) return "unknown"
+  const commit = (await new Response(child.stdout).text()).trim()
+  return /^[0-9a-f]{40}$/i.test(commit) ? commit : "unknown"
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,6 +18,8 @@ import { readRunMetadata } from "./metadata"
 import { preflightRunPlan } from "./preflight"
 import type { LaunchBranchCheck, LaunchBranchProposal, LaunchRunPreparation, LaunchRunSelection } from "./launch-tui"
 import type { FinishOptions } from "./finish-command"
+import { formatVersion } from "./version"
+import type { UpdateResult } from "./update"
 
 /**
  * Flags as written: every scalar stays undefined until the user sets it, so
@@ -80,6 +82,8 @@ export type CliCommand =
   | { type: "init"; options: InitOptions }
   | { type: "finish"; options: FinishOptions }
   | { type: "auth"; provider: "openrouter"; action: "set" | "remove" | "status" }
+  | { type: "version" }
+  | { type: "update"; checkOnly: boolean }
 
 export async function parseAndRun(argv: string[]) {
   if (argv.length === 0 && process.stdin.isTTY && process.stdout.isTTY) {
@@ -90,6 +94,15 @@ export async function parseAndRun(argv: string[]) {
   const command = await parseCommand(argv)
   if (command.type === "help") {
     process.stdout.write(command.text)
+    return
+  }
+  if (command.type === "version") {
+    process.stdout.write(`${formatVersion()}\n`)
+    return
+  }
+  if (command.type === "update") {
+    const { runUpdate } = await import("./update")
+    writeUpdateResult(await runUpdate({ checkOnly: command.checkOnly }))
     return
   }
   if (command.type === "runs") {
@@ -344,6 +357,13 @@ async function runAuthCommand(action: "set" | "remove" | "status") {
 }
 
 export async function parseCommand(argv: string[]): Promise<CliCommand> {
+  if (argv.length === 1 && (argv[0] === "--version" || argv[0] === "-V")) return { type: "version" }
+  if (argv[0] === "update") {
+    if (argv.length === 1) return { type: "update", checkOnly: false }
+    if (argv.length === 2 && argv[1] === "--check") return { type: "update", checkOnly: true }
+    if (argv.length === 2 && (argv[1] === "--help" || argv[1] === "-h")) return { type: "help", text: updateHelp() }
+    throw new Error("usage: convoy update [--check]")
+  }
   if (argv[0] === "auth") {
     const rest = argv.slice(1)
     if (rest.length === 0 || (rest.length === 1 && rest[0] === "status")) {
@@ -747,6 +767,7 @@ Usage:
   convoy --pipeline bug-fix --prompt-file bug.md
   convoy init
   convoy finish
+  convoy update [--check]
   convoy runs [run-id]
   convoy config
   convoy auth openrouter
@@ -759,6 +780,8 @@ Commands:
   finish                   Squash this branch's convoy commits into one conventional commit
                            created with your own git identity, so it lands signed and attributed
                            ("convoy finish --help" for options; [f] on the run dashboard does the same)
+  update [--check]         Check GitHub Releases for a newer official binary, or install it
+                           (source checkouts are never modified)
   runs [run-id]            Browse run history: resume a run, read its summary/reports,
                            or open a subshell in its run dir (under ~/.convoy/runs)
   config                   View and edit the global (~/.convoy) and current project config in a TUI
@@ -766,6 +789,7 @@ Commands:
                            header credits meter (--remove deletes it; "auth status" lists sources)
 
 Flags:
+  --version, -V            Print Convoy's version, commit, and build platform
   --prompt-file <path>     Read the PRD/prompt from a file
   --file, -f <path>        Attach a file or directory to all steps (repeatable)
   --pipeline, -p <name>    Pipeline to run (default: "implement"), which runs
@@ -817,6 +841,35 @@ Config keys:
   The same schema lives globally at ~/.convoy/config.yaml; project config merges on top.
   Precedence: CLI flags > project config > global config > built-in defaults.
 `
+}
+
+function updateHelp() {
+  return `convoy update [--check]
+
+Check the latest stable GitHub Release for a binary matching this platform.
+Without --check, download, verify, and atomically install the newer binary.
+Only official standalone release binaries can update themselves; source
+checkouts are never modified.
+
+Options:
+  --check                  Report whether an update is available without changing files
+`
+}
+
+function writeUpdateResult(result: UpdateResult) {
+  switch (result.status) {
+    case "source-install":
+      process.stdout.write(`${result.message}\n`)
+      return
+    case "up-to-date":
+      process.stdout.write(`convoy ${result.currentVersion} is up to date (latest: v${result.latestVersion})\n`)
+      return
+    case "update-available":
+      process.stdout.write(`update available: ${result.currentVersion} → v${result.latestVersion} (${result.assets.binary.name})\n`)
+      return
+    case "updated":
+      process.stdout.write(`updated convoy ${result.currentVersion} → v${result.latestVersion} (${result.assetName})\n`)
+  }
 }
 
 function initHelp() {

--- a/src/update.ts
+++ b/src/update.ts
@@ -1,0 +1,454 @@
+import { chmod, copyFile, rename, rm, stat, writeFile } from "node:fs/promises"
+import { createHash, randomUUID } from "node:crypto"
+import { basename, dirname, join } from "node:path"
+
+import { versionInfo } from "./version"
+
+export const githubLatestReleaseUrl = "https://api.github.com/repos/Inakitajes/convoy/releases/latest"
+export const releasesUrl = "https://github.com/Inakitajes/convoy/releases"
+
+/**
+ * GitHub release asset URLs are served from `github.com` and redirect to
+ * `objects.githubusercontent.com`. Restricting downloads to these hosts keeps a
+ * tampered release metadata payload from directing the updater's HTTP request
+ * (which carries the user's IP and `convoy-updater` User-Agent) at an arbitrary
+ * external host, even though the bytes would fail hash verification afterwards.
+ */
+const githubAssetHosts = new Set(["github.com", "objects.githubusercontent.com"])
+
+function isGithubAssetUrl(raw: string) {
+  if (!raw.startsWith("https://")) return false
+  try {
+    return githubAssetHosts.has(new URL(raw).host)
+  } catch {
+    return false
+  }
+}
+
+type RecordValue = Record<string, unknown>
+
+export type SemVer = {
+  major: number
+  minor: number
+  patch: number
+  prerelease: string[]
+}
+
+export type ReleaseAsset = {
+  name: string
+  browserDownloadUrl: string
+  digest?: string
+}
+
+export type PublishedRelease = {
+  tagName: string
+  version: SemVer
+  publishedAt: string
+  assets: ReleaseAsset[]
+}
+
+export type SelectedReleaseAssets = {
+  binary: ReleaseAsset
+  checksumFile: ReleaseAsset
+}
+
+export type UpdateCheck = {
+  status: "up-to-date" | "update-available"
+  currentVersion: string
+  latestVersion: string
+  release: PublishedRelease
+  assets: SelectedReleaseAssets
+}
+
+export type UpdateResult =
+  | { status: "source-install"; message: string }
+  | UpdateCheck
+  | { status: "updated"; currentVersion: string; latestVersion: string; assetName: string }
+
+export type UpdateFileOps = {
+  chmod: typeof chmod
+  copyFile: typeof copyFile
+  rename: typeof rename
+  rm: typeof rm
+  stat: typeof stat
+  writeFile: typeof writeFile
+}
+
+export type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+
+type BunStandaloneRuntime = {
+  isStandaloneExecutable?: unknown
+  embeddedFiles?: ReadonlyArray<unknown>
+  main?: unknown
+}
+
+export type UpdateOptions = {
+  checkOnly?: boolean
+  currentVersion?: string
+  platform?: string
+  architecture?: string
+  executablePath?: string
+  standalone?: boolean
+  fetch?: FetchLike
+  validateCandidate?: (path: string, expectedVersion: string) => Promise<boolean>
+  fileOps?: UpdateFileOps
+  randomSuffix?: () => string
+}
+
+const defaultFileOps: UpdateFileOps = { chmod, copyFile, rename, rm, stat, writeFile }
+
+export class UpdateError extends Error {
+  override name = "UpdateError"
+}
+
+/**
+ * Bun 1.4 exposes a zero-cost standalone flag. Bun 1.3 does not expose that
+ * API, so use its compiled-entrypoint path as a compatibility fallback.
+ */
+export function isOfficialStandaloneExecutable(runtime: BunStandaloneRuntime = Bun) {
+  if (typeof runtime.isStandaloneExecutable === "boolean") return runtime.isStandaloneExecutable
+  if (typeof runtime.main === "string" && (runtime.main.startsWith("/$bunfs/") || runtime.main.includes("\\$bunfs\\"))) {
+    return true
+  }
+  try {
+    return (runtime.embeddedFiles?.length ?? 0) > 0
+  } catch {
+    return false
+  }
+}
+
+/** Parses a SemVer value, accepting the conventional leading `v` used by Git tags. */
+export function parseSemVer(value: string): SemVer | undefined {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+([0-9A-Za-z.-]+))?$/.exec(value)
+  if (!match) return undefined
+
+  const numeric = match.slice(1, 4)
+  if (numeric.some((part) => !/^(0|[1-9]\d*)$/.test(part!))) return undefined
+
+  const prerelease = match[4] ? match[4].split(".") : []
+  if (
+    prerelease.some(
+      (part) => !part || !/^[0-9A-Za-z-]+$/.test(part) || (/^\d+$/.test(part) && !/^(0|[1-9]\d*)$/.test(part)),
+    )
+  ) {
+    return undefined
+  }
+
+  // Build metadata does not affect precedence, but still must be syntactically valid.
+  if (match[5]?.split(".").some((part) => !part || !/^[0-9A-Za-z-]+$/.test(part))) return undefined
+
+  return {
+    major: Number(numeric[0]),
+    minor: Number(numeric[1]),
+    patch: Number(numeric[2]),
+    prerelease,
+  }
+}
+
+export function formatSemVer(version: SemVer) {
+  const base = `${version.major}.${version.minor}.${version.patch}`
+  return version.prerelease.length > 0 ? `${base}-${version.prerelease.join(".")}` : base
+}
+
+/** Returns a positive value when `left` is newer than `right`. */
+export function compareSemVer(left: SemVer | string, right: SemVer | string) {
+  const a = typeof left === "string" ? parseSemVer(left) : left
+  const b = typeof right === "string" ? parseSemVer(right) : right
+  if (!a || !b) throw new UpdateError("cannot compare an invalid semantic version")
+
+  for (const field of ["major", "minor", "patch"] as const) {
+    if (a[field] !== b[field]) return a[field] > b[field] ? 1 : -1
+  }
+  if (a.prerelease.length === 0 || b.prerelease.length === 0) {
+    if (a.prerelease.length === b.prerelease.length) return 0
+    return a.prerelease.length === 0 ? 1 : -1
+  }
+
+  const length = Math.max(a.prerelease.length, b.prerelease.length)
+  for (let index = 0; index < length; index++) {
+    const aPart = a.prerelease[index]
+    const bPart = b.prerelease[index]
+    if (aPart === undefined) return -1
+    if (bPart === undefined) return 1
+    if (aPart === bPart) continue
+    const aNumeric = /^\d+$/.test(aPart)
+    const bNumeric = /^\d+$/.test(bPart)
+    if (aNumeric && bNumeric) return Number(aPart) > Number(bPart) ? 1 : -1
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1
+    return aPart > bPart ? 1 : -1
+  }
+  return 0
+}
+
+export function assetNameForPlatform(platform: string, architecture: string) {
+  const names: Record<string, string> = {
+    "darwin-arm64": "convoy-darwin-arm64",
+    "darwin-x64": "convoy-darwin-x64",
+    "linux-arm64": "convoy-linux-arm64",
+    "linux-x64": "convoy-linux-x64",
+  }
+  return names[`${platform}-${architecture}`]
+}
+
+/** Validates that the API payload represents a published stable SemVer release. */
+export function validateLatestRelease(value: unknown): PublishedRelease {
+  const release = record(value, "latest release")
+  const tagName = stringProperty(release, "tag_name", "latest release")
+  if (!tagName.startsWith("v")) throw new UpdateError(`release tag must start with "v": ${tagName}`)
+  const version = parseSemVer(tagName)
+  if (!version || version.prerelease.length > 0) throw new UpdateError(`release tag is not a stable semantic version: ${tagName}`)
+  if (release.draft !== false) throw new UpdateError("latest release is not published")
+  if (release.prerelease !== false) throw new UpdateError("latest release is a prerelease")
+
+  const publishedAt = stringProperty(release, "published_at", "latest release")
+  if (Number.isNaN(Date.parse(publishedAt))) throw new UpdateError("latest release has an invalid publication date")
+  if (!Array.isArray(release.assets)) throw new UpdateError("latest release has no assets")
+
+  const assets = release.assets.map((asset, index) => {
+    const parsed = record(asset, `release asset ${index + 1}`)
+    const name = stringProperty(parsed, "name", `release asset ${index + 1}`)
+    const browserDownloadUrl = stringProperty(parsed, "browser_download_url", `release asset ${name}`)
+    if (!isGithubAssetUrl(browserDownloadUrl)) {
+      throw new UpdateError(`release asset ${name} has an unsafe download URL`)
+    }
+    const digest = parsed.digest
+    if (digest !== undefined && digest !== null && typeof digest !== "string") {
+      throw new UpdateError(`release asset ${name} has an invalid digest`)
+    }
+    return { name, browserDownloadUrl, ...(typeof digest === "string" ? { digest } : {}) }
+  })
+
+  return { tagName, version, publishedAt, assets }
+}
+
+export function selectReleaseAssets(release: PublishedRelease, platform: string, architecture: string): SelectedReleaseAssets {
+  const assetName = assetNameForPlatform(platform, architecture)
+  if (!assetName) throw new UpdateError(`updates are not available for ${platform}-${architecture}`)
+  const binary = exactAsset(release, assetName)
+  // GitHub has exposed release asset digests since 2024. Requiring it prevents a
+  // legacy or malformed release from silently weakening update verification.
+  parseGitHubSha256(binary.digest, assetName)
+  return { binary, checksumFile: exactAsset(release, "SHA256SUMS") }
+}
+
+/** Accepts GitHub's `sha256:<hex>` format and bare hex from early API responses. */
+export function parseGitHubSha256(digest: string | undefined, assetName = "asset") {
+  const match = /^(?:sha256:)?([a-fA-F0-9]{64})$/.exec(digest?.trim() ?? "")
+  if (!match) throw new UpdateError(`release asset ${assetName} is missing a SHA-256 digest`)
+  return match[1]!.toLowerCase()
+}
+
+export function sha256(bytes: Uint8Array) {
+  return createHash("sha256").update(bytes).digest("hex")
+}
+
+/** Reads an exact filename from standard `sha256sum`/`shasum` output. */
+export function checksumForAsset(contents: string, assetName: string) {
+  let checksum: string | undefined
+  for (const rawLine of contents.replace(/\r\n/g, "\n").split("\n")) {
+    if (!rawLine.trim()) continue
+    const match = /^([a-fA-F0-9]{64})\s+\*?(.+)$/.exec(rawLine)
+    if (!match) throw new UpdateError("SHA256SUMS contains an invalid checksum entry")
+    if (match[2] !== assetName) continue
+    const parsed = match[1]!.toLowerCase()
+    if (checksum && checksum !== parsed) throw new UpdateError(`SHA256SUMS contains conflicting entries for ${assetName}`)
+    checksum = parsed
+  }
+  if (!checksum) throw new UpdateError(`SHA256SUMS does not contain ${assetName}`)
+  return checksum
+}
+
+export function verifyAssetBytes(bytes: Uint8Array, binary: ReleaseAsset, checksumContents: string) {
+  const actual = sha256(bytes)
+  const githubDigest = parseGitHubSha256(binary.digest, binary.name)
+  if (actual !== githubDigest) throw new UpdateError(`GitHub digest verification failed for ${binary.name}`)
+
+  const publishedChecksum = checksumForAsset(checksumContents, binary.name)
+  if (actual !== publishedChecksum) throw new UpdateError(`SHA256SUMS verification failed for ${binary.name}`)
+}
+
+export async function fetchLatestRelease(fetchImpl: FetchLike = globalThis.fetch) {
+  let response: Response
+  try {
+    response = await fetchImpl(githubLatestReleaseUrl, {
+      headers: { Accept: "application/vnd.github+json", "User-Agent": "convoy-updater" },
+    })
+  } catch (error) {
+    throw new UpdateError(`could not contact GitHub Releases: ${message(error)}`)
+  }
+  if (!response.ok) throw new UpdateError(`GitHub Releases responded with ${response.status} ${response.statusText}`.trim())
+  try {
+    return validateLatestRelease(await response.json())
+  } catch (error) {
+    if (error instanceof UpdateError) throw error
+    throw new UpdateError(`could not parse the latest GitHub release: ${message(error)}`)
+  }
+}
+
+export async function checkForUpdate(options: Omit<UpdateOptions, "checkOnly" | "executablePath" | "standalone" | "validateCandidate" | "fileOps" | "randomSuffix"> = {}) {
+  const current = parseSemVer(options.currentVersion ?? versionInfo.version)
+  if (!current) throw new UpdateError(`installed version is not valid SemVer: ${options.currentVersion ?? versionInfo.version}`)
+  const release = await fetchLatestRelease(options.fetch)
+  const assets = selectReleaseAssets(release, options.platform ?? process.platform, options.architecture ?? process.arch)
+  const currentVersion = formatSemVer(current)
+  const latestVersion = formatSemVer(release.version)
+  return {
+    status: compareSemVer(release.version, current) > 0 ? "update-available" : "up-to-date",
+    currentVersion,
+    latestVersion,
+    release,
+    assets,
+  } satisfies UpdateCheck
+}
+
+/** Runs the explicit update flow; source checkouts are deliberately never modified. */
+export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResult> {
+  const standalone = options.standalone ?? isOfficialStandaloneExecutable()
+  if (!standalone) {
+    return {
+      status: "source-install",
+      message: `convoy update only supports official release binaries; install one from ${releasesUrl} instead of modifying this source checkout`,
+    }
+  }
+
+  const check = await checkForUpdate(options)
+  if (check.status === "up-to-date" || options.checkOnly) return check
+
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const [binaryBytes, checksumContents] = await Promise.all([
+    downloadBytes(check.assets.binary, fetchImpl),
+    downloadText(check.assets.checksumFile, fetchImpl),
+  ])
+  verifyAssetBytes(binaryBytes, check.assets.binary, checksumContents)
+
+  const executablePath = options.executablePath ?? process.execPath
+  const fileOps = options.fileOps ?? defaultFileOps
+  const suffix = options.randomSuffix ?? randomUUID
+  const candidatePath = temporaryPath(executablePath, "candidate", suffix())
+  try {
+    await fileOps.writeFile(candidatePath, binaryBytes, { mode: 0o755 })
+    await fileOps.chmod(candidatePath, 0o755)
+    const valid = await (options.validateCandidate ?? validateCandidateExecutable)(candidatePath, check.latestVersion)
+    if (!valid) throw new UpdateError("downloaded binary did not report the expected version")
+
+    const existing = await fileOps.stat(executablePath)
+    await fileOps.chmod(candidatePath, existing.mode & 0o777)
+    await replaceExecutableAtomically(executablePath, candidatePath, { fileOps, randomSuffix: suffix })
+  } catch (error) {
+    await removeIfPresent(candidatePath, fileOps)
+    if (error instanceof UpdateError) throw error
+    throw new UpdateError(`could not install the update: ${message(error)}`)
+  }
+
+  return {
+    status: "updated",
+    currentVersion: check.currentVersion,
+    latestVersion: check.latestVersion,
+    assetName: check.assets.binary.name,
+  }
+}
+
+/**
+ * Makes a same-directory backup before atomically renaming the verified
+ * candidate over the executable. If replacement reports an error, restore the
+ * backup so callers never continue with a partial install.
+ */
+export async function replaceExecutableAtomically(
+  executablePath: string,
+  candidatePath: string,
+  options: { fileOps?: UpdateFileOps; randomSuffix?: () => string } = {},
+) {
+  const fileOps = options.fileOps ?? defaultFileOps
+  const backupPath = temporaryPath(executablePath, "backup", (options.randomSuffix ?? randomUUID)())
+  let backupCreated = false
+  try {
+    await fileOps.copyFile(executablePath, backupPath)
+    backupCreated = true
+    // POSIX rename replaces the destination atomically when both paths share a
+    // directory (which temporaryPath guarantees).
+    await fileOps.rename(candidatePath, executablePath)
+  } catch (error) {
+    if (backupCreated) {
+      try {
+        await fileOps.rename(backupPath, executablePath)
+        backupCreated = false
+      } catch {
+        // A failed POSIX rename leaves the original destination intact. The
+        // temporary backup is cleaned up below once that invariant holds.
+      }
+    }
+    throw error
+  } finally {
+    if (backupCreated) await removeIfPresent(backupPath, fileOps)
+  }
+}
+
+export function candidateDeclaresVersion(output: string, expectedVersion: string) {
+  const match = /^convoy\s+([^\s(]+)/m.exec(output)
+  const candidate = match ? parseSemVer(match[1]!) : undefined
+  const expected = parseSemVer(expectedVersion)
+  return Boolean(candidate && expected && formatSemVer(candidate) === formatSemVer(expected))
+}
+
+async function validateCandidateExecutable(path: string, expectedVersion: string) {
+  try {
+    const child = Bun.spawn([path, "--version"], { stdout: "pipe", stderr: "pipe" })
+    const [exitCode, stdout] = await Promise.all([child.exited, new Response(child.stdout).text()])
+    return exitCode === 0 && candidateDeclaresVersion(stdout, expectedVersion)
+  } catch {
+    return false
+  }
+}
+
+async function downloadBytes(asset: ReleaseAsset, fetchImpl: FetchLike) {
+  const response = await fetchAsset(asset, fetchImpl)
+  return new Uint8Array(await response.arrayBuffer())
+}
+
+async function downloadText(asset: ReleaseAsset, fetchImpl: FetchLike) {
+  return (await fetchAsset(asset, fetchImpl)).text()
+}
+
+async function fetchAsset(asset: ReleaseAsset, fetchImpl: FetchLike) {
+  let response: Response
+  try {
+    response = await fetchImpl(asset.browserDownloadUrl, { headers: { Accept: "application/octet-stream" } })
+  } catch (error) {
+    throw new UpdateError(`could not download ${asset.name}: ${message(error)}`)
+  }
+  if (!response.ok) throw new UpdateError(`could not download ${asset.name}: HTTP ${response.status}`)
+  return response
+}
+
+function exactAsset(release: PublishedRelease, name: string) {
+  const matches = release.assets.filter((asset) => asset.name === name)
+  if (matches.length !== 1) throw new UpdateError(`release ${release.tagName} does not contain exactly one ${name} asset`)
+  return matches[0]!
+}
+
+function temporaryPath(executablePath: string, label: string, suffix: string) {
+  return join(dirname(executablePath), `.${basename(executablePath)}.${label}-${suffix}`)
+}
+
+async function removeIfPresent(path: string, fileOps: UpdateFileOps) {
+  try {
+    await fileOps.rm(path, { force: true })
+  } catch {
+    // A failed cleanup cannot make the installed executable less safe.
+  }
+}
+
+function record(value: unknown, name: string): RecordValue {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new UpdateError(`${name} is malformed`)
+  return value as RecordValue
+}
+
+function stringProperty(value: RecordValue, property: string, name: string) {
+  const result = value[property]
+  if (typeof result !== "string" || !result) throw new UpdateError(`${name} is missing ${property}`)
+  return result
+}
+
+function message(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,25 @@
+declare const __CONVOY_VERSION__: string | undefined
+declare const __CONVOY_COMMIT__: string | undefined
+declare const __CONVOY_PLATFORM__: string | undefined
+
+export type VersionInfo = {
+  version: string
+  commit: string
+  platform: string
+}
+
+// The release build replaces these constants from package.json and Git. The
+// environment fallbacks keep `bun run src/main.ts` useful during development.
+const injectedVersion = typeof __CONVOY_VERSION__ === "string" ? __CONVOY_VERSION__ : undefined
+const injectedCommit = typeof __CONVOY_COMMIT__ === "string" ? __CONVOY_COMMIT__ : undefined
+const injectedPlatform = typeof __CONVOY_PLATFORM__ === "string" ? __CONVOY_PLATFORM__ : undefined
+
+export const versionInfo: VersionInfo = {
+  version: injectedVersion ?? process.env.npm_package_version ?? "0.0.0-development",
+  commit: injectedCommit ?? process.env.CONVOY_COMMIT ?? "unknown",
+  platform: injectedPlatform ?? process.env.CONVOY_PLATFORM ?? `${process.platform}-${process.arch}`,
+}
+
+export function formatVersion(info: VersionInfo = versionInfo) {
+  return `convoy ${info.version} (commit ${info.commit}, ${info.platform})`
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -84,6 +84,14 @@ describe("cli parsing", () => {
     if (command.type === "help") expect(command.text).toContain("convoy [prompt]")
   })
 
+  test("parses version and update commands without requiring a prompt", async () => {
+    expect(await parseCommand(["--version"])).toEqual({ type: "version" })
+    expect(await parseCommand(["-V"])).toEqual({ type: "version" })
+    expect(await parseCommand(["update"])).toEqual({ type: "update", checkOnly: false })
+    expect(await parseCommand(["update", "--check"])).toEqual({ type: "update", checkOnly: true })
+    await expect(parseCommand(["update", "--bogus"])).rejects.toThrow("usage: convoy update")
+  })
+
   test("parses the auth subcommand grammar", async () => {
     expect(await parseCommand(["auth"])).toEqual({ type: "auth", provider: "openrouter", action: "status" })
     expect(await parseCommand(["auth", "status"])).toEqual({ type: "auth", provider: "openrouter", action: "status" })

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -1,0 +1,419 @@
+import { chmod, copyFile, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+import { afterEach, describe, expect, test } from "bun:test"
+
+import {
+  UpdateError,
+  assetNameForPlatform,
+  candidateDeclaresVersion,
+  checkForUpdate,
+  checksumForAsset,
+  compareSemVer,
+  fetchLatestRelease,
+  githubLatestReleaseUrl,
+  isOfficialStandaloneExecutable,
+  parseSemVer,
+  replaceExecutableAtomically,
+  runUpdate,
+  selectReleaseAssets,
+  sha256,
+  validateLatestRelease,
+  verifyAssetBytes,
+  type ReleaseAsset,
+  type FetchLike,
+  type UpdateFileOps,
+} from "../src/update"
+
+const tempDirs: string[] = []
+const encoder = new TextEncoder()
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+function releaseFor(bytes: Uint8Array, options: { digest?: string; tag?: string; draft?: boolean; prerelease?: boolean; assets?: unknown[] } = {}) {
+  const binaryDigest = options.digest ?? `sha256:${sha256(bytes)}`
+  const binary = {
+    name: "convoy-darwin-arm64",
+    browser_download_url: "https://github.com/Inakitajes/convoy/releases/download/v0.2.0/convoy-darwin-arm64",
+    ...(options.digest === undefined || options.digest ? { digest: binaryDigest } : {}),
+  }
+  const checksum = {
+    name: "SHA256SUMS",
+    browser_download_url: "https://github.com/Inakitajes/convoy/releases/download/v0.2.0/SHA256SUMS",
+  }
+  return {
+    tag_name: options.tag ?? "v0.2.0",
+    draft: options.draft ?? false,
+    prerelease: options.prerelease ?? false,
+    published_at: "2026-07-30T15:30:00Z",
+    assets: options.assets ?? [binary, checksum],
+  }
+}
+
+function fetchFor(release: unknown, bytes: Uint8Array, checksum = `${sha256(bytes)}  convoy-darwin-arm64\n`): FetchLike {
+  return (async (input: string | URL | Request) => {
+    const url = String(input)
+    if (url === githubLatestReleaseUrl) return new Response(JSON.stringify(release), { status: 200 })
+    if (url.endsWith("SHA256SUMS")) return new Response(checksum, { status: 200 })
+    if (url.endsWith("convoy-darwin-arm64")) return new Response(bytes as unknown as BodyInit, { status: 200 })
+    return new Response("not found", { status: 404 })
+  }) as FetchLike
+}
+
+describe("semantic versions", () => {
+  test("parses and compares stable and prerelease versions", () => {
+    expect(parseSemVer("v1.2.3")).toMatchObject({ major: 1, minor: 2, patch: 3, prerelease: [] })
+    expect(parseSemVer("1.2.3-alpha.1")?.prerelease).toEqual(["alpha", "1"])
+    expect(parseSemVer("1.02.3")).toBeUndefined()
+    expect(parseSemVer("1.2.3-01")).toBeUndefined()
+    expect(compareSemVer("1.2.3", "1.2.3-rc.1")).toBe(1)
+    expect(compareSemVer("1.2.3-beta.2", "1.2.3-beta.11")).toBe(-1)
+    expect(compareSemVer("1.2.4", "1.2.3")).toBe(1)
+  })
+})
+
+describe("release validation", () => {
+  test("maps every supported runtime to the exact release asset", () => {
+    expect(assetNameForPlatform("darwin", "arm64")).toBe("convoy-darwin-arm64")
+    expect(assetNameForPlatform("darwin", "x64")).toBe("convoy-darwin-x64")
+    expect(assetNameForPlatform("linux", "arm64")).toBe("convoy-linux-arm64")
+    expect(assetNameForPlatform("linux", "x64")).toBe("convoy-linux-x64")
+    expect(assetNameForPlatform("win32", "x64")).toBeUndefined()
+  })
+
+  test("rejects malformed, draft, prerelease, and incomplete releases", () => {
+    const bytes = encoder.encode("new binary")
+    expect(() => validateLatestRelease({})).toThrow(UpdateError)
+    expect(() => validateLatestRelease(releaseFor(bytes, { draft: true }))).toThrow("not published")
+    expect(() => validateLatestRelease(releaseFor(bytes, { prerelease: true }))).toThrow("prerelease")
+    expect(() => validateLatestRelease(releaseFor(bytes, { tag: "v0.2.0-rc.1" }))).toThrow("stable semantic version")
+
+    const withoutDigest = validateLatestRelease(releaseFor(bytes, { digest: "" }))
+    expect(() => selectReleaseAssets(withoutDigest, "darwin", "arm64")).toThrow("missing a SHA-256 digest")
+
+    const withoutBinary = validateLatestRelease(releaseFor(bytes, { assets: [] }))
+    expect(() => selectReleaseAssets(withoutBinary, "darwin", "arm64")).toThrow("does not contain exactly one")
+  })
+
+  test("rejects asset download URLs that are not GitHub release hosts", () => {
+    const bytes = encoder.encode("new binary")
+    const offHost = releaseFor(bytes, {
+      assets: [
+        {
+          name: "convoy-darwin-arm64",
+          browser_download_url: "https://downloads.example.invalid/convoy-darwin-arm64",
+          digest: `sha256:${sha256(bytes)}`,
+        },
+        {
+          name: "SHA256SUMS",
+          browser_download_url: "https://github.com/Inakitajes/convoy/releases/download/v0.2.0/SHA256SUMS",
+        },
+      ],
+    })
+    expect(() => validateLatestRelease(offHost)).toThrow("unsafe download URL")
+
+    const httpUrl = releaseFor(bytes, {
+      assets: [
+        {
+          name: "convoy-darwin-arm64",
+          browser_download_url: "http://github.com/Inakitajes/convoy/releases/download/v0.2.0/convoy-darwin-arm64",
+          digest: `sha256:${sha256(bytes)}`,
+        },
+        { name: "SHA256SUMS", browser_download_url: "https://github.com/Inakitajes/convoy/releases/download/v0.2.0/SHA256SUMS" },
+      ],
+    })
+    expect(() => validateLatestRelease(httpUrl)).toThrow("unsafe download URL")
+  })
+})
+
+describe("asset verification", () => {
+  test("requires both GitHub's digest and SHA256SUMS to match", () => {
+    const bytes = encoder.encode("verified binary")
+    const binary: ReleaseAsset = {
+      name: "convoy-darwin-arm64",
+      browserDownloadUrl: "https://github.com/Inakitajes/convoy/releases/download/v0.2.0/convoy-darwin-arm64",
+      digest: `sha256:${sha256(bytes)}`,
+    }
+    const sums = `${sha256(bytes)}  convoy-darwin-arm64\n`
+
+    expect(() => verifyAssetBytes(bytes, binary, sums)).not.toThrow()
+    expect(checksumForAsset(sums, binary.name)).toBe(sha256(bytes))
+    expect(() => verifyAssetBytes(bytes, binary, `${"0".repeat(64)}  convoy-darwin-arm64\n`)).toThrow("SHA256SUMS verification failed")
+    expect(() => verifyAssetBytes(bytes, { ...binary, digest: `sha256:${"0".repeat(64)}` }, sums)).toThrow("GitHub digest verification failed")
+  })
+
+  test("checks candidate --version output exactly", () => {
+    expect(candidateDeclaresVersion("convoy 0.2.0 (commit abc, darwin-arm64)\n", "0.2.0")).toBe(true)
+    expect(candidateDeclaresVersion("convoy 0.2.1 (commit abc, darwin-arm64)\n", "0.2.0")).toBe(false)
+    expect(candidateDeclaresVersion("not convoy 0.2.0", "0.2.0")).toBe(false)
+  })
+})
+
+describe("safe updater", () => {
+  test("recognizes modern and Bun 1.3 standalone runtime signals", () => {
+    expect(isOfficialStandaloneExecutable({ isStandaloneExecutable: true })).toBe(true)
+    expect(isOfficialStandaloneExecutable({ isStandaloneExecutable: false, embeddedFiles: [{}] })).toBe(false)
+    expect(isOfficialStandaloneExecutable({ main: "/$bunfs/root/probe.ts" })).toBe(true)
+    expect(isOfficialStandaloneExecutable({ main: "C:\\$bunfs\\root\\probe.ts" })).toBe(true)
+    expect(isOfficialStandaloneExecutable({ embeddedFiles: [{}] })).toBe(true)
+    expect(isOfficialStandaloneExecutable({ embeddedFiles: [] })).toBe(false)
+  })
+
+  test("recognizes an actual compiled Bun executable", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-standalone-probe-"))
+    tempDirs.push(directory)
+    const entrypoint = join(directory, "probe.ts")
+    const executable = join(directory, "probe")
+    await writeFile(
+      entrypoint,
+      `import { isOfficialStandaloneExecutable } from ${JSON.stringify(resolve(process.cwd(), "src/update.ts"))}; process.stdout.write(String(isOfficialStandaloneExecutable()));`,
+    )
+    const result = await Bun.build({
+      entrypoints: [entrypoint],
+      compile: { target: `bun-${process.platform}-${process.arch}` as Bun.Build.CompileTarget, outfile: executable },
+    })
+
+    expect(result.success).toBe(true)
+    const child = Bun.spawn([executable], { stdout: "pipe", stderr: "pipe" })
+    expect(await child.exited).toBe(0)
+    expect(await new Response(child.stdout).text()).toBe("true")
+  })
+
+  test("does not query GitHub or modify a source checkout", async () => {
+    let requests = 0
+    const result = await runUpdate({
+      standalone: false,
+      fetch: (async () => {
+        requests++
+        return new Response()
+      }) as FetchLike,
+    })
+
+    expect(result.status).toBe("source-install")
+    expect(requests).toBe(0)
+  })
+
+  test("checks for a newer stable release without modifying the executable", async () => {
+    const bytes = encoder.encode("new binary")
+    const result = await checkForUpdate({
+      currentVersion: "0.1.0",
+      platform: "darwin",
+      architecture: "arm64",
+      fetch: fetchFor(releaseFor(bytes), bytes),
+    })
+
+    expect(result).toMatchObject({ status: "update-available", currentVersion: "0.1.0", latestVersion: "0.2.0" })
+    expect(result.assets.binary.name).toBe("convoy-darwin-arm64")
+  })
+
+  test("reports up-to-date when the installed version is not older than the release", async () => {
+    const bytes = encoder.encode("new binary")
+    const same = await checkForUpdate({
+      currentVersion: "0.2.0",
+      platform: "darwin",
+      architecture: "arm64",
+      fetch: fetchFor(releaseFor(bytes), bytes),
+    })
+    expect(same).toMatchObject({ status: "up-to-date", currentVersion: "0.2.0", latestVersion: "0.2.0" })
+
+    const newer = await checkForUpdate({
+      currentVersion: "0.3.0",
+      platform: "darwin",
+      architecture: "arm64",
+      fetch: fetchFor(releaseFor(bytes), bytes),
+    })
+    expect(newer.status).toBe("up-to-date")
+  })
+
+  test("fetchLatestRelease surfaces GitHub HTTP errors as UpdateError", async () => {
+    const fetchImpl = (async () => new Response("rate limited", { status: 403, statusText: "Forbidden" })) as FetchLike
+    await expect(fetchLatestRelease(fetchImpl)).rejects.toThrow(UpdateError)
+    await expect(fetchLatestRelease(fetchImpl)).rejects.toThrow("403")
+  })
+
+  test("checkOnly never downloads or installs even when an update is available", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-update-checkonly-"))
+    tempDirs.push(directory)
+    const executablePath = join(directory, "convoy")
+    const bytes = encoder.encode("new binary")
+    await writeFile(executablePath, "old binary", { mode: 0o755 })
+    await chmod(executablePath, 0o755)
+
+    let downloads = 0
+    const guardedFetch: FetchLike = (async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url === githubLatestReleaseUrl) return new Response(JSON.stringify(releaseFor(bytes)), { status: 200 })
+      downloads++
+      return new Response("not found", { status: 404 })
+    }) as FetchLike
+
+    const result = await runUpdate({
+      standalone: true,
+      checkOnly: true,
+      currentVersion: "0.1.0",
+      platform: "darwin",
+      architecture: "arm64",
+      executablePath,
+      fetch: guardedFetch,
+    })
+    expect(result).toMatchObject({ status: "update-available", currentVersion: "0.1.0", latestVersion: "0.2.0" })
+    expect(downloads).toBe(0)
+    expect(await readFile(executablePath, "utf8")).toBe("old binary")
+  })
+
+  test("does not replace the executable when the candidate fails version validation", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-update-badcandidate-"))
+    tempDirs.push(directory)
+    const executablePath = join(directory, "convoy")
+    const bytes = encoder.encode("new binary")
+    await writeFile(executablePath, "old binary", { mode: 0o755 })
+    await chmod(executablePath, 0o755)
+
+    await expect(
+      runUpdate({
+        standalone: true,
+        currentVersion: "0.1.0",
+        platform: "darwin",
+        architecture: "arm64",
+        executablePath,
+        fetch: fetchFor(releaseFor(bytes), bytes),
+        validateCandidate: async () => false,
+        randomSuffix: () => "badcandidate",
+      }),
+    ).rejects.toThrow("did not report the expected version")
+    expect(await readFile(executablePath, "utf8")).toBe("old binary")
+    // No candidate or backup leftovers remain in the install directory.
+    expect(await readdir(directory)).toEqual(["convoy"])
+  })
+
+  test("replaceExecutableAtomically restores the previous binary when the final rename fails", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-atomic-restore-"))
+    tempDirs.push(directory)
+    const executablePath = join(directory, "convoy")
+    const candidatePath = join(directory, ".convoy.candidate-restore")
+    await writeFile(executablePath, "original", { mode: 0o755 })
+    await chmod(executablePath, 0o755)
+    await writeFile(candidatePath, "replacement", { mode: 0o755 })
+
+    let candidateRenames = 0
+    const guardedFileOps: UpdateFileOps = {
+      chmod,
+      copyFile,
+      rename: async (from, to) => {
+        if (String(from).includes(".candidate-") && to === executablePath) {
+          candidateRenames++
+          throw new Error("rename blocked")
+        }
+        await rename(from, to)
+      },
+      rm,
+      stat,
+      writeFile,
+    }
+
+    await expect(
+      replaceExecutableAtomically(executablePath, candidatePath, { fileOps: guardedFileOps, randomSuffix: () => "restore" }),
+    ).rejects.toThrow("rename blocked")
+    expect(candidateRenames).toBe(1)
+    // The backup was restored over the executable, so the original content survives.
+    expect(await readFile(executablePath, "utf8")).toBe("original")
+    // The temporary backup is cleaned up; the candidate is left for the caller
+    // (runUpdate owns candidate cleanup via removeIfPresent).
+    expect(await readdir(directory)).toEqual([".convoy.candidate-restore", "convoy"])
+  })
+
+  test("installs a verified candidate through a same-directory atomic rename", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-update-"))
+    tempDirs.push(directory)
+    const executablePath = join(directory, "convoy")
+    const bytes = encoder.encode("new binary")
+    await writeFile(executablePath, "old binary", { mode: 0o755 })
+    await chmod(executablePath, 0o755)
+
+    const result = await runUpdate({
+      standalone: true,
+      currentVersion: "0.1.0",
+      platform: "darwin",
+      architecture: "arm64",
+      executablePath,
+      fetch: fetchFor(releaseFor(bytes), bytes),
+      validateCandidate: async (candidate, expected) => {
+        expect(candidate.startsWith(directory)).toBe(true)
+        expect(expected).toBe("0.2.0")
+        expect(await readFile(candidate, "utf8")).toBe("new binary")
+        return true
+      },
+      randomSuffix: () => "test",
+    })
+
+    expect(result).toMatchObject({ status: "updated", latestVersion: "0.2.0" })
+    expect(await readFile(executablePath, "utf8")).toBe("new binary")
+    expect(await readdir(directory)).toEqual(["convoy"])
+  })
+
+  test("leaves the current executable intact after network, hash, or replacement failures", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-update-failure-"))
+    tempDirs.push(directory)
+    const executablePath = join(directory, "convoy")
+    const bytes = encoder.encode("new binary")
+    await writeFile(executablePath, "old binary", { mode: 0o755 })
+    await chmod(executablePath, 0o755)
+
+    const release = releaseFor(bytes)
+    await expect(
+      runUpdate({
+        standalone: true,
+        currentVersion: "0.1.0",
+        platform: "darwin",
+        architecture: "arm64",
+        executablePath,
+        fetch: (async (input: string | URL | Request) => {
+          if (String(input) === githubLatestReleaseUrl) return new Response(JSON.stringify(release), { status: 200 })
+          throw new Error("network unavailable")
+        }) as FetchLike,
+      }),
+    ).rejects.toThrow("could not download")
+    expect(await readFile(executablePath, "utf8")).toBe("old binary")
+
+    await expect(
+      runUpdate({
+        standalone: true,
+        currentVersion: "0.1.0",
+        platform: "darwin",
+        architecture: "arm64",
+        executablePath,
+        fetch: fetchFor(release, encoder.encode("tampered binary")),
+      }),
+    ).rejects.toThrow("digest verification failed")
+    expect(await readFile(executablePath, "utf8")).toBe("old binary")
+
+    const guardedFileOps: UpdateFileOps = {
+      chmod,
+      copyFile,
+      rename: async (from, to) => {
+        if (String(from).includes(".candidate-") && to === executablePath) throw new Error("permission denied")
+        await rename(from, to)
+      },
+      rm,
+      stat,
+      writeFile,
+    }
+    await expect(
+      runUpdate({
+        standalone: true,
+        currentVersion: "0.1.0",
+        platform: "darwin",
+        architecture: "arm64",
+        executablePath,
+        fetch: fetchFor(release, bytes),
+        fileOps: guardedFileOps,
+        validateCandidate: async () => true,
+        randomSuffix: () => "failure",
+      }),
+    ).rejects.toThrow("could not install the update")
+    expect(await readFile(executablePath, "utf8")).toBe("old binary")
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "noEmit": true,
     "verbatimModuleSyntax": true
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
- add release.yml workflow to validate tags, test, cross-compile for darwin/linux arm64/x64, and publish releases
- add build.ts script for local and release builds with injected version, commit, and platform metadata
- add version.ts module to format and expose build metadata
- add update.ts module with SemVer parsing, release validation, checksum verification, and atomic binary replacement
- add update command to CLI with check-only and apply modes
- add comprehensive test coverage for SemVer comparison, release validation, and update logic