### PR TITLE
feat(worktree): decide isolation from the current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ defaults:
   autoAcceptJudgeModel: anthropic/claude-haiku-4-5   # model for smart auto-accept (--smart); defaults to the run's model
   branchNameModel: anthropic/claude-haiku-4-5        # proposes worktree branch names (may look up referenced issues); you confirm the name
   commitMessageModel: anthropic/claude-haiku-4-5     # writes the conventional commit `convoy finish` squashes a run into; you edit it before it lands
-  worktree: true                   # run each job on a new branch in its own worktree (default); false runs in the current tree
+  worktree: true                   # force a new branch + worktree for every run; false always runs in the current tree. Unset decides per branch (isolate on a trunk, run in place on a branch)
   advisor: anthropic/claude-opus-5   # optional; a stronger model consulted at every step's decision points
   advisorMaxCalls: 1000              # optional; consultations allowed per phase attempt (default 1000 — effectively unlimited; set it lower to cap advisor spend)
   advisorAuditPolicy: summary        # summary (hash-only default), redacted, or full transcript/advice content
@@ -644,7 +644,9 @@ Every interactive manual run now displays its fully resolved plan before reposit
 
 ### Isolating a run in a worktree
 
-**This is the default.** Every run gets a new branch checked out under `~/.convoy/worktrees/<branch>`, leaving your current checkout untouched — which is what makes the branch safely rewritable by [`convoy finish`](#finishing-a-run) afterwards. Opt out per run with `--no-worktree`, or permanently with `defaults.worktree: false`. `--branch <name>` pins the name instead of asking the naming model, which is what an unattended or scripted run should use.
+An isolated run gets a new branch checked out under `~/.convoy/worktrees/<branch>`, leaving your current checkout untouched — which is what makes the branch safely rewritable by [`convoy finish`](#finishing-a-run) afterwards.
+
+**The default depends on where you are.** On a trunk — `main`, `master`, `develop`, `trunk`, or whatever `origin/HEAD` points at — Convoy isolates, because you almost certainly don't want a pipeline committing straight onto it. Once you're on a branch of your own, it runs in place: you already made the branch you want the work on. A detached HEAD isolates too. Force either end per run with `--worktree` / `--no-worktree`, or permanently with `defaults.worktree: true` / `false`; the launcher shows which way the default went and why, next to the toggle. `--branch <name>` pins the name instead of asking the naming model, which is what an unattended or scripted run should use.
 
 The branch is always agreed with you first, in a **Branch** step between Options and Review:
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import { buildAgentRegistry, ejectAgentPrompt, emptyHooksConfig, globalConfigPath, loadMergedConvoyConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ConvoyDefaults } from "./config"
-import { detectBaseRef } from "./git"
+import { detectBaseRef, resolveWorktreeDefault } from "./git"
 import { openRouterKeySources } from "./limits"
 import { log } from "./log"
 import { builtInAgents, defaultGptModel, defaultGptVariant, defaultPipeline, defaultPipelineName, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
@@ -583,7 +583,7 @@ export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOpt
     // A resumed run continues in the directory its metadata recorded — which is
     // already the worktree, when the original run made one — so it never creates
     // another.
-    worktree: parsed.resumeRunID ? false : (parsed.worktree ?? defaults.worktree ?? true),
+    worktree: parsed.resumeRunID ? false : await resolveWorktreeOption(parsed, defaults),
     ...(parsed.branch ? { branch: parsed.branch } : {}),
     includeDirty: parsed.includeDirty ?? false,
     yolo: parsed.yolo ?? false,
@@ -605,6 +605,19 @@ export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOpt
   if (!options.resumeRunID) validateStepFilters(pipeline, options)
 
   return options
+}
+
+// Worktree source: flag > config defaults.worktree > the current branch.
+// An unset config means "decide per branch", not "always isolate": on a trunk a
+// run should get its own worktree, but on a branch you're already where you
+// want the work. The launcher applies the same default itself, so an interactive
+// run reaches this with parsed.worktree already set.
+async function resolveWorktreeOption(parsed: ParsedArgs, defaults: ConvoyDefaults): Promise<boolean> {
+  const explicit = parsed.worktree ?? defaults.worktree
+  if (explicit !== undefined) return explicit
+  const auto = await resolveWorktreeDefault(parsed.targetDir)
+  log.info(`worktree: ${auto.isolate ? "on" : "off"} (${auto.reason})`)
+  return auto.isolate
 }
 
 // Base source: flag > config defaults.baseRef > auto-detection (never persisted).
@@ -850,8 +863,9 @@ Flags:
   --max-attempts <n>       Attempts per step before failing (default: 2)
   --max-concurrent <n>     Max agents running at once within a parallel group (default: ${defaultMaxConcurrentAgents}); smaller groups are unaffected
   --base <ref>             Branch/base for calculating diffs (default: auto-detected — origin's default branch, else main/master/develop/trunk, else the current branch)
-  --worktree               Run on a fresh branch in its own worktree under ~/.convoy/worktrees (default)
+  --worktree               Run on a fresh branch in its own worktree under ~/.convoy/worktrees
   --no-worktree            Run in the current working tree instead
+                           (default: worktree on a trunk branch, current tree on any other)
   --branch <name>          Name for the worktree branch, instead of asking the naming model
   --dir <path>             Target repo (default: cwd)
 

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -2010,7 +2010,7 @@ function describeDefault(key: keyof ConvoyDefaults): string {
     case "commitMessageModel":
       return "Model that writes the squashed commit message for finish (default: anthropic/claude-haiku-4-5)."
     case "worktree":
-      return "Run each job on a fresh branch in its own worktree (on when unset)."
+      return "Run each job on a fresh branch in its own worktree. Unset decides per branch: on for a trunk, off once you're on a branch."
     case "maxAttempts":
       return "Attempts per step before failing."
     case "baseRef":

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,7 +60,10 @@ export type ConvoyDefaults = {
   branchNameModel?: string
   /** Model that writes the squashed commit message for `convoy finish`; falls back to the built-in cheap default. */
   commitMessageModel?: string
-  /** Run each job on a fresh branch in its own worktree. On by default; set false to run in place. */
+  /**
+   * Force worktree isolation on (true) or off (false) for every run. Unset is
+   * not "on": it decides per branch, isolating only when HEAD sits on a trunk.
+   */
   worktree?: boolean
   /** Advising model for every step that doesn't set its own; unset means no advisor anywhere. */
   advisor?: string
@@ -249,7 +252,7 @@ defaults:
   # pipeline: implement
   # branchNameModel: anthropic/claude-haiku-4-5 # optional: model that names worktree branches
   # commitMessageModel: anthropic/claude-haiku-4-5 # optional: model that writes the squashed commit message for "convoy finish"
-  # worktree: true # optional: run each job on a fresh branch in its own worktree (default); false runs in the current tree
+  # worktree: true # optional: force a fresh branch + worktree for every run; false always runs in the current tree. Unset decides per branch: isolate on a trunk (main/master/develop/trunk or the detected base), run in place on any other branch
   # advisor: anthropic/claude-opus-5 # optional: reviewing model consulted at phase decision points
   # advisorMaxCalls: 1000 # optional: consultation budget per phase attempt; the default is effectively unlimited, set this to put a real cap on it
   # advisorAuditPolicy: summary # summary (hashes), redacted (lengths), or full content retention

--- a/src/git.ts
+++ b/src/git.ts
@@ -95,6 +95,9 @@ export type BaseRefDetection = {
   source: "origin-head" | "probe" | "current-branch"
 }
 
+/** Branch names conventionally used as a repo's trunk, probed in order when origin/HEAD says nothing. */
+export const baseBranchNames = ["main", "master", "develop", "trunk"] as const
+
 /**
  * Best-effort detection of the branch to diff against when neither --base nor
  * defaults.baseRef is set: the remote's default branch (origin/HEAD), then
@@ -119,7 +122,7 @@ export async function detectBaseRef(cwd: string): Promise<BaseRefDetection | und
     if (await commitExists(remoteBranch)) return { ref: remoteBranch, source: "origin-head" }
   }
 
-  for (const name of ["main", "master", "develop", "trunk"]) {
+  for (const name of baseBranchNames) {
     if (await commitExists(name)) return { ref: name, source: "probe" }
   }
 
@@ -355,6 +358,47 @@ export async function currentBranch(cwd: string): Promise<string | undefined> {
   const result = await execFile("git", ["symbolic-ref", "--quiet", "--short", "HEAD"], { cwd, allowFailure: true })
   if (result.exitCode !== 0) return undefined
   return result.stdout.trim() || undefined
+}
+
+export type WorktreeDefault = {
+  isolate: boolean
+  /** Short human-readable justification, shown next to the launcher's toggle so the default never looks arbitrary. */
+  reason: string
+}
+
+/**
+ * Whether a run should isolate itself in a fresh worktree when nothing said
+ * otherwise: you're on the trunk, so committing here is probably not what you
+ * meant. Already on a branch, the branch is almost certainly where you want the
+ * work to land.
+ *
+ * Two criteria, unioned. `detectBaseRef` is the repo-accurate one but answers
+ * for a single base, so a repo whose origin/HEAD is `main` would not recognize
+ * `develop`; the conventional names cover that. Never throws — anything
+ * unexpected falls back to isolating, which is the older, safer behavior.
+ */
+export async function resolveWorktreeDefault(cwd: string): Promise<WorktreeDefault> {
+  try {
+    // Covers both a detached HEAD and "not a repo at all"; the latter fails in
+    // ensureRepoReady moments later with a message that actually explains it.
+    const branch = await currentBranch(cwd)
+    if (!branch) return { isolate: true, reason: "no branch is checked out" }
+
+    if (baseBranchNames.includes(branch as (typeof baseBranchNames)[number])) {
+      return { isolate: true, reason: `${branch} is a base branch` }
+    }
+
+    const detected = await detectBaseRef(cwd)
+    // detectBaseRef can answer with the remote-tracking form when no local
+    // checkout of the default branch exists (see the origin/HEAD path above).
+    if (detected && (detected.ref === branch || detected.ref === `origin/${branch}`)) {
+      return { isolate: true, reason: `${branch} is this repo's base branch` }
+    }
+
+    return { isolate: false, reason: `${branch} is not a base branch` }
+  } catch {
+    return { isolate: true, reason: "could not read the current branch" }
+  }
 }
 
 /** Resolves `<ref>` to a commit sha, or undefined when it doesn't name one. */

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -5,6 +5,7 @@ import { BoxRenderable, StyledText, TextRenderable, bg, bold, createCliRenderer,
 
 import { defaultAdvisorMaxCalls } from "./advisor"
 import { buildAgentRegistry, emptyHooksConfig, loadMergedConvoyConfig } from "./config"
+import { resolveWorktreeDefault } from "./git"
 import { hooksForPipeline } from "./hooks"
 import { startLimitsPoller } from "./limits"
 import { builtInPipelines, defaultPipelineName, resolvePipeline } from "./pipeline"
@@ -15,6 +16,7 @@ import { hintsRow, joinLines, limitsRow, moreHintsMarker, padBetween, paletteFor
 import { shortVersion } from "./version"
 
 import type { ConvoyConfig } from "./config"
+import type { WorktreeDefault } from "./git"
 import type { BoxOptions, CliRenderer, KeyEvent, PasteEvent, TextChunk } from "@opentui/core"
 import type { LimitsSnapshot } from "./limits"
 import type { AgentSpec, AgentStep, HookSet, HookSpec, RunOptions, RunPlan, Step } from "./types"
@@ -209,7 +211,13 @@ export async function launchRunTui(options: LaunchRunTuiOptions): Promise<Launch
   })
   const mode = await renderer.waitForThemeMode(1_000).catch(() => null)
   setTheme(paletteForTerminal(mode, terminalBackgroundHex(renderer)))
-  return new LaunchPicker(renderer, options.targetDir, choices, config?.modelRouting?.gateway ?? "configured", config?.defaults.worktree ?? true, options).result
+  // Unset config means "decide per branch": isolating is right on a trunk, but
+  // on a branch you're already where the work should land.
+  const worktree =
+    config?.defaults.worktree === undefined
+      ? await resolveWorktreeDefault(options.targetDir)
+      : { isolate: config.defaults.worktree, reason: "set by defaults.worktree" }
+  return new LaunchPicker(renderer, options.targetDir, choices, config?.modelRouting?.gateway ?? "configured", worktree, options).result
 }
 
 function pipelineChoices(config: ConvoyConfig | undefined, agents: readonly AgentSpec[]): PipelineChoice[] {
@@ -333,7 +341,7 @@ class LaunchPicker {
     includeDirty: false,
     keepRunDir: true,
     tui: Boolean(process.stdout.isTTY && process.stderr.isTTY),
-    // Overwritten from defaults.worktree in the constructor; on unless turned off.
+    // Always overwritten in the constructor, from defaults.worktree or the branch.
     worktree: true,
   }
 
@@ -432,11 +440,11 @@ class LaunchPicker {
     private readonly targetDir: string,
     private readonly choices: PipelineChoice[],
     private gateway: ModelGateway,
-    worktreeDefault: boolean,
+    private readonly worktreeDefault: WorktreeDefault,
     // Named `callbacks` rather than `hooks`: this file already uses "hooks" for the pipeline's shell hooks.
     private readonly callbacks: Pick<LaunchRunTuiOptions, "prepareRun" | "proposeBranchName" | "checkBranchName">,
   ) {
-    this.toggleState.worktree = worktreeDefault
+    this.toggleState.worktree = worktreeDefault.isolate
     const defaultIndex = choices.findIndex((choice) => choice.isDefault)
     this.selected = defaultIndex >= 0 ? defaultIndex : 0
     this.result = new Promise((resolve) => {
@@ -1354,7 +1362,13 @@ class LaunchPicker {
       const flag = fg(enabled ? theme.green : theme.dim)(spec.flag)
       lines.push(padBetween([marker, ...toggle, raw(" "), label], [flag], width))
       this.optionRows.push(index)
-      lines.push(new StyledText([raw("        "), fg(theme.dim)(truncate(spec.description, Math.max(8, width - 8)))]))
+      // The worktree default depends on which branch you're on, so say why it
+      // landed where it did — otherwise the checkbox looks like it moves on its own.
+      const description =
+        spec.key === "worktree"
+          ? `Default ${this.worktreeDefault.isolate ? "on" : "off"}: ${this.worktreeDefault.reason}. ${spec.description}`
+          : spec.description
+      lines.push(new StyledText([raw("        "), fg(theme.dim)(truncate(description, Math.max(8, width - 8)))]))
       this.optionRows.push(index)
     }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -167,14 +167,6 @@ describe("cli parsing", () => {
     expect(() => parseArgs(["--no-worktree=yes", "prompt"])).toThrow("--no-worktree does not take a value")
   })
 
-  test("worktrees are on by default and --no-worktree opts out", async () => {
-    const byDefault = await parseCommand(["prompt"])
-    if (byDefault.type === "run") expect(byDefault.options.worktree).toBe(true)
-
-    const off = await parseCommand(["--no-worktree", "prompt"])
-    if (off.type === "run") expect(off.options.worktree).toBe(false)
-  })
-
   test("a resumed run never creates a second worktree, even with --worktree", async () => {
     // It continues in the directory its metadata recorded, which already is the
     // worktree when the original run made one.
@@ -380,6 +372,67 @@ describe("base ref auto-detection", () => {
 
     const options = await resolveRunOptions(parsed)
     expect(options.baseRef).toBe("squad-x")
+  })
+})
+
+describe("worktree default", () => {
+  const dirs: string[] = []
+
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  async function git(args: string[], cwd: string) {
+    const proc = Bun.spawn(["git", "-c", "commit.gpgsign=false", ...args], {
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "convoy-test",
+        GIT_AUTHOR_EMAIL: "convoy-test@example.invalid",
+        GIT_COMMITTER_NAME: "convoy-test",
+        GIT_COMMITTER_EMAIL: "convoy-test@example.invalid",
+      },
+    })
+    if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")}: ${await new Response(proc.stderr).text()}`)
+  }
+
+  async function repoOn(branch: string) {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-cli-worktree-"))
+    dirs.push(dir)
+    await git(["init", "-q", "-b", "main"], dir)
+    await git(["commit", "-q", "--allow-empty", "-m", "init"], dir)
+    if (branch !== "main") await git(["checkout", "-q", "-b", branch], dir)
+    return dir
+  }
+
+  const worktreeFor = async (argv: string[]) => {
+    const command = await parseCommand(argv)
+    if (command.type !== "run") throw new Error(`expected a run command, got ${command.type}`)
+    return command.options.worktree
+  }
+
+  test("isolates on a trunk and runs in place on a branch, with no flag or config", async () => {
+    expect(await worktreeFor(["--dir", await repoOn("main"), "prompt"])).toBe(true)
+    expect(await worktreeFor(["--dir", await repoOn("feat/thing"), "prompt"])).toBe(false)
+  })
+
+  test("flags override the branch default in both directions", async () => {
+    const trunk = await repoOn("main")
+    const branch = await repoOn("feat/thing")
+
+    expect(await worktreeFor(["--dir", trunk, "--no-worktree", "prompt"])).toBe(false)
+    expect(await worktreeFor(["--dir", branch, "--worktree", "prompt"])).toBe(true)
+  })
+
+  test("an explicit defaults.worktree still wins over the branch", async () => {
+    await writeFile(join(process.env.CONVOY_HOME!, ".convoy", "config.yaml"), "version: 1\ndefaults:\n  worktree: false\n")
+
+    // On a trunk, where the branch alone would have isolated.
+    expect(await worktreeFor(["--dir", await repoOn("main"), "prompt"])).toBe(false)
+    // And the flag still beats the config.
+    expect(await worktreeFor(["--dir", await repoOn("main"), "--worktree", "prompt"])).toBe(true)
   })
 })
 

--- a/test/git.test.ts
+++ b/test/git.test.ts
@@ -3,7 +3,17 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { addAllAndCommit, addWorktree, branchExists, detectBaseRef, ensureRepoReady, findSuspiciousStagedFiles, initializeRepoWithInitialCommit, repoBootstrapStatus } from "../src/git"
+import {
+  addAllAndCommit,
+  addWorktree,
+  branchExists,
+  detectBaseRef,
+  ensureRepoReady,
+  findSuspiciousStagedFiles,
+  initializeRepoWithInitialCommit,
+  repoBootstrapStatus,
+  resolveWorktreeDefault,
+} from "../src/git"
 
 describe("findSuspiciousStagedFiles", () => {
   test("flags common secret filenames", () => {
@@ -214,6 +224,54 @@ describe("detectBaseRef", () => {
     const dir = await mkdtemp(join(tmpdir(), "convoy-detect-base-"))
     dirs.push(dir)
     expect(await detectBaseRef(dir)).toBeUndefined()
+  })
+
+  describe("resolveWorktreeDefault", () => {
+    test("isolates on a conventional trunk", async () => {
+      const dir = await repo("main")
+      expect(await resolveWorktreeDefault(dir)).toEqual({ isolate: true, reason: "main is a base branch" })
+    })
+
+    test("runs in place on a branch of your own", async () => {
+      const dir = await repo("main")
+      await git(["checkout", "-q", "-b", "feat/thing"], dir)
+      expect(await resolveWorktreeDefault(dir)).toEqual({ isolate: false, reason: "feat/thing is not a base branch" })
+    })
+
+    test("isolates on develop even when origin/HEAD points at main", async () => {
+      // The union of both criteria: detectBaseRef answers "main" here, so the
+      // conventional-name check is what keeps develop from being treated as a
+      // working branch.
+      const dir = await repo("main")
+      await setOriginHead(dir, "main")
+      await git(["checkout", "-q", "-b", "develop"], dir)
+      expect(await resolveWorktreeDefault(dir)).toEqual({ isolate: true, reason: "develop is a base branch" })
+    })
+
+    test("isolates on an exotically named trunk that origin/HEAD points at", async () => {
+      const dir = await repo("mainline")
+      await setOriginHead(dir, "mainline")
+      expect(await resolveWorktreeDefault(dir)).toEqual({ isolate: true, reason: "mainline is this repo's base branch" })
+    })
+
+    test("isolates on an exotically named branch when the repo has no other base", async () => {
+      // detectBaseRef falls back to the current branch, which makes it the base
+      // by definition — there is nothing else to branch from.
+      const dir = await repo("dev-trunk")
+      expect(await resolveWorktreeDefault(dir)).toEqual({ isolate: true, reason: "dev-trunk is this repo's base branch" })
+    })
+
+    test("isolates when HEAD is detached, where committing in place is never right", async () => {
+      const dir = await repo("main")
+      await git(["checkout", "-q", "--detach"], dir)
+      expect(await resolveWorktreeDefault(dir)).toEqual({ isolate: true, reason: "no branch is checked out" })
+    })
+
+    test("falls back to isolating outside a git repository", async () => {
+      const dir = await mkdtemp(join(tmpdir(), "convoy-worktree-default-"))
+      dirs.push(dir)
+      expect((await resolveWorktreeDefault(dir)).isolate).toBe(true)
+    })
   })
 })
 


### PR DESCRIPTION
## The problem

`defaults.worktree` unset meant `true` — always isolate. `src/cli.ts` resolved `parsed.worktree ?? defaults.worktree ?? true` and the launcher did `config?.defaults.worktree ?? true`; neither ever looked at which branch you were on.

So starting a run from a feature branch created *another* branch in a separate worktree, when being on a branch is already the statement that this is where the work should land. On `main` the old default is right — you don't want a pipeline committing straight onto the trunk.

## What changes

`defaults.worktree` unset now decides per branch. **No schema change**: the value stays `boolean | undefined`, so the config validator and the config TUI's tri-state are untouched — only the meaning of *unset* moves, from "always on" to "decide".

Precedence, with only the last step new:

1. `--worktree` / `--no-worktree`
2. `--resume` → always false (unchanged)
3. `defaults.worktree: true|false`
4. **the branch**: isolate when HEAD is on a trunk, run in place otherwise

`resolveWorktreeDefault()` in `src/git.ts` unions two criteria, because either alone gets a common case wrong:

- the conventional names `main` / `master` / `develop` / `trunk` (extracted from `detectBaseRef`'s existing probe list, now shared);
- whatever `detectBaseRef()` resolves to, which covers repos with an exotically named trunk that `origin/HEAD` points at.

Without the first, a repo whose `origin/HEAD` is `main` would treat `develop` as a working branch. Without the second, a trunk named `mainline` would never isolate. No branch checked out (detached HEAD, or not a repo) isolates — committing in place is never right there — and any unexpected failure falls back to isolating, the older behavior.

The launcher shows which way the default went and why, right under the toggle (`Default off: feat/thing is not a base branch.`), and the headless path logs the same thing next to the existing base-ref line. Without that the checkbox looks like it moves on its own.

## Behavior change

Anyone relying on unset meaning "always worktree" needs `defaults.worktree: true` now. Documented in the README, the `convoy init` template, and the config TUI's help line.

## Verification

`bun test` (810 pass) and `bun run typecheck` are green. New coverage for `resolveWorktreeDefault` (trunk, own branch, `develop` against an `origin/HEAD` of `main`, exotic trunk via origin/HEAD, exotic branch in a repo with no other base, detached HEAD, non-repo) and for the CLI resolution (branch decides, flags override both ways, explicit config wins, flag still beats config). The old "worktrees are on by default" test was replaced — it read `process.cwd()`, so its result depended on whichever branch the suite happened to run from.

Also checked against the real CLI with `--plan`:

```
-> worktree: off (feat/worktree-auto-default is not a base branch)   →   Worktree: no
-> worktree: on (main is a base branch)                              →   Worktree: yes · branch named at start
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Mo6s1UDncWirFvPUxUE1