### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convoy",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
Minor release. Bumps `package.json` 0.1.4 → 0.2.0.

Contents since v0.1.4:

- #42 — `feat(agents)`: `convoy init` no longer seeds all 30 built-in agent prompts. New `convoy agents eject <agent>` copies one prompt when you actually want to override it.

**Why minor and not patch:** `init` stops doing something it used to do. Anyone who relied on it to populate `agents/` now has to eject explicitly. Already-ejected prompts are unaffected.

Merging this then tagging `v0.2.0` triggers the release workflow and publishes the binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A2SdTUpxuV9oZPzGSZfKUh