### PR TITLE
feat(install): add a checksum-verifying install script published per …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,10 +60,18 @@ jobs:
       - name: Smoke-test Linux binary
         run: ./dist/convoy-linux-x64 --version
 
+      - name: Stage the installer
+        # install.sh is published per release so `curl … | sh` resolves to the
+        # script that was tested against these exact binaries, and so a pinned
+        # `/releases/download/<tag>/install.sh` stays reproducible.
+        run: |
+          sh -n install.sh
+          cp install.sh dist/install.sh
+
       - name: Generate checksums
         run: |
           cd dist
-          shasum -a 256 convoy-darwin-arm64 convoy-darwin-x64 convoy-linux-arm64 convoy-linux-x64 > SHA256SUMS
+          shasum -a 256 convoy-darwin-arm64 convoy-darwin-x64 convoy-linux-arm64 convoy-linux-x64 install.sh > SHA256SUMS
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
@@ -75,4 +83,5 @@ jobs:
             dist/convoy-darwin-x64
             dist/convoy-linux-arm64
             dist/convoy-linux-x64
+            dist/install.sh
             dist/SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -104,9 +104,43 @@ To use different providers, authenticate them in OpenCode and select models as `
 
 ## Installation
 
-### Release binary (recommended)
+### Install script (recommended)
 
-GitHub Releases are the distribution source and preserve every published version. Download the binary for your platform into `~/.local/bin`, then make it executable:
+```bash
+curl -fsSL https://github.com/Inakitajes/convoy/releases/latest/download/install.sh | sh
+```
+
+The script detects your platform, downloads the matching release binary, **verifies it against the release's `SHA256SUMS`**, installs it into `~/.local/bin`, and creates `~/.convoy/config.yaml` plus `~/.convoy/agents/*.md` if they do not already exist. Nothing is installed unless the checksum matches and the downloaded binary reports its own version, and the final move is atomic, so a failed install never leaves a partial binary behind.
+
+Options are accepted as environment variables, or as flags after `sh -s --`:
+
+| Variable | Flag | Default |
+| --- | --- | --- |
+| `CONVOY_VERSION` | `--version <tag>` | `latest` |
+| `CONVOY_INSTALL_DIR` | `--dir <path>` | `$HOME/.local/bin` |
+| `CONVOY_NO_INIT` | `--no-init` | unset |
+
+```bash
+# Pin an exact release
+curl -fsSL https://github.com/Inakitajes/convoy/releases/download/v0.1.0/install.sh | sh
+
+# Install somewhere else
+curl -fsSL https://github.com/Inakitajes/convoy/releases/latest/download/install.sh | CONVOY_INSTALL_DIR="$HOME/bin" sh
+
+# Skip creating the default configuration
+curl -fsSL https://github.com/Inakitajes/convoy/releases/latest/download/install.sh | sh -s -- --no-init
+```
+
+The script is [`install.sh`](install.sh) in this repository, published as an asset of every release and listed in that release's `SHA256SUMS`, so the URL above always resolves to the script tested against those exact binaries. To read it before running it, drop the pipe:
+
+```bash
+curl -fsSL https://github.com/Inakitajes/convoy/releases/latest/download/install.sh -o install.sh
+less install.sh && sh install.sh
+```
+
+### Manual download
+
+GitHub Releases are the distribution source and preserve every published version. To skip the script, download the binary for your platform into `~/.local/bin`, then make it executable:
 
 ```bash
 mkdir -p ~/.local/bin
@@ -127,7 +161,7 @@ chmod 755 ~/.local/bin/convoy
 convoy --version
 ```
 
-Make sure `~/.local/bin` is on your `PATH`. To install an exact version, replace `/releases/latest/download/` with `/releases/download/v0.1.0/` (or another tag). The [Releases page](https://github.com/Inakitajes/convoy/releases) lists all available versions and their `SHA256SUMS` files.
+This path verifies nothing on its own; every release publishes a `SHA256SUMS` if you want to check the download yourself. Make sure `~/.local/bin` is on your `PATH`. To install an exact version, replace `/releases/latest/download/` with `/releases/download/v0.1.0/` (or another tag). The [Releases page](https://github.com/Inakitajes/convoy/releases) lists all available versions.
 
 ### Development install
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,248 @@
+#!/bin/sh
+# Convoy installer.
+#
+#   curl -fsSL https://github.com/Inakitajes/convoy/releases/latest/download/install.sh | sh
+#
+# Downloads the release binary for the current platform, verifies it against the
+# release's SHA256SUMS, and installs it into ~/.local/bin. Mirrors the guarantees
+# `convoy update` makes in src/update.ts: nothing is installed unverified, and the
+# candidate must report its own version before it replaces anything.
+#
+# Options (also accepted as flags via `| sh -s -- --version v0.1.0`):
+#   CONVOY_VERSION       release tag to install, or "latest" (default: latest)
+#   CONVOY_INSTALL_DIR   destination directory (default: $HOME/.local/bin)
+#   CONVOY_NO_INIT       set to any value to skip `convoy init --global`
+
+set -eu
+
+REPO="Inakitajes/convoy"
+BIN="convoy"
+
+VERSION="${CONVOY_VERSION:-latest}"
+INSTALL_DIR="${CONVOY_INSTALL_DIR:-$HOME/.local/bin}"
+NO_INIT="${CONVOY_NO_INIT:-}"
+
+if [ -t 1 ]; then
+  BOLD=$(printf '\033[1m')
+  DIM=$(printf '\033[2m')
+  RED=$(printf '\033[31m')
+  GREEN=$(printf '\033[32m')
+  YELLOW=$(printf '\033[33m')
+  RESET=$(printf '\033[0m')
+else
+  BOLD="" DIM="" RED="" GREEN="" YELLOW="" RESET=""
+fi
+
+info() { printf '%s\n' "$*"; }
+step() { printf '%s==>%s %s\n' "$BOLD" "$RESET" "$*"; }
+warn() { printf '%swarning:%s %s\n' "$YELLOW" "$RESET" "$*" >&2; }
+err() {
+  printf '%serror:%s %s\n' "$RED" "$RESET" "$*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<EOF
+convoy installer
+
+usage: install.sh [--version <tag>] [--dir <path>] [--no-init]
+
+  --version <tag>   install a specific release (default: latest)
+  --dir <path>      install into <path> (default: \$HOME/.local/bin)
+  --no-init         skip creating ~/.convoy/config.yaml
+  --help            show this message
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version)
+      [ $# -ge 2 ] || err "--version needs a release tag"
+      VERSION="$2"
+      shift 2
+      ;;
+    --dir)
+      [ $# -ge 2 ] || err "--dir needs a path"
+      INSTALL_DIR="$2"
+      shift 2
+      ;;
+    --no-init)
+      NO_INIT=1
+      shift
+      ;;
+    --help | -h)
+      usage
+      exit 0
+      ;;
+    *) err "unknown option: $1" ;;
+  esac
+done
+
+# ---------------------------------------------------------------- platform ---
+
+os=$(uname -s)
+case "$os" in
+  Darwin) platform="darwin" ;;
+  Linux) platform="linux" ;;
+  *) err "unsupported operating system: $os (Convoy ships macOS and Linux binaries)" ;;
+esac
+
+machine=$(uname -m)
+case "$machine" in
+  arm64 | aarch64) arch="arm64" ;;
+  x86_64 | amd64) arch="x64" ;;
+  *) err "unsupported architecture: $machine" ;;
+esac
+
+# A shell running under Rosetta reports x86_64 on Apple Silicon; installing the
+# translated binary would work but run slower than the native one.
+if [ "$platform" = "darwin" ] && [ "$arch" = "x64" ] &&
+  [ "$(sysctl -n sysctl.proc_translated 2>/dev/null || echo 0)" = "1" ]; then
+  arch="arm64"
+fi
+
+asset="${BIN}-${platform}-${arch}"
+
+# ------------------------------------------------------------------- tools ---
+
+if command -v curl >/dev/null 2>&1; then
+  # Errors are reported by the caller with actionable context, so curl's own
+  # diagnostics would only add noise ahead of them.
+  download() { curl -fsSL --proto '=https' --tlsv1.2 "$1" -o "$2" 2>/dev/null; }
+elif command -v wget >/dev/null 2>&1; then
+  download() { wget -qO "$2" "$1"; }
+else
+  err "neither curl nor wget is available"
+fi
+
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256() { sha256sum "$1" | cut -d' ' -f1; }
+elif command -v shasum >/dev/null 2>&1; then
+  sha256() { shasum -a 256 "$1" | cut -d' ' -f1; }
+elif command -v openssl >/dev/null 2>&1; then
+  sha256() { openssl dgst -sha256 "$1" | awk '{print $NF}'; }
+else
+  err "no SHA-256 tool found (need sha256sum, shasum or openssl)"
+fi
+
+# ----------------------------------------------------------------- release ---
+
+case "$VERSION" in
+  latest) base="https://github.com/${REPO}/releases/latest/download" ;;
+  v*) base="https://github.com/${REPO}/releases/download/${VERSION}" ;;
+  # Accept a bare SemVer; release tags carry the conventional leading "v".
+  *) base="https://github.com/${REPO}/releases/download/v${VERSION}" ;;
+esac
+
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/convoy-install.XXXXXX") || err "could not create a temporary directory"
+staged=""
+# Also clears the staging file below, so an interrupt between staging and the
+# final rename cannot leave a stray dotfile in the install directory.
+cleanup() {
+  rm -rf "$tmp"
+  [ -n "$staged" ] && rm -f "$staged"
+  return 0
+}
+trap cleanup EXIT INT TERM HUP
+
+step "Downloading ${BOLD}${asset}${RESET} (${VERSION})"
+download "${base}/${asset}" "${tmp}/${asset}" ||
+  err "could not download ${base}/${asset}
+  Check the tag exists at https://github.com/${REPO}/releases"
+download "${base}/SHA256SUMS" "${tmp}/SHA256SUMS" ||
+  err "could not download the SHA256SUMS for this release"
+
+expected=$(awk -v name="$asset" '$2 == name || $2 == "*" name { print $1 }' "${tmp}/SHA256SUMS" | head -n 1)
+[ -n "$expected" ] || err "SHA256SUMS does not list ${asset}"
+actual=$(sha256 "${tmp}/${asset}")
+
+if [ "$(printf '%s' "$expected" | tr 'A-F' 'a-f')" != "$(printf '%s' "$actual" | tr 'A-F' 'a-f')" ]; then
+  err "checksum verification failed for ${asset}
+  expected ${expected}
+  got      ${actual}
+  The download was corrupted or tampered with; nothing was installed."
+fi
+step "Checksum verified"
+
+# ----------------------------------------------------------------- install ---
+
+mkdir -p "$INSTALL_DIR" || err "could not create ${INSTALL_DIR}"
+[ -w "$INSTALL_DIR" ] || err "${INSTALL_DIR} is not writable
+  Re-run with a different destination, for example:
+  curl -fsSL ${base}/install.sh | CONVOY_INSTALL_DIR=\"\$HOME/bin\" sh"
+
+target="${INSTALL_DIR}/${BIN}"
+previous=""
+if [ -x "$target" ]; then
+  previous=$("$target" --version 2>/dev/null | head -n 1 || true)
+fi
+
+# Stage inside the destination directory so the final rename is atomic: readers
+# either see the old binary or the new one, never a half-written file.
+staged="${INSTALL_DIR}/.${BIN}.install-$$"
+cp "${tmp}/${asset}" "$staged" || err "could not write to ${INSTALL_DIR}"
+chmod 755 "$staged"
+
+# Do not pipe: POSIX sh has no `pipefail`, so a pipeline would report `head`'s
+# status and hide a binary that fails to execute at all.
+if ! staged_output=$("$staged" --version 2>/dev/null); then
+  rm -f "$staged"
+  err "the downloaded binary did not run on this machine; nothing was installed"
+fi
+
+installed_version=$(printf '%s\n' "$staged_output" | head -n 1)
+case "$installed_version" in
+  "$BIN "*) ;;
+  *)
+    rm -f "$staged"
+    err "the downloaded binary did not identify itself as ${BIN}; nothing was installed"
+    ;;
+esac
+
+mv -f "$staged" "$target" || {
+  rm -f "$staged"
+  err "could not install into ${target}"
+}
+
+step "Installed ${GREEN}${installed_version}${RESET} to ${target}"
+if [ -n "$previous" ] && [ "$previous" != "$installed_version" ]; then
+  info "  ${DIM}replaced ${previous}${RESET}"
+fi
+
+# Creates ~/.convoy/config.yaml and ~/.convoy/agents/*.md when absent, matching
+# what `make install` does for source installs. Never overwrites existing config.
+if [ -z "$NO_INIT" ]; then
+  if "$target" init --global --quiet 2>/dev/null; then
+    step "Default configuration ready at ~/.convoy"
+  else
+    warn "could not write the default configuration; run \`${BIN} init --global\` yourself"
+  fi
+fi
+
+# -------------------------------------------------------------------- PATH ---
+
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) on_path=1 ;;
+  *) on_path="" ;;
+esac
+
+if [ -z "$on_path" ]; then
+  case "$(basename "${SHELL:-sh}")" in
+    zsh) profile="~/.zshrc" ;;
+    bash) profile="~/.bashrc" ;;
+    fish) profile="~/.config/fish/config.fish" ;;
+    *) profile="your shell profile" ;;
+  esac
+  info ""
+  warn "${INSTALL_DIR} is not on your PATH. Add it to ${profile}:"
+  if [ "$profile" = "~/.config/fish/config.fish" ]; then
+    info "  fish_add_path ${INSTALL_DIR}"
+  else
+    info "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+  fi
+fi
+
+info ""
+info "Next: authenticate a provider in OpenCode, then run ${BOLD}${BIN}${RESET} in a repo."
+info "  ${DIM}opencode auth login${RESET}"
+info "  ${DIM}${BIN} --help${RESET}"


### PR DESCRIPTION
…release

Installing a release binary meant copying a four-part mkdir/curl/chmod command out of the README, picking the right asset by hand, and verifying nothing.

install.sh resolves the platform itself (including a shell running under Rosetta, which reports x86_64 on Apple Silicon), downloads the matching binary alongside the release SHA256SUMS, and refuses to install unless the checksum matches and the binary identifies itself as convoy. Staging happens inside the destination directory so the final rename is atomic, and the cleanup trap covers the staging file, so an interrupted or rejected install never leaves a partial or stray file behind. These are the guarantees runUpdate() already makes in src/update.ts, extended to first installs.

The script is published as an asset of every release and listed in that release's SHA256SUMS, so /releases/latest/download/install.sh always resolves to the script tested against those exact binaries and a pinned tag stays reproducible. Destination, release tag and the init step are configurable by environment variable or by flag after `sh -s --`.


Claude-Session: https://claude.ai/code/session_012TNCzEWQADztbztaZSi9XC