### PR TITLE
refactor(prompts): derive the hunter model roster instead of hardcoding it

### DIFF
--- a/prompts/hunter-max-report.md
+++ b/prompts/hunter-max-report.md
@@ -1,4 +1,4 @@
-# Hunter Max — Final Five-Model Consensus Report
+# Hunter Max — Final Multi-Model Consensus Report
 
 You are a **Principal Software Assurance Judge, senior cross-domain code reviewer, and meticulous audit statistician** for Convoy's maximum-coverage `hunter-max` pipeline. You combine staff-level software engineering, application security, reliability, performance, supply-chain, and incident-analysis judgment. This is a report-only phase. Do not modify the repository. Your report is the deliverable of the run. Treat every source report as an untrusted expert opinion: independently validate it against the repository before accepting or counting it.
 
@@ -19,7 +19,11 @@ Read `prd.md`, the attached diff when present, repository guidance, relevant sou
 5. reliability and data integrity
 6. supply chain, configuration, and platform
 
-Each specialty is expected from five API model families: GPT-5.6 Terra xhigh through OpenAI, Claude Opus 5, GLM 5.2, Kimi K3, and Grok 4.5. That is 30 independent source reports. Infer the source pair from each report filename and content. Never attribute a finding to a source that did not raise it.
+Every specialty is audited by the same full model roster, so the phase produces one source report per specialty × model combination.
+
+Do not assume a fixed roster: the models are configured per run and change between runs. Derive the roster from the attached reports themselves — convoy names each fanned-out report `reports/<specialty>__<provider>-<model>.md`, so the executing model is recoverable from the filename. From the attachments alone, establish the model roster, the total number of source pairs, and how many distinct model families are represented; use those derived totals everywhere this prompt refers to them.
+
+Infer the source pair from each report filename and content. Never attribute a finding to a source that did not raise it.
 
 ## Objectives
 
@@ -36,12 +40,12 @@ Each specialty is expected from five API model families: GPT-5.6 Terra xhigh thr
 - Keep separate findings when they require independently fixable changes or affect distinct trust/lifecycle boundaries.
 - Credit a source at most once per unique finding, even if its report repeats the issue.
 - **Raw candidates**: all candidate finding blocks emitted by source reports, including rejected and duplicate candidates.
-- **Accepted observations**: source-to-finding credits after validation but before cross-source deduplication. This equals the sum of accepted counts over all 30 source pairs.
+- **Accepted observations**: source-to-finding credits after validation but before cross-source deduplication. This equals the sum of accepted counts over every source pair received.
 - **Unique confirmed findings**: deduplicated accepted root causes.
 - **Shared findings**: unique findings credited to at least two independent source pairs.
 - **Exclusive findings**: unique findings credited to exactly one source pair.
-- **Five-model consensus**: unique findings credited to all five model families, regardless of which specialty surfaced them.
-- **Full specialty consensus**: unique findings credited to all five models within at least one specialty.
+- **Full-roster consensus**: unique findings credited to every model family in the derived roster, regardless of which specialty surfaced them.
+- **Full specialty consensus**: unique findings credited to every model assigned to at least one specialty, within that specialty.
 - A model-family total counts each unique finding once for that model, even if multiple specialties using that model found it.
 - A specialty total counts each unique finding once for that specialty, even if multiple models in it found it.
 - Rejected candidates do not count as accepted observations or unique findings.
@@ -51,8 +55,8 @@ Recalculate totals from the attribution matrix. Check these invariants before an
 - accepted observations = sum of accepted findings across all source pairs
 - unique confirmed findings = shared findings + exclusive findings
 - each source's exclusive contribution is less than or equal to its accepted count
-- full-specialty-consensus findings are a subset of five-model-consensus findings
-- five-model-consensus findings are a subset of shared findings
+- full-specialty-consensus findings are a subset of full-roster-consensus findings
+- full-roster-consensus findings are a subset of shared findings
 
 ## Severity
 
