### PR TITLE
chore(release): v0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convoy",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch release v0.3.1 to validate the release workflow after bumping all GitHub Actions dependencies:

- actions/checkout v4.4.0 → v7.0.1 (#34)
- actions/upload-artifact v4.6.2 → v7.0.1 (#31)
- actions/download-artifact v4.3.0 → v8.0.1 (#33)
- softprops/action-gh-release v2.6.2 → v3.0.2 (#32)

No application code changes. Bumps package.json version 0.3.0 → 0.3.1. Tag v0.3.1 will be pushed on the merge commit to trigger the Release workflow and confirm the bumped actions work end-to-end.