### PR TITLE
chore(release): v0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convoy",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release. Bumps `package.json` 0.1.3 → 0.1.4.

Contents since v0.1.3:

- #40 — `refactor(prompts)`: the hunter consensus prompts derive their model roster from the attached report filenames instead of naming models and fan-out counts inline, so changing a hunter track's `models:` no longer leaves the judge reporting against a topology it never received.

Merging this then tagging `v0.1.4` triggers the release workflow and publishes the binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2SdTUpxuV9oZPzGSZfKUh