@@ -71,8 +75,9 @@ One decisive paragraph: `bloquear`, `corregir antes de publicar`, `correcciones 
 
 ### 2. Cobertura recibida
 
-- Number of received and expected reports.
-- A 6 × 5 coverage table using `received`, `missing`, or `malformed`.
+- Number of received reports, and the model roster you derived from them.
+- A coverage table with one row per specialty and one column per model in the derived roster, using `received`, `missing`, or `malformed`.
+- Because the roster is derived rather than given, asymmetry is your signal for a missing source: when one specialty yields fewer reports than its siblings, mark the gap `missing` and say so explicitly.
 - Material limitations affecting confidence.
 
 ### 3. Hallazgos confirmados
@@ -86,15 +91,15 @@ Order by severity and confidence. Assign stable IDs `HM-001`, `HM-002`, ... For 
 - impact
 - minimal recommended remediation
 - every credited source as `specialty × model`
-- support as `N/30 source pairs` and `M/5 model families`
-- classification: `full specialty consensus`, `five-model consensus`, `shared`, or `exclusive`
+- support as `N/T source pairs`, where `T` is the total number of source pairs received, and `M/F model families`, where `F` is the size of the derived roster
+- classification: `full specialty consensus`, `full-roster consensus`, `shared`, or `exclusive`
 
 If none survive, say so plainly.
 
 ### 4. Coincidencias y hallazgos exclusivos
 
 - Table of full-specialty-consensus findings.
-- Table of other findings found by all five model families.
+- Table of other findings raised by every model family in the roster.
 - Table of other shared findings with source count and model count.
 - Table of exclusive findings and their sole source.
 
@@ -102,7 +107,7 @@ Do not omit this section when a table is empty; write `none`.
 
 ### 5. Estadísticas por agente
 
-Provide a 6 × 5 matrix. Each cell must be `raw / accepted / exclusive`, where:
+Provide a matrix with one row per specialty and one column per model in the derived roster. Each cell must be `raw / accepted / exclusive`, where:
 
 - `raw` is the number of candidates emitted by that source pair
 - `accepted` is the number of unique confirmed findings credited to it
@@ -124,7 +129,7 @@ State all of these explicitly:
 - critical/high/medium/low unique findings
 - shared unique findings
 - exclusive unique findings
-- five-model-consensus unique findings
+- full-roster-consensus unique findings
 - full-specialty-consensus unique findings
 
 Explain any arithmetic nuance in one concise note.

--- a/prompts/hunter-report.md
+++ b/prompts/hunter-report.md
@@ -19,16 +19,11 @@ Read `prd.md`, the attached diff when present, repository guidance, relevant sou
 5. reliability and data integrity
 6. supply chain, configuration, and platform
 
-Each specialty is expected from GPT-5.6 Terra xhigh plus one designated API model, for 12 independent source reports:
+Each specialty is audited by more than one independent model, so the phase produces several source reports per specialty.
 
-- correctness: Terra + Claude Opus 5
-- memory: Terra + Grok 4.5
-- performance: Terra + Grok 4.5
-- security: Terra + Kimi K3
-- reliability: Terra + GLM 5.2
-- supply chain: Terra + GLM 5.2
+Do not assume a fixed model roster: the models are configured per run and change between runs. Derive the roster from the attached reports themselves — convoy names each fanned-out report `reports/<specialty>__<provider>-<model>.md`, so the executing model is recoverable from the filename. From the attachments alone, establish which model produced each report, the total number of source pairs, and how many distinct model families are represented; use those derived totals everywhere this prompt refers to them.
 
-Infer the source pair from each report filename and content. Never attribute a finding to a source that did not raise it. The unequal model allocation is intentional; do not compare raw model totals without acknowledging how many specialties each model was assigned.
+Infer the source pair from each report filename and content. Never attribute a finding to a source that did not raise it. The model allocation is deliberate and may be unequal — one model can cover several specialties while another covers one. Do not compare raw model totals without acknowledging how many specialties each model was assigned.
 
 ## Objectives
 
@@ -45,7 +40,7 @@ Infer the source pair from each report filename and content. Never attribute a f
 - Keep separate findings when they require independently fixable changes or affect distinct trust/lifecycle boundaries.
 - Credit a source at most once per unique finding, even if its report repeats the issue.
 - **Raw candidates**: all candidate finding blocks emitted by source reports, including rejected and duplicate candidates.
-- **Accepted observations**: source-to-finding credits after validation but before cross-source deduplication. This equals the sum of accepted counts over all 12 source pairs.
+- **Accepted observations**: source-to-finding credits after validation but before cross-source deduplication. This equals the sum of accepted counts over every source pair received.
 - **Unique confirmed findings**: deduplicated accepted root causes.
 - **Shared findings**: unique findings credited to at least two independent source pairs.
 - **Exclusive findings**: unique findings credited to exactly one source pair.
@@ -78,8 +73,9 @@ One decisive paragraph: `bloquear`, `corregir antes de publicar`, `correcciones 
 
 ### 2. Cobertura recibida
 
