### PR TITLE
feat(agents): eject prompts on request instead of seeding them all

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ To use different providers, authenticate them in OpenCode and select models as `
 curl -fsSL https://github.com/Inakitajes/convoy/releases/latest/download/install.sh | sh
 ```
 
-The script detects your platform, downloads the matching release binary, **verifies it against the release's `SHA256SUMS`**, installs it into `~/.local/bin`, and creates `~/.convoy/config.yaml` plus `~/.convoy/agents/*.md` if they do not already exist. Nothing is installed unless the checksum matches and the downloaded binary reports its own version, and the final move is atomic, so a failed install never leaves a partial binary behind.
+The script detects your platform, downloads the matching release binary, **verifies it against the release's `SHA256SUMS`**, installs it into `~/.local/bin`, and creates `~/.convoy/config.yaml` if it does not already exist. Nothing is installed unless the checksum matches and the downloaded binary reports its own version, and the final move is atomic, so a failed install never leaves a partial binary behind.
 
 Options are accepted as environment variables, or as flags after `sh -s --`:
 
@@ -175,7 +175,7 @@ bun install
 make install
 ```
 
-This builds a local binary in `~/.local/bin/convoy` and creates `~/.convoy/config.yaml` plus `~/.convoy/agents/*.md` with Convoy's default configuration if they do not already exist.
+This builds a local binary in `~/.local/bin/convoy` and creates `~/.convoy/config.yaml` with Convoy's default configuration if it does not already exist.
 
 ## Usage
 
@@ -473,16 +473,31 @@ Keys: `↑/↓` move, `enter` edit/expand, `tab` switch tab, `a` add, `d` delete
 
 ## Initializing config files (`convoy init`)
 
-`convoy config` is interactive; `convoy init` is its non-interactive counterpart: it writes a commented starter config and copies the built-in agent prompts so you can customize them in place.
+`convoy config` is interactive; `convoy init` is its non-interactive counterpart: it writes a commented starter config.
 
 ```bash
-convoy init                # .convoy/config.yaml + .convoy/agents/*.md in the current repo
+convoy init                # .convoy/config.yaml in the current repo
 convoy init --dir ../app   # same, in another repo
-convoy init --global       # ~/.convoy/config.yaml + ~/.convoy/agents/*.md
-convoy init --force        # overwrite existing files
+convoy init --global       # ~/.convoy/config.yaml
+convoy init --force        # overwrite an existing config
 ```
 
-The generated config documents every key (commented out) and inlines the built-in `implement` pipeline so it's immediately editable. The copied `agents/*.md` prompts are picked up by name — edit them to override a built-in agent's prompt, or declare a new agent in the config and add its prompt file. Existing files are never overwritten unless `--force` is given. `make install` runs `convoy init --global` automatically, so a fresh install ships with a ready-to-edit global config.
+`init` deliberately writes **no** agent prompts. A file at `agents/<name>.md` overrides its built-in permanently, so seeding all of them would freeze every prompt at the version you installed and silently discard the improved prompts that later `convoy update` runs ship.
+
+## Overriding an agent prompt (`convoy agents eject`)
+
+To customize a built-in agent's system prompt, copy that one prompt out and edit it:
+
+```bash
+convoy agents                             # list the ejectable agents
+convoy agents eject implementer           # .convoy/agents/implementer.md in the current repo
+convoy agents eject design-polisher --global   # ~/.convoy/agents/design-polisher.md
+convoy agents eject implementer --force   # overwrite a prompt you already ejected
+```
+
+The ejected file wins over the built-in from then on, **including across upgrades** — `convoy update` ships new built-in prompts that an ejected file will shadow. Eject only what you mean to own, and delete the file to go back to the built-in. The runtime-safety and advisor-timing prompts are not ejectable: they are always read from the built-ins, so a copy would be inert.
+
+The generated config documents every key (commented out) and inlines the built-in `implement` pipeline so it's immediately editable. Prompts under `agents/` are picked up by name — eject one to override a built-in agent's prompt, or declare a new agent in the config and add its prompt file by hand. Existing files are never overwritten unless `--force` is given, and `--force` never reclaims an ejected prompt. `make install` runs `convoy init --global` automatically, so a fresh install ships with a ready-to-edit global config.
 
 ## Project Context And Custom Agents
 
@@ -496,7 +511,7 @@ CLAUDE.md
 
 Use `.convoy/rules.md` for project-specific Convoy instructions. It is intentionally the only Convoy rules filename to avoid ambiguous precedence. `AGENTS.md` and `CLAUDE.md` are treated as additional repo context.
 
-Built-in agent prompts live as Markdown files under `prompts/`. A project can fully replace a built-in agent prompt with:
+Built-in agent prompts live as Markdown files under `prompts/` and are compiled into the binary. A project can fully replace one with `convoy agents eject <agent>`, which produces:
 
 ```text
 .convoy/

--- a/install.sh
+++ b/install.sh
@@ -209,8 +209,9 @@ if [ -n "$previous" ] && [ "$previous" != "$installed_version" ]; then
   info "  ${DIM}replaced ${previous}${RESET}"
 fi
 
-# Creates ~/.convoy/config.yaml and ~/.convoy/agents/*.md when absent, matching
-# what `make install` does for source installs. Never overwrites existing config.
+# Creates ~/.convoy/config.yaml when absent, matching what `make install` does
+# for source installs. Never overwrites existing config, and never writes agent
+# prompts -- those are ejected one at a time with `convoy agents eject`.
 if [ -z "$NO_INIT" ]; then
   if "$target" init --global --quiet 2>/dev/null; then
     step "Default configuration ready at ~/.convoy"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,11 @@
 import { readFile } from "node:fs/promises"
-import { resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 
-import { buildAgentRegistry, emptyHooksConfig, loadMergedConvoyConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ConvoyDefaults } from "./config"
+import { buildAgentRegistry, ejectAgentPrompt, emptyHooksConfig, globalConfigPath, loadMergedConvoyConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ConvoyDefaults } from "./config"
 import { detectBaseRef } from "./git"
 import { openRouterKeySources } from "./limits"
 import { log } from "./log"
-import { defaultGptModel, defaultGptVariant, defaultPipeline, defaultPipelineName, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
+import { builtInAgents, defaultGptModel, defaultGptVariant, defaultPipeline, defaultPipelineName, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
 import { defaultMaxConcurrentAgents, parseModel, run } from "./runner"
 import { buildRunPlan } from "./run-plan"
 import { confirmRunPlan, renderRunPlan } from "./run-review"
@@ -80,6 +80,7 @@ export type CliCommand =
   | { type: "runs"; runID?: string }
   | { type: "config"; targetDir: string }
   | { type: "init"; options: InitOptions }
+  | { type: "agents"; action: "eject"; agentName: string; options: InitOptions }
   | { type: "finish"; options: FinishOptions }
   | { type: "auth"; provider: "openrouter"; action: "set" | "remove" | "status" }
   | { type: "version" }
@@ -129,6 +130,18 @@ export async function parseAndRun(argv: string[]) {
     if (!command.options.quiet) {
       const scope = command.options.global ? "global config" : "project config"
       process.stdout.write(`${result.created ? "created" : "ensured"} ${scope}: ${result.path}\n`)
+    }
+    return
+  }
+  if (command.type === "agents") {
+    const configDir = command.options.global ? dirname(globalConfigPath()) : join(command.options.targetDir, ".convoy")
+    const result = await ejectAgentPrompt(configDir, command.agentName, command.options.force)
+    if (!command.options.quiet) {
+      process.stdout.write(
+        result.created
+          ? `ejected ${command.agentName}: ${result.path}\n\nThis file now overrides the built-in prompt and will keep doing so across upgrades. Delete it to go back to the built-in.\n`
+          : `${result.path} already exists; pass --force to overwrite it\n`,
+      )
     }
     return
   }
@@ -389,6 +402,21 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
     const parsed = parseInitArgs(argv.slice(1))
     if (parsed.help) return { type: "help", text: initHelp() }
     return { type: "init", options: parsed }
+  }
+  if (argv[0] === "agents") {
+    const rest = argv.slice(1)
+    if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h") return { type: "help", text: agentsHelp() }
+    if (rest[0] !== "eject") throw new Error("usage: convoy agents eject <agent> [--global] [--dir <path>] [--force]")
+    // The agent name is positional; everything after it reuses init's flag
+    // parser so --global/--dir/--force mean exactly what they mean for init.
+    const name = rest[1]
+    if (name === undefined || name.startsWith("-")) {
+      if (name === "--help" || name === "-h") return { type: "help", text: agentsHelp() }
+      throw new Error("usage: convoy agents eject <agent> [--global] [--dir <path>] [--force]")
+    }
+    const parsed = parseInitArgs(rest.slice(2))
+    if (parsed.help) return { type: "help", text: agentsHelp() }
+    return { type: "agents", action: "eject", agentName: name, options: parsed }
   }
   if (argv[0] === "finish") {
     const { finishHelp, parseFinishArgs } = await import("./finish-command")
@@ -766,6 +794,7 @@ Usage:
   convoy --prompt-file prd.md --file lib/onboarding --file test/onboarding_test.dart
   convoy --pipeline bug-fix --prompt-file bug.md
   convoy init
+  convoy agents eject <agent>
   convoy finish
   convoy update [--check]
   convoy runs [run-id]
@@ -775,8 +804,10 @@ Usage:
 Commands:
   convoy                   Open an interactive TUI launcher to pick a pipeline,
                            enter a prompt, and toggle run options
-  init                     Create .convoy/config.yaml and .convoy/agents/*.md in the target repo
-  init --global            Create ~/.convoy/config.yaml and ~/.convoy/agents/*.md
+  init                     Create .convoy/config.yaml in the target repo
+  init --global            Create ~/.convoy/config.yaml
+  agents eject <agent>     Copy one built-in agent prompt to agents/<agent>.md to
+                           override it ("convoy agents" lists the available ones)
   finish                   Squash this branch's convoy commits into one conventional commit
                            created with your own git identity, so it lands signed and attributed
                            ("convoy finish --help" for options; [f] on the run dashboard does the same)
@@ -827,7 +858,8 @@ Flags:
 Config files:
   ~/.convoy/config.yaml    user defaults, created by make install or convoy init --global
   .convoy/config.yaml      project-local overrides, created by convoy init
-  agents/*.md              Markdown prompts loaded by matching the agent name
+  agents/*.md              Markdown prompts loaded by matching the agent name; only
+                           present once you eject one, and they shadow the built-in
 
 Config keys:
   defaults:                model, maxAttempts, baseRef, pipeline, worktree, autoAcceptJudgeModel,
@@ -875,12 +907,41 @@ function writeUpdateResult(result: UpdateResult) {
 function initHelp() {
   return `convoy init [--global] [--force] [--dir <path>]
 
-Create Convoy's default config file and agent prompt Markdown files. Existing files are not overwritten unless --force is set.
+Create Convoy's default config file. An existing config is not overwritten unless --force is set.
+
+Writes no agent prompts: a prompt file under agents/ permanently overrides its
+built-in, so copying them all would freeze every prompt at the installed version.
+Use "convoy agents eject <agent>" to copy the one you actually want to change.
 
 Options:
   --global                 Write ~/.convoy/config.yaml instead of a project config
   --dir <path>             Target repo for .convoy/config.yaml (default: cwd)
   --force                  Overwrite an existing config file
   --quiet                  Suppress status output
+`
+}
+
+function agentsHelp() {
+  return `convoy agents eject <agent> [--global] [--force] [--dir <path>]
+
+Copy one built-in agent prompt to agents/<agent>.md so you can edit it.
+
+The copy takes precedence over the built-in from then on, including across
+upgrades -- "convoy update" ships new built-in prompts that an ejected file will
+shadow. Eject only what you mean to own, and delete the file to return to the
+built-in. Delete the file to return to the built-in.
+
+Options:
+  --global                 Write ~/.convoy/agents/<agent>.md instead of a project prompt
+  --dir <path>             Target repo for .convoy/agents/<agent>.md (default: cwd)
+  --force                  Overwrite an existing prompt file
+  --quiet                  Suppress status output
+
+Agents:
+${builtInAgents
+  .map((agent) => agent.name)
+  .sort()
+  .map((name) => `  ${name}`)
+  .join("\n")}
 `
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -339,27 +339,29 @@ export function projectConfigPath(targetDir: string) {
 /** Re-exported from workspace so callers don't need both modules. */
 export { globalConfigPath }
 
