### PR TITLE
chore(release): v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convoy",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps `package.json` from `0.1.1` to `0.1.2`. One-line change, same shape as #35.

## What's in this release

- **#36 — the running version now shows on every TUI screen.** The launcher carries it in its header border title; the run dashboard, run history, and config editor carry it beside the `◆ convoy` brand mark. Source checkouts are tagged (`v0.1.2-dev` / `dev`) so a dev build never reads as the release sharing its number.

## After merging

`release.yml` triggers on a pushed `v*` tag, not on this merge, and it fails the build unless the tag matches `package.json` exactly. So cutting the release still needs:

```
git tag v0.1.2 && git push origin v0.1.2
```

I have not tagged anything — say the word if you want me to once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011kSdEZibVAPxKruRehhDyv