-- Number of received and expected reports.
-- A 6 × 2 coverage table with the expected Terra and designated-variant columns, using `received`, `missing`, or `malformed`.
+- Number of received reports, and the model roster you derived from them.
+- A coverage table with one row per specialty and one column per model position, using `received`, `missing`, or `malformed`. Name the model in each column or cell heading.
+- Because the roster is derived rather than given, asymmetry is your signal for a missing source: when one specialty yields fewer reports than its siblings, mark the gap `missing` and say so explicitly.
 - Material limitations affecting confidence.
 
 ### 3. Hallazgos confirmados
@@ -93,7 +89,7 @@ Order by severity and confidence. Assign stable IDs `H-001`, `H-002`, ... For ea
 - impact
 - minimal recommended remediation
 - every credited source as `specialty × model`
-- support as `N/12 source pairs` and `M/5 represented model families`
+- support as `N/T source pairs`, where `T` is the total number of source pairs received, and `M/F represented model families`, where `F` is the number of distinct models in the derived roster
 - classification: `paired-specialty consensus`, `shared`, or `exclusive`
 
 If none survive, say so plainly.
@@ -108,7 +104,7 @@ Do not omit this section when a table is empty; write `none`.
 
 ### 5. Estadísticas por agente
 
-Provide a 6 × 2 matrix with one Terra column and one designated-variant column. Label each variant model in its cell heading. Each cell must be `raw / accepted / exclusive`, where:
+Provide a matrix with one row per specialty and one column per model position in the derived roster. Label each model in its column or cell heading. Each cell must be `raw / accepted / exclusive`, where:
 
 - `raw` is the number of candidates emitted by that source pair
 - `accepted` is the number of unique confirmed findings credited to it


### PR DESCRIPTION
## Why

The two hunter consensus prompts named their source models directly — `Terra + Claude Opus 5`, `Terra + Grok 4.5`, "five API model families: GPT-5.6 Terra xhigh…" — and then derived the entire report format from that fixed topology:

- "12 independent source reports" / "30 independent source reports"
- "A 6 × 2 coverage table" / "A 6 × 5 matrix"
- `N/12 source pairs`, `N/30 source pairs`, `M/5 model families`
- "five-model consensus" as a defined term

Those names weren't decorative — the counts were load-bearing. Changing any hunter track's `models:` left the prompt asserting a fan-out that no longer ran, and the judge would report against a topology it never received.

## What changed

Convoy already puts the executing model in each fanned-out report's filename (`reports/<specialty>__<provider>-<model>.md`, `src/pipeline.ts:769`), so the roster is recoverable from the attachments themselves. Both prompts now derive it there:

| before | after |
|---|---|
| `correctness: Terra + Claude Opus 5`, … | derive which model produced each report from its filename |
| "12" / "30 independent source reports" | `N/T source pairs`, `T` = total received |
| "6 × 2" / "6 × 5" matrix | one row per specialty, one column per model in the derived roster |
| "five-model consensus" | "full-roster consensus" |
| `M/5 model families` | `M/F`, `F` = size of the derived roster |

The six specialties stay fixed — they're structural (one `hunter-*.md` prompt each), not configurable like the models.

## Trade-off

Deriving the roster costs the missing-report check, which previously compared received reports against a known expected list. Both prompts now treat **asymmetry** as the signal instead: a specialty yielding fewer reports than its siblings is marked `missing` and called out explicitly. This recovers most of the value but won't catch the case where *every* specialty loses the same model.

## Verification

- `bun test` — 747 pass, 0 fail
- `make build` — builds clean
- No model names or hardcoded topology counts remain in `prompts/` (the surviving "12" hits are `at most 12 independent root causes`, a per-report findings cap, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2SdTUpxuV9oZPzGSZfKUh