### PR TITLE
chore(release): v0.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convoy",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps `package.json` to `0.1.3`. Merging this and pushing the `v0.1.3` tag triggers the Release workflow, which builds and publishes the binaries for all four platforms.

## What ships in v0.1.3

From #38:

- **`fixer` — new built-in pipeline.** Supplied findings become proven regression tests *before* any production edit, then minimal fixes, independent validation, and a final per-finding verdict. Terra xhigh on the three working phases; the reporter runs on `openai/gpt-5.6-luna`.
- **`design` — sharper.** Now on Kimi K3 in all four pipelines that have the step, and the prompt gained a second bar beyond repo consistency: it targets generic "AI slop" (flat hierarchy, rhythmless spacing, decorative gradients, emoji-as-icons, invented one-off values, generic copy, reinvented components) and must either apply fixes or justify why the UI already passes.
- **`review-lite` — genuinely lite.** Nothing runs on Opus: GLM 5.2 scopes and reports, and each audit fans out across GLM 5.2 + Kimi K3.
- **Advisor budget default 3 → 1000.** A cap of 3 was modelled on advising a single decision, but a Convoy phase is a whole implementation session; hitting it silently dropped the advisor mid-phase. Still finite (the cost ceiling and `budget_exhausted` event survive) and still overridable per step or via `defaults`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VzLrAF7qz84TwhVoXp6Zbc