### PR TITLE
fix(release): prevent subprocess hangs and add release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    uses: ./.github/workflows/verify.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,21 +6,26 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
-    name: Build and publish release
+  verify:
+    uses: ./.github/workflows/verify.yml
+
+  build-linux:
+    name: Build release binaries on Linux
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Check out tag
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Bun
         # Pinned: the compiled binaries embed this Bun runtime, so the release
         # must ship the version the test suite ran against, not "latest".
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.14
 
@@ -48,17 +53,68 @@ jobs:
             fi
           done
 
-      - name: Typecheck
-        run: bun run typecheck
-
-      - name: Test
-        run: bun test
-
       - name: Build release binaries
         run: bun run build:release
 
       - name: Smoke-test Linux binary
         run: ./dist/convoy-linux-x64 --version
+
+      - name: Upload release binaries
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-binaries
+          path: dist/convoy-*
+          if-no-files-found: error
+
+  smoke-darwin:
+    name: Smoke-test release binaries on Darwin ARM64
+    runs-on: macos-14
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out tag
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Bun
+        # Keep this pin aligned with verification because compiled binaries embed it.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Install locked dependencies
+        run: bun install --frozen-lockfile --os='*' --cpu='*'
+
+      - name: Verify cross-platform native dependencies
+        run: |
+          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            if [ ! -f "node_modules/@opentui/core-$target/package.json" ]; then
+              echo "missing @opentui/core-$target; cannot build a working $target binary" >&2
+              exit 1
+            fi
+          done
+
+      - name: Build release binaries
+        run: bun run build:release
+
+      - name: Smoke-test Darwin ARM64 binary
+        # darwin-x64 and linux-arm64 remain cross-target-only: their native
+        # runners are not part of this release workflow.
+        run: ./dist/convoy-darwin-arm64 --version
+
+  publish:
+    name: Publish GitHub Release
+    needs: [verify, build-linux, smoke-darwin]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download release binaries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-binaries
+          path: dist
 
       - name: Generate checksums
         run: |
@@ -66,10 +122,12 @@ jobs:
           shasum -a 256 convoy-darwin-arm64 convoy-darwin-x64 convoy-linux-arm64 convoy-linux-x64 > SHA256SUMS
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           generate_release_notes: true
           fail_on_unmatched_files: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          make_latest: ${{ !contains(github.ref_name, '-') }}
           files: |
             dist/convoy-darwin-arm64
             dist/convoy-darwin-x64

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,49 @@
+name: Verify
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-14]
+
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - name: Set up Bun
+        # The compiled binaries embed Bun, so verification must use the same runtime as release.
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: 1.3.14
+
+      - name: Install locked dependencies
+        run: bun install --frozen-lockfile --os='*' --cpu='*'
+
+      - name: Verify cross-platform native dependencies
+        # OpenTUI resolves each target dynamically, so a missing package can
+        # produce a binary that reports a version but cannot open the TUI.
+        run: |
+          for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do
+            if [ ! -f "node_modules/@opentui/core-$target/package.json" ]; then
+              echo "missing @opentui/core-$target; cannot build a working $target binary" >&2
+              exit 1
+            fi
+          done
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Build local binary
+        run: bun run build

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ convoy update
 
 Updates are explicit: Convoy does not make network calls when it starts. `convoy update` only changes official standalone release binaries; it never modifies a source checkout, `~/.convoy`, project configuration, runs, or worktrees.
 
