### PR TITLE
feat(tui): show the running version on every screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ convoy/
 │   ├── config.ts        # config loader/validation, global+project merge, YAML writer
 │   ├── config-tui.ts    # interactive config editor (convoy config)
 │   ├── model-catalog.ts # available-model list via OpenCode SDK, models.dev fallback
-│   ├── version.ts       # injected version/commit/platform + --version formatting
+│   ├── version.ts       # injected version/commit/platform + --version and TUI header formatting
 │   ├── update.ts        # GitHub Releases update check + verified atomic self-install
 │   └── pipeline.ts      # built-in agents/pipeline and pipeline-spec resolution
 ├── scripts/             # build.ts: local + multi-target release binary compilation

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -46,6 +46,7 @@ import {
   theme,
   truncate,
 } from "./tui-theme"
+import { shortVersion } from "./version"
 import { convoyRoot, globalConfigPath } from "./workspace"
 
 import type { BoxOptions, CliRenderer, KeyEvent, TextChunk } from "@opentui/core"
@@ -1420,7 +1421,7 @@ export class ConfigEditor {
       const label = `${tab.title}${tab.dirty ? " ●" : ""}`
       tabs.push(index === this.active ? bold(fg(theme.accent)(`▸ ${label}`)) : fg(theme.dim)(`  ${label}`))
     })
-    const title: TextChunk[] = [bold(fg(theme.accent)("◆ convoy")), fg(theme.faint)("  ·  "), fg(theme.text)("config")]
+    const title: TextChunk[] = [bold(fg(theme.accent)("◆ convoy")), fg(theme.faint)(` ${shortVersion()}`), fg(theme.faint)("  ·  "), fg(theme.text)("config")]
     const line1 = padBetween(title, tabs, width)
     const line2 = new StyledText([fg(theme.dim)(truncate(shortenPath(this.tab().path), width))])
     return joinLines([line1, line2])

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -12,6 +12,7 @@ import { stepRunnerFor } from "./step-runners"
 import { gatewayLabel, modelGateways, type ModelGateway } from "./model-routing"
 import { runReviewLines } from "./review-tui"
 import { joinLines, limitsRow, padBetween, paletteForTerminal, plain, raw, setTheme, spinnerFrame, terminalBackgroundHex, theme, truncate } from "./tui-theme"
+import { shortVersion } from "./version"
 
 import type { ConvoyConfig } from "./config"
 import type { BoxOptions, CliRenderer, KeyEvent, PasteEvent, TextChunk } from "@opentui/core"
@@ -451,7 +452,16 @@ class LaunchPicker {
       paddingX: 1,
     })
 
