### PR TITLE
test(ci): remove host shell and git identity dependencies

### DIFF
--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -315,6 +315,8 @@ describe("unsigned commits", () => {
     const dir = await mkdtemp(join(tmpdir(), "convoy-unsigned-"))
     dirs.push(dir)
     await git(["init", "-q", "-b", "main"], dir)
+    await git(["config", "user.name", "convoy-test"], dir)
+    await git(["config", "user.email", "convoy-test@example.invalid"], dir)
     await git(["config", "commit.gpgsign", "true"], dir)
     await git(["config", "gpg.format", "ssh"], dir)
     await git(["config", "user.signingkey", join(dir, "nonexistent.pub")], dir)

--- a/test/opencode.test.ts
+++ b/test/opencode.test.ts
@@ -16,7 +16,7 @@ describe("session terminal command", () => {
       expect(command).toContain(" && cd ")
       expect(command).toContain(" && touch ")
 
-      const child = Bun.spawn(["zsh", "-c", command], { stdout: "ignore", stderr: "ignore" })
+      const child = Bun.spawn(["sh", "-c", command], { stdout: "ignore", stderr: "ignore" })
       expect(await child.exited).not.toBe(0)
       expect(await Bun.file(marker).exists()).toBe(false)
     } finally {


### PR DESCRIPTION
Makes the release workflow test suite portable to GitHub's Ubuntu runners: the shell-command test uses POSIX sh, and the unsigned-commit fixture configures its own Git identity.