-/** Writes the global config at ~/.convoy/config.yaml (plus default agent prompts). */
+/** Writes the global config at ~/.convoy/config.yaml. */
 export async function writeDefaultGlobalConfig(force = false): Promise<ConfigWriteResult> {
   return writeDefaultConvoyConfig(globalConfigPath(), force)
 }
 
-/** Writes a project config at <targetDir>/.convoy/config.yaml (plus default agent prompts). */
+/** Writes a project config at <targetDir>/.convoy/config.yaml. */
 export async function writeDefaultProjectConfig(targetDir: string, force = false): Promise<ConfigWriteResult> {
   await assertDirectory(targetDir)
   return writeDefaultConvoyConfig(projectConfigPath(targetDir), force)
 }
 
 /**
- * Writes the commented template config and copies every built-in agent prompt
- * to `<dirname(path)>/agents/<name>.md`. Existing files are left alone unless
- * `force` is set. Agent prompts live next to the config file under `agents/`,
- * mirroring how the loader discovers them.
+ * Writes the commented template config. Existing files are left alone unless
+ * `force` is set.
+ *
+ * Deliberately writes no agent prompts. A prompt file under `agents/` shadows
+ * its built-in for good (see `loadAgentPrompt`), so seeding all of them froze
+ * every prompt at the installed version and silently defeated later upgrades.
+ * Prompts are now copied one at a time, on request, by `ejectAgentPrompt`.
  */
 export async function writeDefaultConvoyConfig(path: string, force = false): Promise<ConfigWriteResult> {
   const configDir = dirname(path)
   await mkdir(configDir, { recursive: true })
-  await writeDefaultAgentPrompts(configDir, force)
   try {
     await writeFile(path, defaultConvoyConfig, { flag: force ? "w" : "wx" })
     return { path, created: true }
@@ -369,19 +371,33 @@ export async function writeDefaultConvoyConfig(path: string, force = false): Pro
   }
 }
 
