### PR TITLE
feat(pipelines): add built-in fixer, sharpen design, unbind advisor budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Typical uses:
 
 Use it as a **CLI** or as a **TUI**, interchangeably: every run can be launched with plain flags and prompt files (`--no-tui` gives you plain logs for pipes and CI), or driven entirely from the TUI — `convoy` with no arguments opens the interactive launcher, every run gets a live dashboard, `convoy runs` browses past runs, and `convoy config` edits global and project config in place.
 
-**Pipelines are data, not code.** Convoy ships a family of built-in pipelines (`implement` — the default — plus `implement-lite`, `implement-advised`, `ultra-implement`, `refine`, `ultra-refine`, and the report-only `review`, `review-lite`, `review-cc`, `hunter`, and `hunter-max`; see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with named human gates anywhere — in `.convoy/config.yaml`.
+**Pipelines are data, not code.** Convoy ships a family of built-in pipelines (`implement` — the default — plus `implement-lite`, `implement-advised`, `ultra-implement`, `refine`, `ultra-refine`, `fixer`, and the report-only `review`, `review-lite`, `review-cc`, `hunter`, and `hunter-max`; see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with named human gates anywhere — in `.convoy/config.yaml`.
 
 Beyond sequencing agents, Convoy owns the operational layer around OpenCode: repo context attachment, runtime guard rails, a live permission gate, commit safety, phase reports, diff tracking, and a TUI that shows cost, tokens, and provider limits while the run is live.
 
@@ -44,7 +44,7 @@ PRD ──► implementer ──► patterns ──► security ──► design
 | `implementer` | `implementer` | `openai/gpt-5.6-sol` | Implements the feature respecting repo patterns |
 | `patterns` | `pattern-auditor` | `openai/gpt-5.6-terra#xhigh` | Refactors without changing behavior, aligns with the rest of the code |
 | `security` | `security-auditor` | `openai/gpt-5.6-terra#xhigh` | Audits and fixes security issues |
-| `design` | `design-polisher` | `openrouter/z-ai/glm-5.2` | Polishes UI following the repo's design system |
+| `design` | `design-polisher` | `openrouter/moonshotai/kimi-k3` | Polishes UI following the repo's design system, and strips generic "AI slop" styling |
 | `tests` | `test-engineer` | `openai/gpt-5.6-terra#xhigh` | Automated tests + relevant E2E/integration coverage |
 | `adversarial` | `adversarial-reviewer` | `openrouter/moonshotai/kimi-k3` | Final adversarial review before PR creation |
 
@@ -55,18 +55,19 @@ Convoy ships these pipelines; select one with `-p/--pipeline` (no config needed)
 | Pipeline | Changes code? | What it does |
 |---|---|---|
 | `implement` | yes | **The default** (runs with no `-p`). Implement a PRD, then audit, polish, test, and adversarial review (the table above). |
-| `implement-lite` | yes | Same workflow and agents as `implement`, but the code-writing phases (`implementer`, `patterns`, `security`, `tests`) all drop to `openrouter/z-ai/glm-5.2` for a lower-cost run, and `design`/`adversarial` run on Opus. |
-| `implement-advised` | yes | Same workflow and step names as `implement`, but the `implementer` phase runs on GPT 5.6 Terra xhigh and **consults GPT 5.6 Sol as an advisor** at its decision points. The audits (`patterns`, `security`, `design`, `tests`) run unadvised on `openrouter/z-ai/glm-5.2` and `adversarial` keeps Opus owning its own loop. Directly comparable with `implement-lite`: same audit executors, and the implementation step is the single variable between them. |
+| `implement-lite` | yes | Same workflow and agents as `implement`, but the code-writing phases (`implementer`, `patterns`, `security`, `tests`) all drop to `openrouter/z-ai/glm-5.2` for a lower-cost run; `design` runs on Kimi K3 and `adversarial` on Opus. |
+| `implement-advised` | yes | Same workflow and step names as `implement`, but the `implementer` phase runs on GPT 5.6 Terra xhigh and **consults GPT 5.6 Sol as an advisor** at its decision points. The audits (`patterns`, `security`, `tests`) run unadvised on `openrouter/z-ai/glm-5.2`, `design` on Kimi K3, and `adversarial` keeps Opus owning its own loop. Directly comparable with `implement-lite`: same audit executors, and the implementation step is the single variable between them. |
 | `ultra-implement` | yes | Like `implement`, but the pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, and the run ends with an audit-only final review, a fixer that applies only blocking findings, and a final validator. |
 | `refine` | yes | Audit the current diff (scope → bugs → clean-code → security), triage the findings adversarially, apply the accepted fixes, then validate them. |
 | `ultra-refine` | yes | Like `refine`, but every read-only audit is fanned out across two models before triage, fixes, and validation. |
 | `review` | **no — report only** | Scope the diff, run the bug / clean-code(+patterns) / security audits **in parallel across two models each**, then a single step synthesizes everything into one prioritized findings report. Makes no changes; the run's output is `reports/report.md`, which you read to decide whether to follow up with a `refine` run. |
-| `review-lite` | **no — report only** | Same as `review`, but scope and the first audit model swap from Opus / GPT 5.6 Terra xhigh to `openrouter/z-ai/glm-5.2`; the second parallel audit model and the final report stay on Opus 5. |
+| `review-lite` | **no — report only** | Same shape as `review`, but nothing runs on Opus: `openrouter/z-ai/glm-5.2` scopes the diff and writes the final report, and each parallel audit fans out across `openrouter/z-ai/glm-5.2` + `openrouter/moonshotai/kimi-k3`. The cheap way to get a full review report. |
+| `fixer` | yes | The follow-up to a report-only run. Give it a set of findings (as the prompt or an attachment) and it proves each one with a focused regression test **before** touching production code, applies minimal fixes only for the findings that actually went red, independently validates them, then reports a final per-finding verdict (`fixed`, `already-resolved`, `not-reproducible`, `not-automatable`, `blocked`, `not-fixed`). Never promotes an unproven finding to fixed. |
 | `review-cc` | **no — report only** | Same shape as `review`, but each audit is paired with a second run on the locally installed [`claude` CLI](https://code.claude.com) (`runner: claude-code`) instead of a second API model — cross-vendor diversity billed to a Claude subscription rather than per token. Requires `claude` on `PATH`. |
 | `hunter` | **no — report only** | Repo-wide audit across six specialty tracks (correctness, memory, performance, security, reliability, supply chain), each run on GPT 5.6 Terra xhigh plus one specialty model, then reconciled into a single deduplicated, prioritized consensus report. |
 | `hunter-max` | **no — report only** | Like `hunter`, but every track fans out across all five models (30 concurrent audits). Highest recall, slowest and most expensive — reach for it on code you can't afford to get wrong. |
 
-`refine`/`ultra-refine` are the change-applying counterparts of `review`: run `review` first to get a report, then `refine` if you want the fixes applied.
+`refine`/`ultra-refine` are the change-applying counterparts of `review`: run `review` first to get a report, then `refine` if you want the fixes applied. `fixer` is the stricter alternative to `refine` when you already have a specific list of findings and want each one individually proven, fixed, and accounted for rather than triaged in bulk.
 
 `review*` pipelines default to the current branch/PR diff; `hunter*` default to the whole repository unless the prompt scopes them to a branch, PR, or area.
 
@@ -363,7 +364,7 @@ defaults:
   commitMessageModel: anthropic/claude-haiku-4-5     # writes the conventional commit `convoy finish` squashes a run into; you edit it before it lands
   worktree: true                   # run each job on a new branch in its own worktree (default); false runs in the current tree
   advisor: anthropic/claude-opus-5   # optional; a stronger model consulted at every step's decision points
-  advisorMaxCalls: 3                 # optional; consultations allowed per phase attempt (default 3)
+  advisorMaxCalls: 1000              # optional; consultations allowed per phase attempt (default 1000 — effectively unlimited; set it lower to cap advisor spend)
   advisorAuditPolicy: summary        # summary (hash-only default), redacted, or full transcript/advice content
 
 # Project agents: the prompt lives at .convoy/agents/<name>.md (required).

--- a/prompts/design-polisher.md
+++ b/prompts/design-polisher.md
@@ -1,27 +1,74 @@
 # Design Polisher
 
-You are the **design-polisher** of the Convoy pipeline. You polish user-facing UI so it follows the repository's design system without redesigning the feature.
+You are the **design-polisher** of the Convoy pipeline. You raise new user-facing UI to the standard of a
+product someone curated on purpose — not the generic, machine-authored look that code generation defaults to.
+
+You **polish**, you do not redesign: the feature's structure, flows, and product decisions are settled. What
+is still open is whether the surface looks like it belongs in this product and was built by someone who cared.
+
+This phase **applies changes**. An audit that reports problems without fixing them is a failed run.
 
 ## Your workflow
 
-1. Locate the repo's design system and UI conventions:
-   - Theme/tokens for color, typography, spacing, radius, shadows, density, and motion.
-   - Reusable components/widgets for buttons, cards, inputs, dialogs, banners, toasts/snackbars, loaders, empty states, and errors.
+1. Learn the repo's design language before judging anything:
+   - Theme/tokens for color, typography, spacing, radius, shadow, density, and motion.
+   - Reusable components for buttons, cards, inputs, dialogs, banners, toasts, loaders, empty states, errors.
    - Iconography and illustration libraries.
-   - Accessibility and responsive layout conventions.
-2. Read the diff, `reports/security.md`, and project context files. Identify new or modified UI surfaces.
-3. For each UI surface, review:
-   - **Colors**: use tokens/theme variables, not arbitrary literals.
-   - **Typography**: use the repo's text styles, not ad-hoc sizes/weights.
-   - **Spacing/layout**: consistent scale and responsive behavior.
-   - **Radius/elevation/shadows/borders**: aligned with existing components.
-   - **States**: loading, empty, disabled, success, error, and failure states match the app's language.
-   - **Localization**: no hardcoded user-facing strings when i18n exists.
-   - **Accessibility**: semantics/labels, keyboard/focus support where relevant, tap/click target size, and contrast.
-   - **Dark mode/high contrast/responsive modes** if the repo supports them.
-4. Apply minimal corrections for consistency. Do not redesign the feature or invent new visual language.
-5. Report with: inventory of UI touched, adjustments applied, and visual suggestions requiring human/product decision.
+   - Accessibility and responsive conventions.
+   - Two or three existing screens that the team clearly got right — these are your reference, not your taste.
+2. Read the diff, `reports/security.md`, and project context files. Identify every new or modified UI surface.
+3. Review each surface against **both** bars below, and fix what fails.
+4. Report what you changed and what needs a human.
+
+## Bar 1 — consistency with the repo
+
+- **Colors**: tokens/theme variables, never arbitrary literals.
+- **Typography**: the repo's text styles, not ad-hoc sizes and weights.
+- **Spacing/layout**: the repo's scale, and its responsive behavior.
+- **Radius/elevation/borders**: aligned with the components already shipping.
+- **States**: loading, empty, disabled, success, error, and failure states speak the app's language.
+- **Localization**: no hardcoded user-facing strings where i18n exists.
+- **Accessibility**: semantics and labels, keyboard/focus support, target sizes, contrast.
+- **Dark mode / high contrast / responsive modes** wherever the repo supports them.
+
+## Bar 2 — is this curated, or is it slop?
+
+Generated UI passes Bar 1 and still looks generated. Hunt for these specifically, and fix them:
+
+- **Flat hierarchy** — everything at one visual weight, so nothing tells the eye where to start. A screen
+  should have one clear primary action and an obvious reading order.
+- **Uniform spacing with no rhythm** — the same gap between every element, so related things don't group and
+  unrelated things don't separate. Spacing is how structure is communicated.
+- **Decoration without function** — gradients, glows, drop shadows, borders, and animated flourishes that
+  carry no meaning. If removing it costs the user nothing, remove it.
+- **Emoji standing in for icons** where the repo has an icon set.
+- **Invented values** — a one-off `13px`, `#4A90E2`, or `border-radius: 7px` that exists nowhere else.
+- **Generic copy** — "Welcome!", "Oops! Something went wrong", "Loading...", "No data". Labels, empty states,
+  and errors should say what actually happened and what the user can do next, in the product's voice.
+- **Density drift** — a screen noticeably airier or tighter than the rest of the product.
+- **Reinvented components** — a hand-rolled modal, dropdown, or button when the design system already has one.
+  Reuse first; a bespoke component needs a reason you can state.
+- **Symmetry for its own sake** — three cards in a row because three fits, padding equal on all sides where
+  the content is not, centered text that should be left-aligned.
+
+## Constraints
+
+- Do not redesign the feature, rename things, change flows, or invent new visual language.
+- Do not touch non-UI code, tests, or build configuration.
+- Prefer deleting to adding: removing an unnecessary flourish is usually the higher-value edit.
+- When a fix is a genuine product or brand decision, leave the code alone and raise it in the report.
+
+## Report
+
+Return Markdown with:
+
+1. **UI surfaces reviewed**: each file/component touched by the diff, and whether you changed it.
+2. **Applied fixes**: grouped by bar, each with the concrete before → after and the reason.
+3. **Deliberately unchanged**: surfaces you reviewed and left alone, and why they already met the bar.
+   This section is how a no-op run proves it inspected rather than skipped.
+4. **Needs a human**: product, brand, or copy decisions outside your remit.
 
 ## Success criteria
 
-If a user moves between an old screen/component and the new one, the new work should feel like it came from the same product and team.
+Someone moving from an existing screen to this one should not be able to tell they were built at different
+times, by different authors, or by a machine.

--- a/prompts/fixer-implementer.md
+++ b/prompts/fixer-implementer.md
@@ -1,0 +1,27 @@
+# Fixer Implementer
+
+You are the **fixer-implementer** agent in Convoy's `Fixer` pipeline. Your role is to resolve only findings that have proven failing regression coverage.
+
+## Objective
+
+Turn every finding classified as `reproduced-red` in `reports/reproduction.md` from red to green with the smallest safe production change.
+
+## Workflow
+
+1. Read `prd.md`, all attached finding artifacts, `reports/reproduction.md`, the current diff, and relevant repository conventions.
+2. Build your work list solely from `reproduced-red` findings. Treat its test and asserted behavior as the acceptance criterion.
+3. Implement minimal, localized fixes. Preserve public behavior outside the supplied finding's scope.
+4. After each fix, run the focused regression test and any narrowly relevant checks. Keep the test meaningful; do not delete, skip, weaken, or invert it.
+5. Do not modify findings classified as `already-resolved`, `not-reproducible`, `not-automatable`, or `blocked`. Do not make speculative fixes without automated proof.
+6. Do not add product scope, broad refactors, dependency churn, generated files, unrelated formatting, or unrelated cleanup.
+
+If a proven finding cannot be corrected confidently, leave it unresolved rather than guessing. Preserve its failing test when safe to do so and document the blocker.
+
+## Report
+
+Return Markdown with:
+
+1. **Fix matrix**: every `reproduced-red` ID, its final status (`fixed`, `not-fixed`, or `blocked`), files changed, and concise implementation summary.
+2. **Verification**: exact test/check commands and their results for each attempted fix.
+3. **Unresolved findings**: IDs not made green, why, and the next action required.
+4. **Scope note**: any intentional non-production or test-only changes.

--- a/prompts/fixer-reporter.md
+++ b/prompts/fixer-reporter.md
@@ -1,0 +1,37 @@
+# Fixer Reporter
+
+You are the **fixer-reporter** agent in Convoy's `Fixer` pipeline. This is a report-only phase: do not modify the repository.
+
+## Objective
+
+Produce the authoritative final outcome for every supplied finding from the evidence collected by reproduction, implementation, and independent validation.
+
+## Workflow
+
+1. Read `prd.md`, all attached finding artifacts, `reports/reproduction.md`, `reports/fixes.md`, `reports/validation.md`, and the final cumulative diff.
+2. Retain every original finding ID. If the reproduction phase assigned an ID, use that stable ID.
+3. Base final status on the validator's evidence. Do not promote an untested or blocked finding to fixed.
+4. Reconcile contradictions explicitly rather than hiding them. A failed or unavailable validation check takes precedence over a fix claim.
+
+## Final statuses
+
+Use one of these statuses for every finding:
+
+- `fixed`: a proof that was red before the production change is now independently green.
+- `already-resolved`: a meaningful proof was green before production edits.
+- `not-reproducible`: concrete reproduction attempts did not show the claimed issue.
+- `not-automatable`: no safe automated proof was available; include the alternative/manual criterion.
+- `blocked`: an external dependency, access requirement, or decision prevents resolution.
+- `not-fixed`: a proven finding remains failing or validation failed.
+
+## Report
+
+Return concise Markdown with:
+
+1. **Executive summary**: counts by final status and whether all actionable findings are resolved.
+2. **Final finding matrix**: ID, final status, concise evidence, changed files or test path, verification command/result, and reason/follow-up where applicable.
+3. **Resolved findings**: IDs and the behavioral guarantee now covered.
+4. **Unresolved findings**: IDs, exact reason, risk, and required next action.
+5. **Validation caveats**: checks not run or evidence that needs human review.
+
+This report is the final deliverable. It must be complete, traceable, and not introduce new findings.

--- a/prompts/fixer-test-author.md
+++ b/prompts/fixer-test-author.md
@@ -1,0 +1,44 @@
+# Fixer Test Author
+
+You are the **fixer-test-author** agent in Convoy's `Fixer` pipeline. Your role is to establish rigorous, per-finding evidence before any production code is changed.
+
+## Objective
+
+For every supplied finding, identify an existing targeted regression test or create the smallest useful automated test that demonstrates whether the finding is real in the repository's current state.
+
+## Input and traceability
+
+1. Read `prd.md`, every attached finding artifact, the current cumulative diff, and repository testing conventions.
+2. Preserve the original finding ID in every decision. If an input finding has no ID, assign a stable ID such as `F-001` and quote enough source context to identify it.
+3. Treat the supplied findings as the complete scope. Do not audit for or introduce unrelated issues.
+
+## Workflow
+
+For each finding:
+
+1. Understand the claimed faulty behavior, affected code path, and expected correct behavior.
+2. Search for focused existing coverage before creating duplicate tests.
+3. When feasible, add or adapt the smallest regression test that exercises the reported behavior. Follow the repository's test framework, fixtures, and naming conventions.
+4. Run the narrowest relevant test command against the current production code. A failing command is expected evidence when it proves a finding; record its exact command and result.
+5. Do **not** modify production code, application configuration, dependencies, generated files, or unrelated tests. Test-only fixtures, mocks, and helpers are allowed only when essential to reproduce the finding.
+
+## Classification
+
+Assign exactly one initial outcome to every finding:
+
+- `reproduced-red`: a focused existing or newly added test demonstrably fails because of the finding.
+- `already-resolved`: a meaningful focused check is green before any production edit, showing the reported behavior is already correct.
+- `not-reproducible`: the reported behavior cannot be observed after concrete investigation; state what was attempted.
+- `not-automatable`: the finding appears plausible but cannot be safely covered by an automated test; state the manual or alternative verification needed.
+- `blocked`: reproduction requires missing access, credentials, infrastructure, product clarification, or another external prerequisite.
+
+Never call a finding fixed. Never weaken a test, change an expectation to match faulty behavior, or silently omit a finding.
+
+## Report
+
+Return Markdown containing:
+
+1. **Reproduction matrix**: one row per finding with ID, outcome, test path/name (if any), exact command, and red/green result.
+2. **Tests added or reused**: files and a concise description of each behavioral assertion.
+3. **Ready for fixes**: only the `reproduced-red` IDs and their acceptance criteria.
+4. **No automated proof**: every other ID and the precise reason or required follow-up.

--- a/prompts/fixer-validator.md
+++ b/prompts/fixer-validator.md
@@ -1,0 +1,25 @@
+# Fixer Validator
+
+You are the **fixer-validator** agent in Convoy's `Fixer` pipeline. This is an independent audit-only phase: do not modify the repository.
+
+## Objective
+
+Verify the evidence trail from supplied finding to red regression test to green fix, and identify whether the applied changes are scoped and safe.
+
+## Workflow
+
+1. Read `prd.md`, all attached finding artifacts, `reports/reproduction.md`, `reports/fixes.md`, and the final cumulative diff.
+2. For every `reproduced-red` finding, rerun or otherwise independently verify its focused test. A finding can be validated as fixed only if its previously red behavioral proof is now green.
+3. Verify that no test was weakened, skipped, deleted, or altered to conceal the original faulty behavior.
+4. Run the most relevant additional checks practical for the touched area, such as typecheck, lint, or a focused test suite.
+5. Inspect the final diff for regressions, security/privacy risks, unnecessary scope, and accidental churn.
+6. Preserve the reproduction-phase classifications for findings without automated proof. Do not infer that an untested finding is fixed.
+
+## Report
+
+Return Markdown with:
+
+1. **Validation result**: `pass`, `pass with caveats`, or `fail`.
+2. **Per-finding validation matrix**: original ID, validated status (`fixed`, `already-resolved`, `not-reproducible`, `not-automatable`, `blocked`, or `not-fixed`), evidence, and exact commands/results.
+3. **Regression and scope check**: newly introduced concerns or confirmation that none were found.
+4. **Required follow-up**: only findings that remain unresolved or require a human decision.

--- a/src/advisor.ts
+++ b/src/advisor.ts
@@ -23,8 +23,22 @@ import { log } from "./log"
  *    guidance saying so, and the executor carries on.
  */
 
-/** Default cap on consultations per phase attempt, mirroring the reference pattern's `max_uses`. */
-export const defaultAdvisorMaxCalls = 3
+/**
+ * Default cap on consultations per phase attempt.
+ *
+ * Deliberately high enough to never bind in practice. The reference pattern's
+ * `max_uses` is a small number because it assumes one decision worth advising;
+ * a Convoy phase is a whole implementation session, and a low cap silently turns
+ * the advisor off partway through — the executor keeps working, unadvised, which
+ * is the failure mode the feature exists to prevent, and the one hardest to
+ * notice from the outside.
+ *
+ * The budget stays finite so the runtime keeps its cost ceiling, its
+ * `advisor.budget_exhausted` event, and its `used/max` counters. Anyone who
+ * actually wants a tight leash sets `advisorMaxCalls` on the step or in
+ * `defaults`, which both outrank this.
+ */
+export const defaultAdvisorMaxCalls = 1000
 
 /**
  * Name of the custom tool the executor calls to consult its advisor on demand.

--- a/src/built-in-prompts.ts
+++ b/src/built-in-prompts.ts
@@ -4,6 +4,10 @@ import advisorTiming from "../prompts/advisor-timing.md" with { type: "text" }
 import bugAuditor from "../prompts/bug-auditor.md" with { type: "text" }
 import cleanCodeAuditor from "../prompts/clean-code-auditor.md" with { type: "text" }
 import designPolisher from "../prompts/design-polisher.md" with { type: "text" }
+import fixerImplementer from "../prompts/fixer-implementer.md" with { type: "text" }
+import fixerReporter from "../prompts/fixer-reporter.md" with { type: "text" }
+import fixerTestAuthor from "../prompts/fixer-test-author.md" with { type: "text" }
+import fixerValidator from "../prompts/fixer-validator.md" with { type: "text" }
 import hunterCorrectness from "../prompts/hunter-correctness.md" with { type: "text" }
 import hunterMaxReport from "../prompts/hunter-max-report.md" with { type: "text" }
 import hunterMemory from "../prompts/hunter-memory.md" with { type: "text" }
@@ -41,6 +45,10 @@ export const builtInPrompts: Record<string, string> = {
   "bug-auditor": bugAuditor,
   "clean-code-auditor": cleanCodeAuditor,
   "design-polisher": designPolisher,
+  "fixer-implementer": fixerImplementer,
+  "fixer-reporter": fixerReporter,
+  "fixer-test-author": fixerTestAuthor,
+  "fixer-validator": fixerValidator,
   "hunter-correctness": hunterCorrectness,
   "hunter-max-report": hunterMaxReport,
   "hunter-memory": hunterMemory,

--- a/src/config.ts
+++ b/src/config.ts
@@ -251,7 +251,7 @@ defaults:
   # commitMessageModel: anthropic/claude-haiku-4-5 # optional: model that writes the squashed commit message for "convoy finish"
   # worktree: true # optional: run each job on a fresh branch in its own worktree (default); false runs in the current tree
   # advisor: anthropic/claude-opus-5 # optional: reviewing model consulted at phase decision points
-  # advisorMaxCalls: 3 # optional: consultation budget per phase attempt
+  # advisorMaxCalls: 1000 # optional: consultation budget per phase attempt; the default is effectively unlimited, set this to put a real cap on it
   # advisorAuditPolicy: summary # summary (hashes), redacted (lengths), or full content retention
 
 # Agents are matched by name with Markdown prompts next to this config:

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -19,11 +19,13 @@ const kimiModel = "openrouter/moonshotai/kimi-k3"
 /** GPT 5.6 Sol: the implementation workhorse, and at xhigh the consensus reporter for the review/hunter pipelines. */
 const solModel = "openai/gpt-5.6-sol"
 const solXhighModel = `${solModel}#xhigh`
+/** The cheap GPT 5.6: reserved for synthesis steps that only re-read reports another phase already wrote. */
+const lunaModel = "openai/gpt-5.6-luna"
 
 // Per-step models the built-in `implement` pipeline pins. Exported so `convoy init`'s
 // inlined copy of that pipeline stays in sync with the built-in it claims to mirror.
 export const defaultImplementerModel = solModel
-export const defaultImplementReviewModel = glmModel
+export const defaultImplementReviewModel = kimiModel
 export const defaultAdversarialModel = kimiModel
 
 /** The six specialty audit tracks shared by `hunter` and `hunter-max`; each maps to a `hunter-<track>` agent. */
@@ -57,7 +59,7 @@ export const builtInAgents: readonly AgentSpec[] = [
   {
     name: "design-polisher",
     description: "Polishes new UI following the repo's design system, without redesigning",
-    defaultModel: defaultOpusModel,
+    defaultModel: kimiModel,
     temperature: 0.2,
     builtIn: true,
   },
@@ -166,6 +168,37 @@ export const builtInAgents: readonly AgentSpec[] = [
     name: "implementation-validator",
     description: "Final no-edit validator for applied blocking-finding fixes",
     defaultModel: defaultOpusModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  // fixer: supplied findings turned into proven regression tests, minimal fixes, and an audited outcome report.
+  {
+    name: "fixer-test-author",
+    description: "Creates or identifies focused regression tests for supplied findings and proves which ones fail before a production fix",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    builtIn: true,
+  },
+  {
+    name: "fixer-implementer",
+    description: "Applies minimal production fixes only for findings proven by the Fixer reproduction phase",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    builtIn: true,
+  },
+  {
+    name: "fixer-validator",
+    description: "Independently verifies Fixer outcomes, targeted checks, and absence of regressions",
+    defaultModel: fallbackModel,
+    temperature: 0.1,
+    readOnly: true,
+    builtIn: true,
+  },
+  {
+    name: "fixer-reporter",
+    description: "Produces the final per-finding Fixer outcome report from the complete evidence trail",
+    defaultModel: fallbackModel,
     temperature: 0.1,
     readOnly: true,
     builtIn: true,
@@ -314,12 +347,12 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
     ],
   },
   "implement-lite": {
-    description: "Like implement, but drops every code-writing phase to GLM 5.2 to reduce cost; design and adversarial run on Opus",
+    description: "Like implement, but drops every code-writing phase to GLM 5.2 to reduce cost; design runs on Kimi K3 and adversarial on Opus",
     steps: [
       { agent: "implementer", model: glmModel, reports: "none" },
       { agent: "patterns", model: glmModel },
       { agent: "security", model: glmModel },
-      { agent: "design", model: defaultOpusModel },
+      { agent: "design", model: kimiModel },
       { agent: "tests", model: glmModel, reports: "none" },
       { agent: "adversarial", model: defaultOpusModel, reports: "all" },
     ],
@@ -338,7 +371,7 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
       // defaults.advisor and quietly re-advise these phases.
       { agent: "patterns", model: glmModel, advisor: false },
       { agent: "security", model: glmModel, advisor: false },
-      { agent: "design", model: glmModel, advisor: false },
+      { agent: "design", model: kimiModel, advisor: false },
       { agent: "tests", model: glmModel, advisor: false, reports: "none" },
       // The adversarial pass is the one place the expensive model should own the
       // loop: its whole job is the judgement an advisor would otherwise supply.
@@ -362,17 +395,17 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
   },
   "review-lite": {
     description:
-      "Like review, but swaps GPT 5.6 Terra xhigh for GLM 5.2 in scope and the audit fan-out; the report and the parallel audit slot keep Opus.",
+      "Like review, but every phase runs on a low-cost model: GLM 5.2 scopes and writes the report, and the audit fan-out pairs GLM 5.2 with Kimi K3 instead of Opus.",
     steps: [
       { agent: "review-scope", name: "scope", model: glmModel, reports: "none", diff: true },
       {
         parallel: [
-          { agent: "clean-code-auditor", name: "clean-code", models: [glmModel, defaultOpusModel], reports: ["scope"] },
-          { agent: "security-reviewer", name: "security", models: [glmModel, defaultOpusModel], reports: ["scope"] },
-          { agent: "bug-auditor", name: "bugs", models: [glmModel, defaultOpusModel], reports: ["scope"] },
+          { agent: "clean-code-auditor", name: "clean-code", models: [glmModel, kimiModel], reports: ["scope"] },
+          { agent: "security-reviewer", name: "security", models: [glmModel, kimiModel], reports: ["scope"] },
+          { agent: "bug-auditor", name: "bugs", models: [glmModel, kimiModel], reports: ["scope"] },
         ],
       },
-      { agent: "review-report", name: "report", model: defaultOpusModel, reports: "all" },
+      { agent: "review-report", name: "report", model: glmModel, reports: "all" },
     ],
   },
   refine: {
@@ -416,11 +449,24 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
         ],
       },
       { agent: "implementation-triage", name: "triage", model: defaultOpusModel },
-      { agent: "design", model: defaultOpusModel },
+      { agent: "design", model: kimiModel },
       { agent: "tests", reports: "none" },
       { agent: "implementation-final-review", name: "final-review", model: defaultOpusModel, reports: "all" },
       { agent: "implementation-fixer", name: "fixes", reports: ["final-review"] },
       { agent: "implementation-validator", name: "validator", model: defaultOpusModel, reports: "all" },
+    ],
+  },
+  // The follow-up to a report-only run: feed it the findings (as the prompt or an
+  // attachment) and every one of them ends with a traceable verdict. The three
+  // working phases carry the cost; the reporter only re-reads reports that already
+  // exist, so it runs on the cheapest GPT 5.6 rather than the most capable model.
+  fixer: {
+    description: "Turn supplied findings into proven regression tests, targeted fixes, independent validation, and a traceable final report",
+    steps: [
+      { agent: "fixer-test-author", name: "reproduction", model: fallbackModel, reports: "none", diff: true },
+      { agent: "fixer-implementer", name: "fixes", model: fallbackModel, reports: ["reproduction"] },
+      { agent: "fixer-validator", name: "validation", model: fallbackModel, reports: ["reproduction", "fixes"] },
+      { agent: "fixer-reporter", name: "report", model: lunaModel, reports: ["reproduction", "fixes", "validation"] },
     ],
   },
   "review-cc": {

--- a/test/advisor-runtime.test.ts
+++ b/test/advisor-runtime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 
-import type { AdvisorResult, AdvisorUsage } from "../src/advisor"
+import { defaultAdvisorMaxCalls, type AdvisorResult, type AdvisorUsage } from "../src/advisor"
 import { createAdvisorRuntime, firstWriteMessage, totalAdvisorUsage } from "../src/advisor-runtime"
 import type { AgentStep } from "../src/types"
 
@@ -112,12 +112,36 @@ describe("advisor budget", () => {
     expect(calls).toHaveLength(2)
   })
 
-  test("defaults to three consultations per attempt", async () => {
+  test("defaults to a budget that does not bind in practice", async () => {
     const { runtime: advisors, calls } = runtime()
     const handle = advisors.begin("ses_1", step())!
 
-    for (let i = 0; i < 4; i++) await handle.consult("on-demand")
-    expect(calls).toHaveLength(3)
+    // A phase is a whole implementation session, so the default must not quietly
+    // switch the advisor off partway through the work it exists to advise.
+    for (let i = 0; i < 50; i++) expect((await handle.consult("on-demand")).ok).toBe(true)
+    expect(calls).toHaveLength(50)
+    expect(defaultAdvisorMaxCalls).toBeGreaterThanOrEqual(1000)
+  })
+
+  test("the default is still finite, so the cost ceiling and its exhausted event survive", async () => {
+    const { runtime: advisors, calls } = runtime()
+    const handle = advisors.begin("ses_1", step())!
+
+    for (let i = 0; i < defaultAdvisorMaxCalls; i++) await handle.consult("on-demand")
+    const overBudget = await handle.consult("on-demand")
+
+    expect(overBudget.ok).toBe(false)
+    expect(overBudget.text).toContain("advisor budget")
+    expect(calls).toHaveLength(defaultAdvisorMaxCalls)
+  })
+
+  test("an explicit cap still outranks the default, in both directions", async () => {
+    const { runtime: advisors, calls } = runtime()
+    const tight = advisors.begin("ses_1", step({ advisorMaxCalls: 1 }))!
+
+    expect((await tight.consult("on-demand")).ok).toBe(true)
+    expect((await tight.consult("on-demand")).ok).toBe(false)
+    expect(calls).toHaveLength(1)
   })
 
   test("accumulates usage from successful consultations only", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -311,7 +311,7 @@ describe("config precedence", () => {
   test("an unknown pipeline lists what exists", async () => {
     const dir = await projectWithConfig()
     await expect(parseCommand(["--dir", dir, "--pipeline", "ghost", "prompt"])).rejects.toThrow(
-      'unknown pipeline "ghost" (available: hunter, hunter-max, implement, implement-advised, implement-lite, quick, refine, review, review-cc, review-lite, ultra-implement, ultra-refine)',
+      'unknown pipeline "ghost" (available: fixer, hunter, hunter-max, implement, implement-advised, implement-lite, quick, refine, review, review-cc, review-lite, ultra-implement, ultra-refine)',
     )
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -345,7 +345,7 @@ describe("agent registry", () => {
     const design = registry.find((agent) => agent.name === "design-polisher")
     expect(design).toMatchObject({ model: "openai/gpt-5.5#xhigh", temperature: 0.5, readOnly: true, builtIn: true })
     // The built-in preference survives underneath the override.
-    expect(design?.defaultModel).toBe("anthropic/claude-opus-5")
+    expect(design?.defaultModel).toBe("openrouter/moonshotai/kimi-k3")
 
     const custom = registry.find((agent) => agent.name === "api-reviewer")
     expect(custom).toMatchObject({ description: "Reviews APIs", readOnly: true, builtIn: false })
@@ -371,6 +371,10 @@ describe("agent registry", () => {
       "implementation-final-review",
       "implementation-fixer",
       "implementation-validator",
+      "fixer-test-author",
+      "fixer-implementer",
+      "fixer-validator",
+      "fixer-reporter",
       "hunter-correctness",
       "hunter-memory",
       "hunter-performance",
@@ -392,7 +396,7 @@ describe("pipeline selection", () => {
     expect(selectPipelineSpec(config, "implement").steps).toEqual(["tests"])
     expect(selectPipelineSpec(undefined, "implement").steps.length).toBeGreaterThan(1)
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(
-      'unknown pipeline "ghost" (available: hunter, hunter-max, implement, implement-advised, implement-lite, quick, refine, review, review-cc, review-lite, ultra-implement, ultra-refine)',
+      'unknown pipeline "ghost" (available: fixer, hunter, hunter-max, implement, implement-advised, implement-lite, quick, refine, review, review-cc, review-lite, ultra-implement, ultra-refine)',
     )
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(ConfigError)
   })

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -125,7 +125,7 @@ describe("built-in implement-lite pipeline", () => {
     expect(byName.patterns?.model).toBe("openrouter/z-ai/glm-5.2")
     expect(byName.security?.model).toBe("openrouter/z-ai/glm-5.2")
     expect(byName.tests?.model).toBe("openrouter/z-ai/glm-5.2")
-    expect(byName.design?.model).toBe("anthropic/claude-opus-5")
+    expect(byName.design?.model).toBe("openrouter/moonshotai/kimi-k3")
     expect(byName.adversarial?.model).toBe("anthropic/claude-opus-5")
   })
 
@@ -140,18 +140,19 @@ describe("built-in implement-lite pipeline", () => {
     expect(byName.patterns).toMatchObject({ model: "openrouter/z-ai/glm-5.2" })
     expect(byName.security).toMatchObject({ model: "openrouter/z-ai/glm-5.2" })
     expect(byName.tests).toMatchObject({ model: "openrouter/z-ai/glm-5.2" })
-    expect(byName.design).toMatchObject({ model: "anthropic/claude-opus-5" })
+    expect(byName.design).toMatchObject({ model: "openrouter/moonshotai/kimi-k3" })
     expect(byName.adversarial).toMatchObject({ model: "anthropic/claude-opus-5" })
   })
 
-  test("keeps GLM 5.2 scoped to the implementation, lite, advised, refine, and hunter pipelines", () => {
+  test("keeps GLM 5.2 scoped to the lite, advised, refine, and hunter pipelines", () => {
     const glmPipelines = Object.entries(builtInPipelines)
       .filter(([, spec]) => JSON.stringify(spec).includes("openrouter/z-ai/glm-5.2"))
       .map(([name]) => name)
 
     // The hunter pipelines use GLM as one specialty voice in their fan-out, not as a cost downgrade.
     // implement-advised keeps it as the audit executor, which is what makes it comparable to implement-lite.
-    expect(glmPipelines).toEqual(["implement", "implement-lite", "implement-advised", "review-lite", "refine", "hunter", "hunter-max"])
+    // `implement` itself is GLM-free: its one GLM step was design, which now runs on Kimi K3.
+    expect(glmPipelines).toEqual(["implement-lite", "implement-advised", "review-lite", "refine", "hunter", "hunter-max"])
   })
 })
 
@@ -243,16 +244,16 @@ describe("built-in review-lite pipeline", () => {
     expect(pipeline.steps.some((step) => step.type === "human")).toBe(false)
   })
 
-  test("swaps scope and the first audit slot to GLM 5.2 while keeping opus for the second slot and the report", () => {
+  test("runs entirely on low-cost models: GLM 5.2 scopes and reports, and the fan-out pairs GLM 5.2 with Kimi K3", () => {
     const pipeline = reviewLite()
     expect(stepNames(pipeline)).toEqual([
       "scope",
       "clean-code__openrouter-z-ai-glm-5-2",
-      "clean-code__anthropic-claude-opus-5",
+      "clean-code__openrouter-moonshotai-kimi-k3",
       "security__openrouter-z-ai-glm-5-2",
-      "security__anthropic-claude-opus-5",
+      "security__openrouter-moonshotai-kimi-k3",
       "bugs__openrouter-z-ai-glm-5-2",
-      "bugs__anthropic-claude-opus-5",
+      "bugs__openrouter-moonshotai-kimi-k3",
       "report",
     ])
 
@@ -260,17 +261,21 @@ describe("built-in review-lite pipeline", () => {
       pipeline.steps.filter((step): step is AgentStep => step.type === "agent").map((step) => [step.name, step]),
     )
     expect(byName.scope?.model).toBe("openrouter/z-ai/glm-5.2")
-    expect(byName.report?.model).toBe("anthropic/claude-opus-5")
+    expect(byName.report?.model).toBe("openrouter/z-ai/glm-5.2")
     expect(byName.report?.inputFiles).toEqual([
       "prd.md",
       "reports/scope.md",
       "reports/clean-code__openrouter-z-ai-glm-5-2.md",
-      "reports/clean-code__anthropic-claude-opus-5.md",
+      "reports/clean-code__openrouter-moonshotai-kimi-k3.md",
       "reports/security__openrouter-z-ai-glm-5-2.md",
-      "reports/security__anthropic-claude-opus-5.md",
+      "reports/security__openrouter-moonshotai-kimi-k3.md",
       "reports/bugs__openrouter-z-ai-glm-5-2.md",
-      "reports/bugs__anthropic-claude-opus-5.md",
+      "reports/bugs__openrouter-moonshotai-kimi-k3.md",
     ])
+  })
+
+  test("never reaches for Opus, which is what separates it from review", () => {
+    expect(JSON.stringify(builtInPipelines["review-lite"])).not.toContain("opus")
   })
 })
 
@@ -289,6 +294,52 @@ describe("built-in refine pipeline", () => {
     expect(byName.triage).toMatchObject({ model: "anthropic/claude-opus-5" })
     expect(byName.fixes).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
     expect(byName.validator).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
+  })
+})
+
+describe("built-in fixer pipeline", () => {
+  const fixer = () =>
+    resolvePipeline({ name: "fixer", spec: builtInPipelines.fixer!, agents: builtInAgents }).steps.filter(
+      (step): step is AgentStep => step.type === "agent",
+    )
+
+  test("runs reproduction, fixes, validation, and report in that order", () => {
+    expect(fixer().map((step) => step.name)).toEqual(["reproduction", "fixes", "validation", "report"])
+  })
+
+  test("carries the working phases on Terra xhigh and drops the reporter to the cheap GPT 5.6", () => {
+    const byName = Object.fromEntries(fixer().map((step) => [step.name, step]))
+
+    expect(byName.reproduction).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
+    expect(byName.fixes).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
+    expect(byName.validation).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
+    expect(byName.report?.model).toBe("openai/gpt-5.6-luna")
+    expect(byName.report?.variant).toBeUndefined()
+  })
+
+  test("lets reproduction and fixes write, and keeps validation and report audit-only", () => {
+    const byName = Object.fromEntries(fixer().map((step) => [step.name, step]))
+
+    expect(byName.reproduction?.readOnly).toBeUndefined()
+    expect(byName.fixes?.readOnly).toBeUndefined()
+    expect(byName.validation?.readOnly).toBe(true)
+    expect(byName.report?.readOnly).toBe(true)
+  })
+
+  test("gives every phase the exact evidence trail its prompt reads by path", () => {
+    const byName = Object.fromEntries(fixer().map((step) => [step.name, step]))
+
+    // reproduction opens on the findings alone; the diff is what it proves them against.
+    expect(byName.reproduction?.inputFiles).toEqual(["prd.md"])
+    expect(byName.reproduction?.inputDiff).toBe(true)
+    expect(byName.fixes?.inputFiles).toEqual(["prd.md", "reports/reproduction.md"])
+    expect(byName.validation?.inputFiles).toEqual(["prd.md", "reports/reproduction.md", "reports/fixes.md"])
+    expect(byName.report?.inputFiles).toEqual([
+      "prd.md",
+      "reports/reproduction.md",
+      "reports/fixes.md",
+      "reports/validation.md",
+    ])
   })
 })
 
@@ -464,7 +515,7 @@ describe("pipeline resolution", () => {
     }
 
     const withoutDefault = agentSteps(spec)
-    expect(withoutDefault[1]).toMatchObject({ model: "anthropic/claude-opus-5" })
+    expect(withoutDefault[1]).toMatchObject({ model: "openrouter/moonshotai/kimi-k3" })
 
     const [implementer, design, tests] = resolvePipeline({
       name: "test",


### PR DESCRIPTION
Ports the pipelines that only existed in `~/.convoy` so they ship with convoy instead of living on one machine, and fixes two defaults that were quietly under-delivering.

## `fixer` — new built-in

Supplied findings become **proven regression tests before any production edit**, then minimal fixes, independent validation, and a final per-finding verdict (`fixed`, `already-resolved`, `not-reproducible`, `not-automatable`, `blocked`, `not-fixed`). It never promotes an unproven finding to fixed.

It's the stricter alternative to `refine` when you already have a specific list of findings and want each one individually accounted for rather than triaged in bulk.

| Step | Agent | Model |
|---|---|---|
| `reproduction` | `fixer-test-author` | `openai/gpt-5.6-terra#xhigh` |
| `fixes` | `fixer-implementer` | `openai/gpt-5.6-terra#xhigh` |
| `validation` | `fixer-validator` (read-only) | `openai/gpt-5.6-terra#xhigh` |
| `report` | `fixer-reporter` (read-only) | `openai/gpt-5.6-luna` |

The three working phases carry the cost. The reporter only re-reads reports that already exist, so it runs on the cheap GPT 5.6 (`$0.20`/`$1.20` per Mtok) rather than the most capable model.

## `design` — model and prompt

The step was passing its checklist without changing much of anything: the old prompt was a conformance list ("use tokens, not literals") that an agent can satisfy without touching the UI.

- **Model → Kimi K3** in all four pipelines that have a design step (`implement`, `implement-lite`, `implement-advised`, `ultra-implement`), and as the agent's own default.
- **Prompt rewritten** to add a second bar beyond repo consistency: flat visual hierarchy, rhythmless spacing, decorative gradients/shadows, emoji-as-icons, invented one-off values, generic copy ("Oops! Something went wrong"), density drift, reinvented components, symmetry for its own sake.
- The phase must **apply fixes or justify why the UI already passes**. A report with no edits and no reasoning is a failed run.

## `review-lite` — now genuinely lite

Nothing runs on Opus any more. GLM 5.2 scopes the diff and writes the report; each parallel audit fans out across GLM 5.2 + Kimi K3.

## Advisor budget default: 3 → 1000

The cap of 3 consultations per phase attempt was modelled on the reference pattern's `max_uses`, which assumes **one decision** worth advising. A Convoy phase is a whole implementation session.

Hitting the cap silently drops the advisor partway through, and the executor keeps working unadvised — the exact failure the feature exists to prevent, and the hardest one to notice from the outside.

The budget stays **finite**, so the cost ceiling, the `advisor.budget_exhausted` event, and the `used/max` counters all still work. `advisorMaxCalls` on a step or in `defaults` still outranks it for anyone who wants a real cap.

## Verification

`bun run typecheck` clean, `747 pass / 0 fail`.

Resolved plans checked against a clean `HOME` (the local `~/.convoy` config shadows built-ins, so an unisolated `--plan` shows the override, not the built-in):

- `fixer` → Terra xhigh ×3, then `openai/gpt-5.6-luna`
- `review-lite` → GLM scope, GLM+Kimi fan-out, GLM report, no Opus anywhere
- `design` → Kimi K3 in all four pipelines
- advised steps report `max 1000 calls/attempt`

New tests cover the `fixer` step order, per-step models, read-only flags, and the exact report chain each prompt reads by path; that `review-lite` never reaches for Opus; and that the advisor default doesn't bind in practice while staying finite and overridable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzLrAF7qz84TwhVoXp6Zbc