+Release candidates use prerelease tags such as `v0.2.0-rc.1`. They are published as GitHub prereleases and never replace the stable `latest` release; install one explicitly from its release tag when testing it.
+
 From the root of the target repo, ideally on a working branch:
 
 ```bash

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,6 +1,8 @@
 import { mkdir } from "node:fs/promises"
 import { resolve } from "node:path"
 
+import { parseSemVer } from "../src/update"
+
 type PackageManifest = { version?: unknown }
 
 type BuildTarget = {
@@ -26,7 +28,7 @@ const release = process.argv.slice(2).join(" ") === "--release"
 if (!release && process.argv.length > 2) throw new Error("usage: bun run scripts/build.ts [--release]")
 
 const manifest = (await Bun.file("package.json").json()) as PackageManifest
-if (typeof manifest.version !== "string" || !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(manifest.version)) {
+if (typeof manifest.version !== "string" || !parseSemVer(manifest.version)) {
   throw new Error("package.json must contain a valid SemVer version")
 }
 
@@ -49,8 +51,9 @@ for (const target of release ? releaseTargets : [localTarget]) {
 }
 
 async function gitCommit() {
-  const child = Bun.spawn(["git", "rev-parse", "HEAD"], { stdout: "pipe", stderr: "pipe" })
+  const child = Bun.spawn(["git", "rev-parse", "HEAD"], { stdout: "pipe", stderr: "ignore" })
+  const stdout = new Response(child.stdout).text()
   if ((await child.exited) !== 0) return "unknown"
-  const commit = (await new Response(child.stdout).text()).trim()
+  const commit = (await stdout).trim()
   return /^[0-9a-f]{40}$/i.test(commit) ? commit : "unknown"
 }

--- a/src/update.ts
+++ b/src/update.ts
@@ -7,6 +7,11 @@ import { versionInfo } from "./version"
 export const githubLatestReleaseUrl = "https://api.github.com/repos/Inakitajes/convoy/releases/latest"
 export const releasesUrl = "https://github.com/Inakitajes/convoy/releases"
 
+const latestReleaseTimeoutMs = 15_000
+const assetDownloadTimeoutMs = 300_000
+const candidateValidationTimeoutMs = 10_000
+const candidateKillGraceMs = 2_000
+
 /**
  * GitHub release asset URLs are served from `github.com` and redirect to
  * `objects.githubusercontent.com`. Restricting downloads to these hosts keeps a
@@ -268,20 +273,23 @@ export function verifyAssetBytes(bytes: Uint8Array, binary: ReleaseAsset, checks
 }
 
 export async function fetchLatestRelease(fetchImpl: FetchLike = globalThis.fetch) {
-  let response: Response
   try {
-    response = await fetchImpl(githubLatestReleaseUrl, {
-      headers: { Accept: "application/vnd.github+json", "User-Agent": "convoy-updater" },
+    return await withTimeout(latestReleaseTimeoutMs, "GitHub Releases request", async (signal) => {
+      const response = await fetchImpl(githubLatestReleaseUrl, {
+        headers: { Accept: "application/vnd.github+json", "User-Agent": "convoy-updater" },
+        signal,
+      })
+      if (!response.ok) throw new UpdateError(`GitHub Releases responded with ${response.status} ${response.statusText}`.trim())
+      try {
+        return validateLatestRelease(await response.json())
+      } catch (error) {
+        if (error instanceof UpdateError) throw error
+        throw new UpdateError(`could not parse the latest GitHub release: ${message(error)}`)
+      }
     })
   } catch (error) {
-    throw new UpdateError(`could not contact GitHub Releases: ${message(error)}`)
-  }
-  if (!response.ok) throw new UpdateError(`GitHub Releases responded with ${response.status} ${response.statusText}`.trim())
-  try {
-    return validateLatestRelease(await response.json())
-  } catch (error) {
     if (error instanceof UpdateError) throw error
-    throw new UpdateError(`could not parse the latest GitHub release: ${message(error)}`)
+    throw new UpdateError(`could not contact GitHub Releases: ${message(error)}`)
   }
 }
 
@@ -304,6 +312,7 @@ export async function checkForUpdate(options: Omit<UpdateOptions, "checkOnly" | 
 /** Runs the explicit update flow; source checkouts are deliberately never modified. */
 export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResult> {
   const standalone = options.standalone ?? isOfficialStandaloneExecutable()
+  if (options.checkOnly) return checkForUpdate(options)
   if (!standalone) {
     return {
       status: "source-install",
@@ -312,7 +321,7 @@ export async function runUpdate(options: UpdateOptions = {}): Promise<UpdateResu
   }
 
   const check = await checkForUpdate(options)
-  if (check.status === "up-to-date" || options.checkOnly) return check
+  if (check.status === "up-to-date") return check
 
   const fetchImpl = options.fetch ?? globalThis.fetch
   const [binaryBytes, checksumContents] = await Promise.all([
@@ -391,33 +400,68 @@ export function candidateDeclaresVersion(output: string, expectedVersion: string
 }
 
 async function validateCandidateExecutable(path: string, expectedVersion: string) {
+  let child: Bun.Subprocess<"ignore", "pipe", "ignore"> | undefined
+  let exited = false
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  let killTimer: ReturnType<typeof setTimeout> | undefined
+  let timedOut = false
   try {
-    const child = Bun.spawn([path, "--version"], { stdout: "pipe", stderr: "pipe" })
-    const [exitCode, stdout] = await Promise.all([child.exited, new Response(child.stdout).text()])
-    return exitCode === 0 && candidateDeclaresVersion(stdout, expectedVersion)
+    child = Bun.spawn([path, "--version"], { stdout: "pipe", stderr: "ignore" })
+    const kill = (signal: NodeJS.Signals) => {
+      try {
+        child?.kill(signal)
+      } catch {
+        // The candidate may have exited while the timeout was firing.
+      }
+    }
+    timeout = setTimeout(() => {
+      timedOut = true
+      kill("SIGTERM")
+      killTimer = setTimeout(() => kill("SIGKILL"), candidateKillGraceMs)
+      killTimer.unref?.()
+    }, candidateValidationTimeoutMs)
+    timeout.unref?.()
+
+    const stdoutPromise = new Response(child.stdout).text()
+    const exitCode = await child.exited
+    exited = true
+    const stdout = await stdoutPromise
+    return !timedOut && exitCode === 0 && candidateDeclaresVersion(stdout, expectedVersion)
   } catch {
     return false
+  } finally {
+    if (timeout) clearTimeout(timeout)
+    if (killTimer) clearTimeout(killTimer)
+    if (child && !exited) {
+      try {
+        child.kill("SIGKILL")
+      } catch {
+        // The candidate may have exited after the read failed.
+      }
+      await child.exited
+    }
   }
 }
 
 async function downloadBytes(asset: ReleaseAsset, fetchImpl: FetchLike) {
-  const response = await fetchAsset(asset, fetchImpl)
-  return new Uint8Array(await response.arrayBuffer())
+  return new Uint8Array(await fetchAsset(asset, fetchImpl, (response) => response.arrayBuffer()))
 }
 
 async function downloadText(asset: ReleaseAsset, fetchImpl: FetchLike) {
-  return (await fetchAsset(asset, fetchImpl)).text()
+  return fetchAsset(asset, fetchImpl, (response) => response.text())
 }
 
-async function fetchAsset(asset: ReleaseAsset, fetchImpl: FetchLike) {
-  let response: Response
+async function fetchAsset<T>(asset: ReleaseAsset, fetchImpl: FetchLike, consume: (response: Response) => Promise<T>) {
   try {
-    response = await fetchImpl(asset.browserDownloadUrl, { headers: { Accept: "application/octet-stream" } })
+    return await withTimeout(assetDownloadTimeoutMs, `download of ${asset.name}`, async (signal) => {
+      const response = await fetchImpl(asset.browserDownloadUrl, { headers: { Accept: "application/octet-stream" }, signal })
+      if (!response.ok) throw new UpdateError(`could not download ${asset.name}: HTTP ${response.status}`)
+      return consume(response)
+    })
   } catch (error) {
+    if (error instanceof UpdateError) throw error
     throw new UpdateError(`could not download ${asset.name}: ${message(error)}`)
   }
-  if (!response.ok) throw new UpdateError(`could not download ${asset.name}: HTTP ${response.status}`)
-  return response
 }
 
 function exactAsset(release: PublishedRelease, name: string) {
@@ -435,6 +479,23 @@ async function removeIfPresent(path: string, fileOps: UpdateFileOps) {
     await fileOps.rm(path, { force: true })
   } catch {
     // A failed cleanup cannot make the installed executable less safe.
+  }
+}
+
+async function withTimeout<T>(timeoutMs: number, operation: string, callback: (signal: AbortSignal) => Promise<T>) {
+  const controller = new AbortController()
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort()
+  }, timeoutMs)
+  try {
+    return await callback(controller.signal)
+  } catch (error) {
+    if (timedOut) throw new UpdateError(`${operation} timed out after ${timeoutMs / 1_000}s`)
+    throw error
+  } finally {
+    clearTimeout(timeout)
   }
 }
 

--- a/test/release-workflow.test.ts
+++ b/test/release-workflow.test.ts
@@ -1,0 +1,72 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+
+import { describe, expect, test } from "bun:test"
+
+const workflowsDirectory = join(import.meta.dir, "..", ".github", "workflows")
+
+function workflow(name: string) {
+  return readFile(join(workflowsDirectory, name), "utf8")
+}
+
+function expectPinnedActionLines(contents: string) {
+  const actionLines = contents
+    .split("\n")
+    .filter((line) => line.trimStart().startsWith("uses:") && !line.includes("uses: ./"))
+  expect(actionLines.length).toBeGreaterThan(0)
+  for (const line of actionLines) {
+    expect(line).toMatch(/uses:\s+[^@\s]+@[a-f0-9]{40}\s+# v\d/i)
+  }
+}
+
+describe("release workflow", () => {
+  test("publishes prerelease tags without making them latest", async () => {
+    const release = await workflow("release.yml")
+
+    expect(release).toContain("prerelease: ${{ contains(github.ref_name, '-') }}")
+    expect(release).toContain("make_latest: ${{ !contains(github.ref_name, '-') }}")
+  })
+
+  test("smoke-tests native Linux and Darwin release binaries", async () => {
+    const release = await workflow("release.yml")
+
+    expect(release).toContain("./dist/convoy-linux-x64 --version")
+    expect(release).toContain("./dist/convoy-darwin-arm64 --version")
+    expect(release).toContain("darwin-x64")
+    expect(release).toContain("linux-arm64")
+  })
+})
+
+describe("pull-request CI workflow", () => {
+  test("validates main and pull requests on both supported runner platforms", async () => {
+    const ci = await workflow("ci.yml")
+    const verify = await workflow("verify.yml")
+
+    expect(ci).toContain("pull_request:\n    branches:\n      - main")
+    expect(ci).toContain("push:\n    branches:\n      - main")
+    expect(ci).toContain("permissions:\n  contents: read")
+    expect(ci).toContain("concurrency:")
+    expect(ci).toContain("cancel-in-progress: true")
+    expect(ci).toContain("uses: ./.github/workflows/verify.yml")
+    expect(verify).toContain("matrix:")
+    expect(verify).toContain("ubuntu-latest")
+    expect(verify).toContain("macos-14")
+    expect(verify).toContain("bun-version: 1.3.14")
+    expect(verify).toContain("bun install --frozen-lockfile --os='*' --cpu='*'")
+    expect(verify).toContain("for target in darwin-arm64 darwin-x64 linux-arm64 linux-x64; do")
+    expect(verify).toContain("bun run typecheck")
+    expect(verify).toContain("bun test")
+    expect(verify).toContain("bun run build")
+  })
+})
+
+describe("GitHub Action supply-chain pins", () => {
+  test("uses version-commented immutable action SHAs and enables Dependabot", async () => {
+    expectPinnedActionLines(await workflow("release.yml"))
+    expectPinnedActionLines(await workflow("verify.yml"))
+
+    const dependabot = await readFile(join(import.meta.dir, "..", ".github", "dependabot.yml"), "utf8")
+    expect(dependabot).toContain('package-ecosystem: "github-actions"')
+    expect(dependabot).toContain('directory: "/"')
+  })
+})

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -1,4 +1,4 @@
-import { chmod, copyFile, mkdtemp, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises"
+import { chmod, copyFile, mkdtemp, readFile, readdir, rename, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 
@@ -28,6 +28,7 @@ import {
 
 const tempDirs: string[] = []
 const encoder = new TextEncoder()
+const realSetTimeout = globalThis.setTimeout
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
@@ -63,15 +64,106 @@ function fetchFor(release: unknown, bytes: Uint8Array, checksum = `${sha256(byte
   }) as FetchLike
 }
 