-async function writeDefaultAgentPrompts(configDir: string, force: boolean) {
+/**
+ * Copies one built-in agent prompt to `<configDir>/agents/<name>.md` so it can
+ * be edited as a deliberate override. Only agents are ejectable: the runtime
+ * safety and advisor-timing prompts are always read from the built-ins, so a
+ * copy of either would be inert and misleading.
+ */
+export async function ejectAgentPrompt(configDir: string, agentName: string, force = false): Promise<ConfigWriteResult> {
+  if (!builtInAgents.some((agent) => agent.name === agentName)) {
+    // The pipeline-step aliases are the likeliest near-miss, so resolve rather
+    // than just listing 30 names at someone who typed a name convoy accepts.
+    const aliased = agentAliases[agentName]
+    if (aliased) throw new Error(`${agentName} is a pipeline-step alias; eject the agent itself: convoy agents eject ${aliased}`)
+    const names = builtInAgents.map((agent) => agent.name).sort().join(", ")
+    throw new Error(`unknown built-in agent: ${agentName}\n\nAvailable agents: ${names}`)
+  }
+  const body = builtInPrompts[agentName]
+  if (body === undefined) throw new Error(`missing built-in prompt: add prompts/${agentName}.md to src/built-in-prompts.ts`)
+
   const agentsDir = join(configDir, "agents")
   await mkdir(agentsDir, { recursive: true })
-  for (const agent of builtInAgents) {
-    const target = join(agentsDir, `${agent.name}.md`)
-    const body = builtInPrompts[agent.name]
-    if (body === undefined) throw new Error(`missing built-in prompt: add prompts/${agent.name}.md to src/built-in-prompts.ts`)
-    try {
-      await writeFile(target, body, { flag: force ? "w" : "wx" })
-    } catch (error) {
-      if (!force && isErrno(error, "EEXIST")) continue
-      throw error
-    }
+  const path = join(agentsDir, `${agentName}.md`)
+  try {
+    await writeFile(path, body, { flag: force ? "w" : "wx" })
+    return { path, created: true }
+  } catch (error) {
+    if (!force && isErrno(error, "EEXIST")) return { path, created: false }
+    throw error
   }
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { existsSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -409,6 +410,35 @@ describe("init command", () => {
     await expect(parseCommand(["init", "extra"])).rejects.toThrow("usage: convoy init")
   })
 
+  test("parses agents eject, reusing init's flags", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-cli-eject-"))
+    dirs.push(dir)
+
+    const local = await parseCommand(["agents", "eject", "implementer", "--dir", dir, "--force"])
+    expect(local.type).toBe("agents")
+    if (local.type === "agents") {
+      expect(local.agentName).toBe("implementer")
+      expect(local.options).toMatchObject({ targetDir: dir, global: false, force: true })
+    }
+
+    const global = await parseCommand(["agents", "eject", "design-polisher", "--global"])
+    expect(global.type).toBe("agents")
+    if (global.type === "agents") {
+      expect(global.agentName).toBe("design-polisher")
+      expect(global.options).toMatchObject({ global: true })
+    }
+  })
+
+  test("agents without an ejectable target prints help instead of failing", async () => {
+    const bare = await parseCommand(["agents"])
+    expect(bare.type).toBe("help")
+    // The help has to name the agents, since it is the only place they are listed.
+    if (bare.type === "help") expect(bare.text).toContain("implementer")
+
+    await expect(parseCommand(["agents", "eject"])).rejects.toThrow("usage: convoy agents eject")
+    await expect(parseCommand(["agents", "list"])).rejects.toThrow("usage: convoy agents eject")
+  })
+
   test("creates project config without overwriting unless forced", async () => {
     const dir = await mkdtemp(join(tmpdir(), "convoy-cli-init-write-"))
     dirs.push(dir)
@@ -418,16 +448,30 @@ describe("init command", () => {
     expect(await readFile(path, "utf8")).toContain("version: 1")
     expect(await readFile(path, "utf8")).toContain("#   implementer:")
     expect(await readFile(path, "utf8")).toContain("# maxAttempts: 2")
-    expect(await readFile(join(dir, ".convoy", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+    expect(existsSync(join(dir, ".convoy", "agents"))).toBe(false)
 
     await writeFile(path, "version: 1\nattachments:\n  - custom.md\n")
-    await writeFile(join(dir, ".convoy", "agents", "implementer.md"), "# Custom Implementer\n")
     await parseAndRun(["init", "--dir", dir, "--quiet"])
     expect(await readFile(path, "utf8")).toContain("custom.md")
-    expect(await readFile(join(dir, ".convoy", "agents", "implementer.md"), "utf8")).toContain("# Custom Implementer")
 
     await parseAndRun(["init", "--dir", dir, "--force", "--quiet"])
     expect(await readFile(path, "utf8")).not.toContain("custom.md")
-    expect(await readFile(join(dir, ".convoy", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+  })
+
+  test("agents eject writes only the requested prompt", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-cli-eject-write-"))
+    dirs.push(dir)
+    const prompt = join(dir, ".convoy", "agents", "implementer.md")
+
+    await parseAndRun(["agents", "eject", "implementer", "--dir", dir, "--quiet"])
+    expect(await readFile(prompt, "utf8")).toContain("# Implementer")
+    expect(existsSync(join(dir, ".convoy", "agents", "design-polisher.md"))).toBe(false)
+
+    await writeFile(prompt, "# Mine\n")
+    await parseAndRun(["agents", "eject", "implementer", "--dir", dir, "--quiet"])
+    expect(await readFile(prompt, "utf8")).toBe("# Mine\n")
+
+    await parseAndRun(["agents", "eject", "implementer", "--dir", dir, "--force", "--quiet"])
+    expect(await readFile(prompt, "utf8")).toContain("# Implementer")
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -1,4 +1,5 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { existsSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -9,6 +10,7 @@ import {
   checkPipelineResolves,
   ConfigError,
   defaultConfigTemplate,
+  ejectAgentPrompt,
   isValidModelString,
   loadConvoyConfig,
   loadGlobalConvoyConfig,
@@ -22,6 +24,7 @@ import {
   writeDefaultConvoyConfig,
   writeDefaultProjectConfig,
 } from "../src/config"
+import { loadAgentPrompt } from "../src/agents"
 import {
   builtInAgents,
   builtInPipelines,
@@ -700,9 +703,8 @@ describe("default config init", () => {
     expect(body).toContain("#   api-reviewer:")
     expect(config.defaults).toEqual({})
     expect(config.agents).toEqual({})
-    for (const agent of builtInAgents) {
-      expect(await readFile(join(dir, "agents", `${agent.name}.md`), "utf8")).toContain("#")
-    }
+    // Seeding prompts would shadow every built-in for good, so init writes none.
+    expect(existsSync(join(dir, "agents"))).toBe(false)
     expect(config.pipelines.implement?.steps).toEqual([
       { agent: "implementer", model: defaultImplementerModel, reports: "none" },
       "patterns",
@@ -723,17 +725,27 @@ describe("default config init", () => {
 
     expect(await writeDefaultConvoyConfig(path)).toEqual({ path, created: true })
     expect(await readFile(path, "utf8")).toContain("version: 1")
-    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Implementer")
 
     await writeFile(path, "version: 1\nattachments:\n  - custom.md\n")
-    await writeFile(join(dir, "agents", "implementer.md"), "# Custom Implementer\n")
     expect(await writeDefaultConvoyConfig(path)).toEqual({ path, created: false })
     expect(await readFile(path, "utf8")).toContain("custom.md")
-    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Custom Implementer")
 
     expect(await writeDefaultConvoyConfig(path, true)).toEqual({ path, created: true })
     expect(await readFile(path, "utf8")).not.toContain("custom.md")
-    expect(await readFile(join(dir, "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+  })
+
+  test("init leaves an ejected prompt alone even with --force", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-config-force-"))
+    dirs.push(dir)
+    const path = join(dir, "config.yaml")
+
+    await writeDefaultConvoyConfig(path)
+    const ejected = await ejectAgentPrompt(dir, "implementer")
+    await writeFile(ejected.path, "# Custom Implementer\n")
+
+    // --force is about the config file; it must never reclaim an override.
+    await writeDefaultConvoyConfig(path, true)
+    expect(await readFile(ejected.path, "utf8")).toBe("# Custom Implementer\n")
   })
 
   test("writes project default config under .convoy", async () => {
@@ -744,7 +756,66 @@ describe("default config init", () => {
     expect(await writeDefaultProjectConfig(dir)).toEqual({ path, created: true })
     expect(await writeDefaultProjectConfig(dir)).toEqual({ path, created: false })
     expect(await readFile(path, "utf8")).toContain("pipelines:")
-    expect(await readFile(join(dir, ".convoy", "agents", "implementer.md"), "utf8")).toContain("# Implementer")
+    expect(existsSync(join(dir, ".convoy", "agents"))).toBe(false)
+  })
+})
+
+describe("ejecting agent prompts", () => {
+  test("copies one built-in prompt and reports whether it wrote", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-eject-"))
+    dirs.push(dir)
+    const path = join(dir, "agents", "implementer.md")
+
+    expect(await ejectAgentPrompt(dir, "implementer")).toEqual({ path, created: true })
+    expect(await readFile(path, "utf8")).toContain("# Implementer")
+    // Only the requested agent lands on disk.
+    expect(existsSync(join(dir, "agents", "design-polisher.md"))).toBe(false)
+  })
+
+  test("refuses to clobber an edited prompt unless forced", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-eject-force-"))
+    dirs.push(dir)
+    const path = join(dir, "agents", "implementer.md")
+
+    await ejectAgentPrompt(dir, "implementer")
+    await writeFile(path, "# Mine\n")
+
+    expect(await ejectAgentPrompt(dir, "implementer")).toEqual({ path, created: false })
+    expect(await readFile(path, "utf8")).toBe("# Mine\n")
+
+    expect(await ejectAgentPrompt(dir, "implementer", true)).toEqual({ path, created: true })
+    expect(await readFile(path, "utf8")).toContain("# Implementer")
+  })
+
+  test("an ejected prompt overrides the built-in for the run", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-eject-override-"))
+    dirs.push(dir)
+    // Point the global home at an empty dir so this asserts the project layer
+    // rather than whatever the developer happens to have in ~/.convoy/agents.
+    const previousHome = process.env.CONVOY_HOME
+    process.env.CONVOY_HOME = dir
+    try {
+      expect(loadAgentPrompt("implementer", dir)).toContain("# Implementer")
+      const ejected = await ejectAgentPrompt(join(dir, ".convoy"), "implementer")
+      await writeFile(ejected.path, "# Overridden\n")
+      expect(loadAgentPrompt("implementer", dir)).toContain("# Overridden")
+    } finally {
+      if (previousHome === undefined) delete process.env.CONVOY_HOME
+      else process.env.CONVOY_HOME = previousHome
+    }
+  })
+
+  test("rejects unknown agents and non-agent prompts, listing what is available", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-eject-unknown-"))
+    dirs.push(dir)
+
+    expect(ejectAgentPrompt(dir, "nope")).rejects.toThrow("unknown built-in agent: nope")
+    expect(ejectAgentPrompt(dir, "nope")).rejects.toThrow("implementer")
+    // An alias is a name convoy otherwise accepts, so it gets redirected rather than listed at.
+    expect(ejectAgentPrompt(dir, "patterns")).rejects.toThrow("convoy agents eject pattern-auditor")
+    // Always read from the built-ins, so a copy would be inert.
+    expect(ejectAgentPrompt(dir, "runtime-safety")).rejects.toThrow("unknown built-in agent")
+    expect(existsSync(join(dir, "agents"))).toBe(false)
   })
 })
 


### PR DESCRIPTION
## The problem

`convoy init` copied **all 30** built-in agent prompts into `<config>/agents/`. Every one of those files permanently shadows its built-in — `loadAgentPrompt` resolves project → global → built-in (`src/agents.ts:86`) — so running `init` once froze every prompt at the version installed that day.

The consequence is silent and compounding: `convoy update` ships improved built-in prompts, and none of them are ever read again. Nothing on screen says so. There was also no way for convoy to distinguish *"I copied this to read it"* from *"I deliberately override this"*, because seeding produced byte-identical files either way.

`make install` runs `convoy init --global`, so this fired on every source install.

## The change

**`init` writes only the config file.** No prompts.

**New: `convoy agents eject <agent>`** copies one prompt, when you actually want to own it.

```bash
convoy agents                                  # list the ejectable agents
convoy agents eject implementer                # .convoy/agents/implementer.md
convoy agents eject design-polisher --global   # ~/.convoy/agents/design-polisher.md
convoy agents eject implementer --force        # overwrite one you already ejected
```

Details worth knowing:

- Reuses `init`'s `--global` / `--dir` / `--force` / `--quiet` flags, so they mean exactly what they already meant.
- Refuses to clobber an edited prompt without `--force`.
- Prints the cost on success: the file shadows the built-in **across upgrades**, delete it to go back.
- A pipeline-step alias (`patterns`, `security`, `design`, `tests`, `adversarial`) is redirected to its real agent instead of being listed at: `patterns is a pipeline-step alias; eject the agent itself: convoy agents eject pattern-auditor`.
- `runtime-safety` and `advisor-timing` are **not** ejectable — `loadAgentPrompt` always reads both from the built-ins, so a copy would be inert and misleading.

**Nothing breaks for existing users.** Already-ejected prompts keep working untouched. `init --force` is about the config file and now never reclaims an override — there's a regression test for exactly that.

## Verification

- `bun test` — 755 pass, 0 fail (updated the 4 tests that asserted seeding; added 7 covering eject, the force semantics, the override taking effect via `loadAgentPrompt`, and the rejection paths)
- `tsc --noEmit` clean, `make build` clean
- Exercised against the built binary: `init` writes only `config.yaml`; `eject implementer` writes only `agents/implementer.md`; re-running without `--force` declines; unknown names list all 30 agents

Docs updated: README (`init` section, new eject section, install/make-install descriptions), `install.sh` comment, and both `--help` texts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2SdTUpxuV9oZPzGSZfKUh