-    const header = this.panel({ id: "convoy-launch-header", height: 4, borderColor: theme.border, backgroundColor: theme.bg })
+    // The version rides the border instead of a content row: it never changes
+    // while the launcher is open, so it costs nothing to draw it once as chrome.
+    const header = this.panel({
+      id: "convoy-launch-header",
+      height: 4,
+      borderColor: theme.border,
+      backgroundColor: theme.bg,
+      title: ` convoy ${shortVersion()} `,
+      titleAlignment: "left",
+    })
     const body = new BoxRenderable(renderer, { id: "convoy-launch-body", width: "100%", flexGrow: 1, flexDirection: "row", gap: 1 })
 
     const selectFromList = (event: { y: number; preventDefault(): void; stopPropagation(): void }) => {
@@ -1155,6 +1165,8 @@ class LaunchPicker {
 
   // No "◆ convoy" branding here: the launcher is convoy's own front door, so
   // the target project is the header's anchor and the meter row stays clean.
+  // The version still shows, but as the header box's border title so neither
+  // content row has to give up space for it.
   private headerContent(width: number) {
     const project = basename(this.targetDir) || this.targetDir
     const title: TextChunk[] = [fg(theme.faint)("target "), bold(fg(theme.text)(truncate(project, Math.max(12, width - 32))))]

--- a/src/runs-tui.ts
+++ b/src/runs-tui.ts
@@ -20,6 +20,7 @@ import {
   theme,
   truncate,
 } from "./tui-theme"
+import { shortVersion } from "./version"
 import { runsRoot } from "./workspace"
 
 import type { BoxOptions, CliRenderer, KeyEvent, TextChunk } from "@opentui/core"
@@ -487,6 +488,7 @@ class RunsBrowser {
 
     const title: TextChunk[] = [
       bold(fg(theme.accent)("◆ convoy")),
+      fg(theme.faint)(` ${shortVersion()}`),
       fg(theme.faint)("  ·  "),
       fg(theme.text)("run history"),
     ]

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -50,6 +50,7 @@ import {
   truncate,
   wrapLines,
 } from "./tui-theme"
+import { shortVersion } from "./version"
 
 import type { BoxOptions, CliRenderer, KeyEvent, Selection, TextChunk } from "@opentui/core"
 import type { LimitsSnapshot } from "./limits"
@@ -2419,7 +2420,7 @@ export class TuiProgress implements ProgressUI {
       fg(theme.faint)("  ·  "),
       fg(theme.dim)(`↑${formatCount(usage.tokens.input + advisorInput)} ↓${formatCount(usage.tokens.output + advisorOutput)} tokens`),
     ]
-    const title: TextChunk[] = [bold(fg(theme.accent)("◆ convoy"))]
+    const title: TextChunk[] = [bold(fg(theme.accent)("◆ convoy")), fg(theme.faint)(` ${shortVersion()}`)]
     if (!this.finished && this.controlState !== "running") {
       title.push(
         fg(theme.faint)("  ·  "),

--- a/src/version.ts
+++ b/src/version.ts
@@ -6,6 +6,8 @@ export type VersionInfo = {
   version: string
   commit: string
   platform: string
+  /** False on `bun run src/main.ts`, where nothing was injected at build time. */
+  release: boolean
 }
 
 // The release build replaces these constants from package.json and Git. The
@@ -14,12 +16,24 @@ const injectedVersion = typeof __CONVOY_VERSION__ === "string" ? __CONVOY_VERSIO
 const injectedCommit = typeof __CONVOY_COMMIT__ === "string" ? __CONVOY_COMMIT__ : undefined
 const injectedPlatform = typeof __CONVOY_PLATFORM__ === "string" ? __CONVOY_PLATFORM__ : undefined
 
+const developmentVersion = "0.0.0-development"
+
 export const versionInfo: VersionInfo = {
-  version: injectedVersion ?? process.env.npm_package_version ?? "0.0.0-development",
+  version: injectedVersion ?? process.env.npm_package_version ?? developmentVersion,
   commit: injectedCommit ?? process.env.CONVOY_COMMIT ?? "unknown",
   platform: injectedPlatform ?? process.env.CONVOY_PLATFORM ?? `${process.platform}-${process.arch}`,
+  release: injectedVersion !== undefined,
 }
 
 export function formatVersion(info: VersionInfo = versionInfo) {
   return `convoy ${info.version} (commit ${info.commit}, ${info.platform})`
+}
+
+// The TUI header has room for a tag, not a build line. Source checkouts fall
+// back to package.json's version, so they are marked: a dev build must never
+// read as the release that shares its number. When even that fallback is
+// missing there is no number worth showing, just the fact that it's a checkout.
+export function shortVersion(info: VersionInfo = versionInfo) {
+  if (info.release) return `v${info.version}`
+  return info.version === developmentVersion ? "dev" : `v${info.version}-dev`
 }

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -3,7 +3,8 @@ import { createTestRenderer } from "@opentui/core/testing"
 import type { Selection } from "@opentui/core"
 
 import { TuiProgress, autoFollowGroup, comparisonColumnCount, initialContentTab, iteratePrompt, phaseCapabilityBadges, phaseCapabilityLabel, pickBadge, pipelineSelectionTargets, type ContentTab } from "../src/tui"
-import { formatMoney, limitsRow } from "../src/tui-theme"
+import { displayWidth, formatMoney, limitsRow } from "../src/tui-theme"
+import { shortVersion } from "../src/version"
 
 import type { ClipboardResult } from "../src/clipboard"
 import type { LimitsSnapshot } from "../src/limits"
@@ -97,6 +98,22 @@ describe("run dashboard defaults", () => {
     expect(live).toBe("session")
     expect(historical).toBe("reports")
     expect([live, historical]).not.toContain("logs")
+  })
+
+  test("brands the header with the running version and keeps it inside a narrow panel", async () => {
+    const wide = await createDashboard(120, 40)
+    await wide.renderOnce()
+
+    expect((wide.dashboard as unknown as DashboardInternals).headerText.plainText).toContain(`◆ convoy ${shortVersion()}`)
+
+    // The version lengthens the left side of padBetween, which clips the right;
+    // no header line may outgrow the panel and get chopped by its border.
+    const narrow = await createDashboard(60, 40)
+    await narrow.renderOnce()
+    const lines = (narrow.dashboard as unknown as DashboardInternals).headerText.plainText.split("\n")
+
+    expect(lines[0]).toContain(shortVersion())
+    for (const line of lines) expect(displayWidth(line)).toBeLessThanOrEqual(54)
   })
 
   test("labels audit-only phases without tagging writable work", () => {

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+
+import { formatVersion, shortVersion, versionInfo } from "../src/version"
+
+const released = { version: "0.1.1", commit: "a".repeat(40), platform: "darwin-arm64", release: true }
+
+describe("version formatting", () => {
+  test("the header tag marks source checkouts so a dev build never reads as the release", () => {
+    expect(shortVersion(released)).toBe("v0.1.1")
+    expect(shortVersion({ ...released, release: false })).toBe("v0.1.1-dev")
+    // `bun src/main.ts` sets no npm_package_version, so the triple falls all
+    // the way through: "v0.0.0-development-dev" would be noise, not a version.
+    expect(shortVersion({ ...released, version: "0.0.0-development", release: false })).toBe("dev")
+  })
+
+  // install.sh and the self-updater both parse this line to confirm a staged
+  // binary is really convoy before it replaces the installed one, so the shape
+  // is part of the release contract, not just cosmetics.
+  test("--version keeps the shape the installer and self-updater parse", () => {
+    expect(formatVersion(released)).toBe(`convoy 0.1.1 (commit ${"a".repeat(40)}, darwin-arm64)`)
+    expect(formatVersion(released)).toMatch(/^convoy\s+([^\s(]+)/m)
+  })
+
+  test("a source checkout still reports a usable version triple", () => {
+    expect(versionInfo.version.length).toBeGreaterThan(0)
+    expect(versionInfo.platform).toContain("-")
+    expect(typeof versionInfo.release).toBe("boolean")
+  })
+})


### PR DESCRIPTION
## Context

The release system landed recently (#26, #30, now v0.1.1) and the CLI side of the version story is complete: `convoy --version` works, the version is baked in at build time from `package.json` + `git rev-parse HEAD`, and `release.yml` fails the release if the tag and `package.json` disagree.

What was missing: **the version appeared nowhere inside the TUI**. No TUI file imported `src/version.ts` — not the launcher, the run dashboard, the run history, or the config editor. You had to quit Convoy to find out which build you were running.

## What changed

The version rides the brand mark. The three screens that render `◆ convoy` get a dim tag beside it. The launcher deliberately has no brand mark (`launch-tui.ts`: *"the launcher is convoy's own front door, so the target project is the header's anchor"*), so there it becomes the header box's **border title** — chrome rather than content, so neither header row gives up space and the rule that comment protects stays intact.

```
╭─ convoy v0.1.1 ────────────────────────────────────────────╮   ← launcher
│ target convoy       pipeline → prompt → options → review   │

◆ convoy v0.1.1  ·  run history      61 runs · ✓ 37 ✗ 6 · $150.66
◆ convoy v0.1.1  ·  config                     ▸ Global   Project
```

`shortVersion()` distinguishes builds so a dev checkout never reads as the release sharing its number:

| how it ran | shows |
|---|---|
| release binary | `v0.1.1` |
| `bun run src/main.ts` (npm_package_version set) | `v0.1.1-dev` |
| `bun src/main.ts` (nothing injected) | `dev` |

`formatVersion()` is deliberately untouched — its exact `convoy <ver> (…)` shape is parsed by `install.sh` and by the self-updater's `candidateDeclaresVersion` before either replaces an installed binary.

## Out of scope

- **No "update available" indicator.** That needs a network call at startup, which would break the README's promise that "Convoy does not make network calls when it starts". `convoy update --check` stays the explicit path.
- A lowercase `-v` alias for `--version`, which currently throws `unknown flag: -v`. Worth a separate decision.

## Verification

- `bun run typecheck` clean; **740 pass, 0 fail**.
- New `test/version.test.ts` covers all three build modes plus a guard that `formatVersion()` keeps the shape the installer and self-updater parse.
- New test in `test/tui.test.ts` renders the dashboard and asserts no header line outgrows its panel at 60 columns — the real risk of lengthening the left side of `padBetween`.
- Checked against a real `bun run build` binary, capturing TUI frames over a pty (that's where the boxes above come from). `convoy --version` and `convoy update --check` both still behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kSdEZibVAPxKruRehhDyv