### PR TITLE
chore(release): v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convoy",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
Release v0.3.0.

Minor bump from v0.2.0: ships the command palette (new user-facing feature) plus responsive footer hints from #45.

- Bumps `package.json` version `0.2.0` → `0.3.0`
- Tag `v0.3.0` will be pushed on the merge commit, triggering the Release workflow (build binaries, smoke-test, publish GitHub Release)