+type Settled<T> = { status: "resolved"; value: T } | { status: "rejected"; error: unknown } | { status: "pending" }
+
+function wait(ms: number) {
+  return new Promise<void>((resolve) => realSetTimeout(resolve, ms))
+}
+
+async function settleWithin<T>(operation: Promise<T>, ms = 1_000): Promise<Settled<T>> {
+  return Promise.race([
+    operation.then<Settled<T>, Settled<T>>(
+      (value) => ({ status: "resolved", value }),
+      (error: unknown) => ({ status: "rejected", error }),
+    ),
+    wait(ms).then<Settled<T>>(() => ({ status: "pending" })),
+  ])
+}
+
+function useImmediateTimeouts(delay = 0) {
+  const originalSetTimeout = globalThis.setTimeout
+  globalThis.setTimeout = ((handler: () => void) => originalSetTimeout(handler, delay)) as typeof setTimeout
+  return () => {
+    globalThis.setTimeout = originalSetTimeout
+  }
+}
+
+async function terminateRecordedProcesses(pidPath: string) {
+  let pids: number[] = []
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      pids = (await readFile(pidPath, "utf8"))
+        .split("\n")
+        .map(Number)
+        .filter((pid) => Number.isInteger(pid) && pid > 0)
+      if (pids.length > 0) break
+    } catch {
+      // The candidate has not reached its first instruction yet.
+    }
+    await wait(25)
+  }
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGKILL")
+    } catch {
+      // The candidate may have exited while the test was reading its PID.
+    }
+  }
+  return pids
+}
+
+function processIsAlive(pid: number) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function expectTimeoutError(outcome: Settled<unknown>) {
+  if (outcome.status !== "rejected") throw new Error("operation did not reject after its deadline")
+  expect(outcome.error).toBeInstanceOf(UpdateError)
+  expect(String(outcome.error)).toContain("timed out")
+}
+
 describe("semantic versions", () => {
   test("parses and compares stable and prerelease versions", () => {
     expect(parseSemVer("v1.2.3")).toMatchObject({ major: 1, minor: 2, patch: 3, prerelease: [] })
     expect(parseSemVer("1.2.3-alpha.1")?.prerelease).toEqual(["alpha", "1"])
     expect(parseSemVer("1.02.3")).toBeUndefined()
     expect(parseSemVer("1.2.3-01")).toBeUndefined()
+    expect(parseSemVer("1.2.3-.")).toBeUndefined()
     expect(compareSemVer("1.2.3", "1.2.3-rc.1")).toBe(1)
     expect(compareSemVer("1.2.3-beta.2", "1.2.3-beta.11")).toBe(-1)
     expect(compareSemVer("1.2.4", "1.2.3")).toBe(1)
+  })
+})
+
+describe("release builds", () => {
+  test("rejects a manifest version that the updater rejects", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-invalid-build-version-"))
+    tempDirs.push(directory)
+    const root = process.cwd()
+    await Promise.all([
+      symlink(resolve(root, "src"), join(directory, "src"), "dir"),
+      symlink(resolve(root, "node_modules"), join(directory, "node_modules"), "dir"),
+      writeFile(join(directory, "package.json"), JSON.stringify({ name: "convoy-invalid-version", version: "0.01.0", type: "module" })),
+    ])
+
+    const build = Bun.spawn([process.execPath, "run", resolve(root, "scripts/build.ts")], {
+      cwd: directory,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    const [exitCode, stdout, stderr] = await Promise.all([
+      build.exited,
+      new Response(build.stdout).text(),
+      new Response(build.stderr).text(),
+    ])
+
+    expect(exitCode).not.toBe(0)
+    expect(`${stdout}\n${stderr}`).toContain("valid SemVer")
   })
 })
 
@@ -196,6 +288,25 @@ describe("safe updater", () => {
     expect(requests).toBe(0)
   })
 
+  test("checks for updates from a source checkout without modifying it", async () => {
+    const bytes = encoder.encode("new binary")
+    let requests = 0
+    const result = await runUpdate({
+      standalone: false,
+      checkOnly: true,
+      currentVersion: "0.0.0-development",
+      platform: "darwin",
+      architecture: "arm64",
+      fetch: (async (input: string | URL | Request) => {
+        requests++
+        return fetchFor(releaseFor(bytes), bytes)(input)
+      }) as FetchLike,
+    })
+
+    expect(result).toMatchObject({ status: "update-available", currentVersion: "0.0.0-development", latestVersion: "0.2.0" })
+    expect(requests).toBe(1)
+  })
+
   test("checks for a newer stable release without modifying the executable", async () => {
     const bytes = encoder.encode("new binary")
     const result = await checkForUpdate({
@@ -234,6 +345,64 @@ describe("safe updater", () => {
     await expect(fetchLatestRelease(fetchImpl)).rejects.toThrow("403")
   })
 
+  test("times out while waiting for GitHub Release response headers", async () => {
+    const fetchImpl = ((_input: string | URL | Request, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true })
+      })
+    }) as FetchLike
+    const restoreTimeouts = useImmediateTimeouts()
+    let outcome: Settled<Awaited<ReturnType<typeof fetchLatestRelease>>>
+    try {
+      outcome = await settleWithin(fetchLatestRelease(fetchImpl))
+    } finally {
+      restoreTimeouts()
+    }
+
+    expectTimeoutError(outcome!)
+  })
+
+  test("times out while consuming a release asset body", async () => {
+    const bytes = encoder.encode("new binary")
+    const release = releaseFor(bytes)
+    const fetchImpl = (async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (url === githubLatestReleaseUrl) return new Response(JSON.stringify(release), { status: 200 })
+      if (url.endsWith("convoy-darwin-arm64")) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          arrayBuffer: () =>
+            new Promise<ArrayBuffer>((_resolve, reject) => {
+              const signal = init?.signal
+              signal?.addEventListener("abort", () => reject(signal.reason), { once: true })
+            }),
+        } as Response
+      }
+      if (url.endsWith("SHA256SUMS")) return new Response(`${sha256(bytes)}  convoy-darwin-arm64\n`, { status: 200 })
+      return new Response("not found", { status: 404 })
+    }) as FetchLike
+    const restoreTimeouts = useImmediateTimeouts()
+    let outcome: Settled<Awaited<ReturnType<typeof runUpdate>>>
+    try {
+      outcome = await settleWithin(
+        runUpdate({
+          standalone: true,
+          currentVersion: "0.1.0",
+          platform: "darwin",
+          architecture: "arm64",
+          fetch: fetchImpl,
+        }),
+      )
+    } finally {
+      restoreTimeouts()
+    }
+
+    expectTimeoutError(outcome!)
+  })
+
   test("checkOnly never downloads or installs even when an update is available", async () => {
     const directory = await mkdtemp(join(tmpdir(), "convoy-update-checkonly-"))
     tempDirs.push(directory)
@@ -264,6 +433,87 @@ describe("safe updater", () => {
     expect(await readFile(executablePath, "utf8")).toBe("old binary")
   })
 
+  test("accepts a candidate that writes more than one megabyte to stderr", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-update-noisy-candidate-"))
+    tempDirs.push(directory)
+    const executablePath = join(directory, "convoy")
+    const pidPath = join(directory, "candidate.pid")
+    const candidate = [
+      "#!/bin/sh",
+      `printf '%s\\n' "$$" > ${JSON.stringify(pidPath)}`,
+      "dd if=/dev/zero bs=1024 count=2048 1>&2 2>/dev/null &",
+      "child=$!",
+      `printf '%s\\n' "$child" >> ${JSON.stringify(pidPath)}`,
+      "wait \"$child\"",
+      "printf '%s\\n' 'convoy 0.2.0 (commit test, darwin-arm64)'",
+      "",
+    ].join("\n")
+    const bytes = encoder.encode(candidate)
+    await writeFile(executablePath, "old binary", { mode: 0o755 })
+    await chmod(executablePath, 0o755)
+
+    const update = runUpdate({
+      standalone: true,
+      currentVersion: "0.1.0",
+      platform: "darwin",
+      architecture: "arm64",
+      executablePath,
+      fetch: fetchFor(releaseFor(bytes), bytes),
+    })
+    const outcome = await settleWithin(update)
+    if (outcome.status === "pending") {
+      await terminateRecordedProcesses(pidPath)
+      await update.catch(() => undefined)
+    }
+    await rm(pidPath, { force: true })
+
+    expect(outcome.status).toBe("resolved")
+    expect(await readFile(executablePath, "utf8")).toBe(candidate)
+    expect((await readdir(directory)).sort()).toEqual(["convoy"])
+  })
+
+  test("rejects a hung candidate and reaps it after the validation deadline", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "convoy-update-hung-candidate-"))
+    tempDirs.push(directory)
+    const executablePath = join(directory, "convoy")
+    const pidPath = join(directory, "candidate.pid")
+    const bytes = encoder.encode([
+      "#!/bin/sh",
+      `printf '%s\\n' "$$" > ${JSON.stringify(pidPath)}`,
+      "exec sleep 60",
+      "",
+    ].join("\n"))
+    await writeFile(executablePath, "old binary", { mode: 0o755 })
+    await chmod(executablePath, 0o755)
+
+    // Let the shell write its PID before the simulated deadline fires so the
+    // test can verify that the updater reaped the actual child process.
+    const restoreTimeouts = useImmediateTimeouts(500)
+    const update = runUpdate({
+      standalone: true,
+      currentVersion: "0.1.0",
+      platform: "darwin",
+      architecture: "arm64",
+      executablePath,
+      fetch: fetchFor(releaseFor(bytes), bytes),
+    })
+    let outcome: Settled<Awaited<ReturnType<typeof runUpdate>>>
+    try {
+      outcome = await settleWithin(update)
+    } finally {
+      restoreTimeouts()
+    }
+    const pids = await terminateRecordedProcesses(pidPath)
+    if (outcome!.status === "pending") await update.catch(() => undefined)
+    await rm(pidPath, { force: true })
+
+    expect(outcome!.status).toBe("rejected")
+    if (outcome!.status === "rejected") expect(outcome!.error).toBeInstanceOf(UpdateError)
+    expect(pids).toHaveLength(1)
+    expect(processIsAlive(pids[0]!)).toBe(false)
+    expect((await readdir(directory)).sort()).toEqual(["convoy"])
+  })
+
   test("does not replace the executable when the candidate fails version validation", async () => {
     const directory = await mkdtemp(join(tmpdir(), "convoy-update-badcandidate-"))
     tempDirs.push(directory)
@@ -286,7 +536,7 @@ describe("safe updater", () => {
     ).rejects.toThrow("did not report the expected version")
     expect(await readFile(executablePath, "utf8")).toBe("old binary")
     // No candidate or backup leftovers remain in the install directory.
-    expect(await readdir(directory)).toEqual(["convoy"])
+    expect((await readdir(directory)).sort()).toEqual(["convoy"])
   })
 
   test("replaceExecutableAtomically restores the previous binary when the final rename fails", async () => {
@@ -322,7 +572,7 @@ describe("safe updater", () => {
     expect(await readFile(executablePath, "utf8")).toBe("original")
     // The temporary backup is cleaned up; the candidate is left for the caller
     // (runUpdate owns candidate cleanup via removeIfPresent).
-    expect(await readdir(directory)).toEqual([".convoy.candidate-restore", "convoy"])
+    expect((await readdir(directory)).sort()).toEqual([".convoy.candidate-restore", "convoy"])
   })
 
   test("installs a verified candidate through a same-directory atomic rename", async () => {
@@ -351,7 +601,7 @@ describe("safe updater", () => {
 
     expect(result).toMatchObject({ status: "updated", latestVersion: "0.2.0" })
     expect(await readFile(executablePath, "utf8")).toBe("new binary")
-    expect(await readdir(directory)).toEqual(["convoy"])
+    expect((await readdir(directory)).sort()).toEqual(["convoy"])
   })
 
   test("leaves the current executable intact after network, hash, or replacement failures", async () => {


### PR DESCRIPTION
- fix validateCandidateExecutable hanging on large stderr output by reading stdout properly and ignoring stderr
- fix gitCommit hanging by reading subprocess stdout with proper async handling
- add timeout and process cleanup for hung candidate validation with SIGTERM/SIGKILL escalation
- add comprehensive tests for subprocess timeouts, large stderr output, and hung process reaping
- add release workflow tests validating prerelease handling, smoke tests, and action supply-chain pins
- restructure CI into reusable verify workflow for cross-platform validation on PRs and main