### PR TITLE
feat(pipelines): promote the tuned local pipelines to built-in defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Typical uses:
 
 Use it as a **CLI** or as a **TUI**, interchangeably: every run can be launched with plain flags and prompt files (`--no-tui` gives you plain logs for pipes and CI), or driven entirely from the TUI — `convoy` with no arguments opens the interactive launcher, every run gets a live dashboard, `convoy runs` browses past runs, and `convoy config` edits global and project config in place.
 
-**Pipelines are data, not code.** Convoy ships a family of built-in pipelines (`implement` — the default — plus `implement-lite`, `implement-advised`, `ultra-implement`, `refine`, `ultra-refine`, `fixer`, and the report-only `review`, `review-lite`, `review-cc`, `hunter`, and `hunter-max`; see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with named human gates anywhere — in `.convoy/config.yaml`.
+**Pipelines are data, not code.** Convoy ships a family of built-in pipelines (`implement` — the default — plus `implement-lite`, `implement-advised`, `ultra-implement`, `refine`, `ultra-refine`, `ship`, `fixer`, and the report-only `review`, `review-lite`, `review-cc`, `hunter`, and `hunter-max`; see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with named human gates anywhere — in `.convoy/config.yaml`.
 
 Beyond sequencing agents, Convoy owns the operational layer around OpenCode: repo context attachment, runtime guard rails, a live permission gate, commit safety, phase reports, diff tracking, and a TUI that shows cost, tokens, and provider limits while the run is live.
 
@@ -41,12 +41,12 @@ PRD ──► implementer ──► patterns ──► security ──► design
 
 | Step | Agent | Model | What it does |
 |---|---|---|---|
-| `implementer` | `implementer` | `openai/gpt-5.6-sol` | Implements the feature respecting repo patterns |
-| `patterns` | `pattern-auditor` | `openai/gpt-5.6-terra#xhigh` | Refactors without changing behavior, aligns with the rest of the code |
-| `security` | `security-auditor` | `openai/gpt-5.6-terra#xhigh` | Audits and fixes security issues |
-| `design` | `design-polisher` | `openrouter/moonshotai/kimi-k3` | Polishes UI following the repo's design system, and strips generic "AI slop" styling |
-| `tests` | `test-engineer` | `openai/gpt-5.6-terra#xhigh` | Automated tests + relevant E2E/integration coverage |
-| `adversarial` | `adversarial-reviewer` | `openrouter/moonshotai/kimi-k3` | Final adversarial review before PR creation |
+| `implementer` | `implementer` | `openai/gpt-5.6-sol#xhigh` | Implements the feature respecting repo patterns |
+| `patterns` | `pattern-auditor` | `openrouter/z-ai/glm-5.2#xhigh` | Refactors without changing behavior, aligns with the rest of the code |
+| `security` | `security-auditor` | `openrouter/z-ai/glm-5.2#xhigh` | Audits and fixes security issues |
+| `design` | `design-polisher` | `openrouter/moonshotai/kimi-k3#high` | Polishes UI following the repo's design system, and strips generic "AI slop" styling |
+| `tests` | `test-engineer` | `openrouter/z-ai/glm-5.2#xhigh` | Automated tests + relevant E2E/integration coverage |
+| `adversarial` | `adversarial-reviewer` | `openrouter/moonshotai/kimi-k3#high` | Final adversarial review before PR creation |
 
 ## Built-in pipelines
 
@@ -55,11 +55,12 @@ Convoy ships these pipelines; select one with `-p/--pipeline` (no config needed)
 | Pipeline | Changes code? | What it does |
 |---|---|---|
 | `implement` | yes | **The default** (runs with no `-p`). Implement a PRD, then audit, polish, test, and adversarial review (the table above). |
-| `implement-lite` | yes | Same workflow and agents as `implement`, but the code-writing phases (`implementer`, `patterns`, `security`, `tests`) all drop to `openrouter/z-ai/glm-5.2` for a lower-cost run; `design` runs on Kimi K3 and `adversarial` on Opus. |
-| `implement-advised` | yes | Same workflow and step names as `implement`, but the `implementer` phase runs on GPT 5.6 Terra xhigh and **consults GPT 5.6 Sol as an advisor** at its decision points. The audits (`patterns`, `security`, `tests`) run unadvised on `openrouter/z-ai/glm-5.2`, `design` on Kimi K3, and `adversarial` keeps Opus owning its own loop. Directly comparable with `implement-lite`: same audit executors, and the implementation step is the single variable between them. |
+| `implement-lite` | yes | Same workflow and agents as `implement`, and the same GLM 5.2 audits — but at base reasoning instead of xhigh, with `implementer` dropping to GLM 5.2 too and `adversarial` to Opus. The cheaper run: what it gives up is Sol writing the code and Kimi judging it. |
+| `implement-advised` | yes | `implement` with exactly one thing changed: the `implementer` phase runs on GPT 5.6 Terra xhigh and **consults GPT 5.6 Sol xhigh as an advisor** at its decision points. Every other phase is `implement`'s, model for model and unadvised, so the advised implementation step is the single variable between the two. |
 | `ultra-implement` | yes | Like `implement`, but the pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, and the run ends with an audit-only final review, a fixer that applies only blocking findings, and a final validator. |
 | `refine` | yes | Audit the current diff (scope → bugs → clean-code → security), triage the findings adversarially, apply the accepted fixes, then validate them. |
 | `ultra-refine` | yes | Like `refine`, but every read-only audit is fanned out across two models before triage, fixes, and validation. |
+| `ship` | yes | `refine`, but preceded by a `sync` phase that merges the advanced base branch in and resolves the conflicts — real and semantic — so the audits read the branch as it will actually merge rather than a diff that no longer describes what lands. Two things it expects from your config, because both are machine-local: `permissions.allow` entries for `git merge*`, `git add*` and `git checkout --ours*`/`--theirs*` (without them those commands fall through to "ask" rather than failing), and, optionally, `hooks.pipelines.ship` to fetch the base beforehand and open the PR afterwards — Convoy never runs remote git itself. |
 | `review` | **no — report only** | Scope the diff, run the bug / clean-code(+patterns) / security audits **in parallel across two models each**, then a single step synthesizes everything into one prioritized findings report. Makes no changes; the run's output is `reports/report.md`, which you read to decide whether to follow up with a `refine` run. |
 | `review-lite` | **no — report only** | Same shape as `review`, but nothing runs on Opus: `openrouter/z-ai/glm-5.2` scopes the diff and writes the final report, and each parallel audit fans out across `openrouter/z-ai/glm-5.2` + `openrouter/moonshotai/kimi-k3`. The cheap way to get a full review report. |
 | `fixer` | yes | The follow-up to a report-only run. Give it a set of findings (as the prompt or an attachment) and it proves each one with a focused regression test **before** touching production code, applies minimal fixes only for the findings that actually went red, then independently reruns those proofs and the surrounding checks to report a final per-finding verdict (`fixed`, `already-resolved`, `not-reproducible`, `not-automatable`, `blocked`, `not-fixed`). The validation phase runs the commands itself (see [verifying agents](#project-configuration-convoyconfigyaml)) rather than taking the fix phase's word for it, and never promotes an unproven finding to fixed. |
@@ -67,7 +68,7 @@ Convoy ships these pipelines; select one with `-p/--pipeline` (no config needed)
 | `hunter` | **no — report only** | Repo-wide audit across six specialty tracks (correctness, memory, performance, security, reliability, supply chain), each run on GPT 5.6 Terra xhigh plus one specialty model, then reconciled into a single deduplicated, prioritized consensus report. |
 | `hunter-max` | **no — report only** | Like `hunter`, but every track fans out across all five models (30 concurrent audits). Highest recall, slowest and most expensive — reach for it on code you can't afford to get wrong. |
 
-`refine`/`ultra-refine` are the change-applying counterparts of `review`: run `review` first to get a report, then `refine` if you want the fixes applied. `fixer` is the stricter alternative to `refine` when you already have a specific list of findings and want each one individually proven, fixed, and accounted for rather than triaged in bulk.
+`refine`/`ultra-refine` are the change-applying counterparts of `review`: run `review` first to get a report, then `refine` if you want the fixes applied. `ship` is `refine` for a branch whose base has moved on — it syncs first, so the audit is of the merged result. `fixer` is the stricter alternative to `refine` when you already have a specific list of findings and want each one individually proven, fixed, and accounted for rather than triaged in bulk.
 
 `review*` pipelines default to the current branch/PR diff; `hunter*` default to the whole repository unless the prompt scopes them to a branch, PR, or area.
 

--- a/prompts/sync-with-base.md
+++ b/prompts/sync-with-base.md
@@ -1,0 +1,55 @@
+# Sync With Base
+
+You are the **sync-with-base** agent, the first phase of Convoy's `ship` pipeline. You run **before** any audit. Your job is to bring the branch up to date with its base branch and resolve every conflict, so the later phases review the branch as it will actually merge.
+
+This is a phase that **may modify the target repository**.
+
+## What you can and cannot do
+
+`git fetch`, `git pull`, `git rebase`, `git reset --hard` and `git push` are blocked for you — Convoy never runs remote git from an agent. You work with whatever the local repository already knows.
+
+A project that wires a `hooks.pipelines.ship` pre-hook (running `git fetch origin` and fast-forwarding the local base) will have the remote state present locally. Do not assume it ran: check, and if the local base is stale, say so in your report rather than silently syncing against an outdated ref.
+
+## Procedure
+
+1. **Detect the base branch.** Run `git symbolic-ref --short refs/remotes/origin/HEAD` and strip the leading `origin/`. If that fails, fall back to the first of `develop`, `main`, `master` that exists (`git rev-parse --verify --quiet <name>`). Never touch or check out any other branch. Let `CURRENT` = `git branch --show-current`. If `CURRENT` is empty or equals the base, there is nothing to sync — report that and stop.
+
+2. **Check whether the base advanced.** Run `git rev-list --count HEAD..origin/<base>`.
+   - If it is `0`, the base has not advanced. **Do not modify anything.** Report "base has not advanced — nothing to sync" and finish.
+
+3. **Merge the base in.** Run `git merge --no-edit origin/<base>`.
+   - If it completes cleanly, verify the result (below) and finish.
+   - If it reports conflicts, resolve them.
+
+4. **Resolve conflicts, preserving both sides.** List conflicted files with `git diff --name-only --diff-filter=U`. For each one, edit by hand to keep **both**:
+   - the **branch's intended behaviour** (the change this branch is introducing), and
+   - the **incoming base changes** (what advanced on the base).
+
+   Resolve **real textual conflicts** *and* **semantic conflicts** — cases where the two sides don't overlap in text but still clash: a symbol renamed on base that the branch calls, a changed function signature or return type, a moved/renamed/deleted file the branch depends on, a new required argument, a lint/format rule that base tightened. Read the surrounding code on both sides before deciding; do not blindly pick `--ours`/`--theirs` unless one side is genuinely a clean superset. When a whole file is cleanly owned by one side, `git checkout --ours <file>` / `git checkout --theirs <file>` then `git add <file>` is acceptable.
+
+5. **Prove coherence.** Before finishing, make sure no conflict markers survive anywhere:
+
+   ```
+   git grep -nE '^(<<<<<<<|=======|>>>>>>>)' || echo "no markers"
+   ```
+
+   If any remain, keep resolving. When practical, run the repo's own fast read-only checks for the touched areas (e.g. `git diff`, a typecheck or the narrowest test) to confirm the merged code is consistent — the point is that the branch still works *with* the new base.
+
+## Finish in a clean state — this is mandatory
+
+You must end in exactly one of two states. Never leave a half-finished merge or a dirty tree (conflict markers must never be committed):
+
+- **Merged:** all conflicts resolved and verified → `git add -A` and stop there. Do **not** run `git commit` yourself: Convoy is denied that command for every agent, and it commits the working tree as this phase anyway — with `MERGE_HEAD` still present, that phase commit is what concludes the merge.
+- **Abort:** if the conflicts genuinely cannot be resolved confidently → `git merge --abort` to restore the pre-merge state, then clearly explain why. Convoy will continue the audits on the un-synced branch.
+
+Do not guess your way through a conflict you don't understand — abort and document it instead.
+
+## Report
+
+Write or return Markdown with:
+
+- **Base:** the detected base branch and how many commits it was ahead (`HEAD..origin/<base>`).
+- **Outcome:** `no-op` (not advanced), `merged` (clean or resolved), or `aborted`.
+- **Conflicts resolved:** each file and, for semantic ones, a one-line note on how you reconciled the branch's behaviour with the incoming change.
+- **Verification:** checks run and their result, or why none were run.
+- **Residual risk:** anything the audits or a human should double-check.

--- a/src/built-in-prompts.ts
+++ b/src/built-in-prompts.ts
@@ -29,6 +29,7 @@ import reviewValidator from "../prompts/review-validator.md" with { type: "text"
 import runtimeSafety from "../prompts/runtime-safety.md" with { type: "text" }
 import securityAuditor from "../prompts/security-auditor.md" with { type: "text" }
 import securityReviewer from "../prompts/security-reviewer.md" with { type: "text" }
+import syncWithBase from "../prompts/sync-with-base.md" with { type: "text" }
 import testEngineer from "../prompts/test-engineer.md" with { type: "text" }
 
 /**
@@ -69,5 +70,6 @@ export const builtInPrompts: Record<string, string> = {
   "runtime-safety": runtimeSafety,
   "security-auditor": securityAuditor,
   "security-reviewer": securityReviewer,
+  "sync-with-base": syncWithBase,
   "test-engineer": testEngineer,
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ import {
   defaultGptModel,
   defaultGptVariant,
   defaultAdversarialModel,
+  defaultImplementAuditModel,
   defaultImplementerModel,
   defaultImplementReviewModel,
   defaultOpusModel,
@@ -281,6 +282,9 @@ defaults:
 #   ultra-implement      like implement, with dual-model parallel audits and a final review/fix/validate stage
 #   refine               audit the current diff, then apply the triaged fixes (changes code)
 #   ultra-refine         like refine, with every audit fanned out across two models
+#   ship                 merge the advanced base in (resolving conflicts), then refine the merged branch
+#                        wants permissions.allow: git merge*, git add*, git checkout --ours*|--theirs*
+#                        and, optionally, hooks.pipelines.ship to fetch the base first / open the PR after
 #   review               report-only: parallel audits across two models plus one prioritized report (no changes)
 #   review-lite          like review, but swaps GPT 5.6 Terra xhigh for GLM 5.2 (scope + audit fan-out); report stays on Opus
 #   review-cc            like review, but pairs each audit with a Claude Code run (needs the \`claude\` CLI on PATH)
@@ -294,11 +298,14 @@ pipelines:
       - agent: implementer
         model: ${defaultImplementerModel}
         reports: none
-      - patterns
-      - security
+      - agent: patterns
+        model: ${defaultImplementAuditModel}
+      - agent: security
+        model: ${defaultImplementAuditModel}
       - agent: design
         model: ${defaultImplementReviewModel}
       - agent: tests
+        model: ${defaultImplementAuditModel}
         reports: none
       - agent: adversarial
         model: ${defaultAdversarialModel}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -11,20 +11,25 @@ const fallbackModel = `${defaultGptModel}#${defaultGptVariant}`
 const sonnetModel = "openrouter/anthropic/claude-sonnet-5"
 /** Lower-cost replacement for the GPT xhigh phases in the lightweight pipelines. */
 const glmModel = "openrouter/z-ai/glm-5.2"
+/** GLM 5.2 with its reasoning turned up: what the audit phases of `implement` run on. */
+const glmXhighModel = `${glmModel}#xhigh`
 /** Opus reached through OpenRouter, so the hunter fan-outs share one provider across every track. */
 const opusViaOpenRouter = "openrouter/anthropic/claude-opus-5"
 /** Remaining specialty models the hunter pipelines fan their audit tracks across. */
 const grokModel = "openrouter/x-ai/grok-4.5"
 const kimiModel = "openrouter/moonshotai/kimi-k3"
+/** Kimi K3 with reasoning raised one notch: the design and adversarial passes earn it, the cheap fan-outs don't. */
+const kimiHighModel = `${kimiModel}#high`
 /** GPT 5.6 Sol: the implementation workhorse, and at xhigh the consensus reporter for the review/hunter pipelines. */
 const solModel = "openai/gpt-5.6-sol"
 const solXhighModel = `${solModel}#xhigh`
 
 // Per-step models the built-in `implement` pipeline pins. Exported so `convoy init`'s
 // inlined copy of that pipeline stays in sync with the built-in it claims to mirror.
-export const defaultImplementerModel = solModel
-export const defaultImplementReviewModel = kimiModel
-export const defaultAdversarialModel = kimiModel
+export const defaultImplementerModel = solXhighModel
+export const defaultImplementAuditModel = glmXhighModel
+export const defaultImplementReviewModel = kimiHighModel
+export const defaultAdversarialModel = kimiHighModel
 
 /** The six specialty audit tracks shared by `hunter` and `hunter-max`; each maps to a `hunter-<track>` agent. */
 const hunterTracks = ["correctness", "memory", "performance", "security", "reliability", "supply-chain"] as const
@@ -137,6 +142,15 @@ export const builtInAgents: readonly AgentSpec[] = [
     defaultModel: defaultOpusModel,
     temperature: 0.1,
     readOnly: true,
+    builtIn: true,
+  },
+  // ship: bring the branch up to date before anything reviews it.
+  {
+    name: "sync-with-base",
+    description:
+      "Merges the advanced base branch into the current branch, resolving real and semantic conflicts while preserving both the branch's behaviour and the incoming base changes",
+    defaultModel: defaultOpusModel,
+    temperature: 0.1,
     builtIn: true,
   },
   // ultra-implement: final-review stage over the whole PR.
@@ -328,14 +342,18 @@ export const readOnlyAgentSuffix = "__ro"
 export const defaultPipelineName = "implement"
 
 export const builtInPipelines: Record<string, PipelineSpec> = {
+  // The audits are pinned to GLM 5.2 xhigh rather than left to inherit the run's
+  // model: they read a diff that already exists, which is the work GLM does at
+  // parity with the expensive models, so the budget belongs in the phases that
+  // write (Sol xhigh) and judge (Kimi K3 high).
   implement: {
     description: "Implementation, pattern/security audits, design polish, tests, and adversarial review",
     steps: [
       { agent: "implementer", model: defaultImplementerModel, reports: "none" },
-      "patterns",
-      "security",
+      { agent: "patterns", model: defaultImplementAuditModel },
+      { agent: "security", model: defaultImplementAuditModel },
       { agent: "design", model: defaultImplementReviewModel },
-      { agent: "tests", reports: "none" },
+      { agent: "tests", model: defaultImplementAuditModel, reports: "none" },
       { agent: "adversarial", model: defaultAdversarialModel, reports: "all" },
     ],
   },
@@ -351,24 +369,21 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
     ],
   },
   // The advisor←executor pattern as a runnable default, aimed at the one phase
-  // that earns it: Terra xhigh writes the code and consults Sol at its decision
-  // points, pairing the two GPT 5.6 variants that disagree most usefully. The
-  // audits that follow read a diff that already exists, so they run unadvised
-  // and the pipeline stays comparable to `implement-lite` — same audit
-  // executors, one advised step between them.
+  // that earns it: Terra xhigh writes the code and consults Sol xhigh at its
+  // decision points, pairing the two GPT 5.6 variants that disagree most
+  // usefully. Every other phase is `implement`'s, unchanged and unadvised, so
+  // the advised implementation step is the single variable between the two.
   "implement-advised": {
-    description: "Like implement-lite, but the implementation phase runs on Terra xhigh and consults Sol as an advisor at its decision points; the audits run unadvised",
+    description: "Like implement, but the implementation phase runs on Terra xhigh and consults Sol as an advisor at its decision points; the audits run unadvised",
     steps: [
-      { agent: "implementer", model: fallbackModel, advisor: solModel, reports: "none" },
+      { agent: "implementer", model: fallbackModel, advisor: solXhighModel, reports: "none" },
       // `false` rather than an absent key: absent would inherit a project's
       // defaults.advisor and quietly re-advise these phases.
-      { agent: "patterns", model: glmModel, advisor: false },
-      { agent: "security", model: glmModel, advisor: false },
-      { agent: "design", model: kimiModel, advisor: false },
-      { agent: "tests", model: glmModel, advisor: false, reports: "none" },
-      // The adversarial pass is the one place the expensive model should own the
-      // loop: its whole job is the judgement an advisor would otherwise supply.
-      { agent: "adversarial", model: defaultOpusModel, advisor: false, reports: "all" },
+      { agent: "patterns", model: defaultImplementAuditModel, advisor: false },
+      { agent: "security", model: defaultImplementAuditModel, advisor: false },
+      { agent: "design", model: defaultImplementReviewModel, advisor: false },
+      { agent: "tests", model: defaultImplementAuditModel, advisor: false, reports: "none" },
+      { agent: "adversarial", model: defaultAdversarialModel, advisor: false, reports: "all" },
     ],
   },
   review: {
@@ -404,6 +419,29 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
   refine: {
     description: "Audit-only PR review, adversarial finding triage, targeted fixes, and final validation — applies changes.",
     steps: [
+      { agent: "review-scope", name: "scope", model: glmModel, reports: "none", diff: true },
+      { agent: "bug-auditor", name: "bugs", model: fallbackModel, reports: ["scope"] },
+      { agent: "clean-code-auditor", name: "clean-code", model: fallbackModel, reports: ["scope"] },
+      { agent: "security-reviewer", name: "security", model: fallbackModel, reports: ["scope"] },
+      { agent: "review-adversary", name: "triage", model: defaultOpusModel, reports: ["scope", "bugs", "clean-code", "security"] },
+      { agent: "review-fixer", name: "fixes", model: fallbackModel, reports: ["triage"] },
+      { agent: "review-validator", name: "validator", model: fallbackModel, reports: "all" },
+    ],
+  },
+  // refine's audits, but against the branch as it will actually merge: the sync
+  // phase lands the advanced base first, so the auditors read the merged result
+  // instead of a diff that no longer describes what lands.
+  //
+  // Two things it expects from config rather than shipping itself, because both
+  // are machine-local. Conflict resolution needs `git merge*`, `git add*` and
+  // `git checkout --ours*|--theirs*` in `permissions.allow` — without them those
+  // commands fall through to "ask" rather than failing. And fetching the base
+  // beforehand or opening the PR afterwards belongs in `hooks.pipelines.ship`,
+  // since Convoy never runs remote git itself.
+  ship: {
+    description: "Sync the branch with its base (merge + conflict resolution), then audit the merged diff, triage, fix, and validate",
+    steps: [
+      { agent: "sync-with-base", name: "sync", model: fallbackModel, reports: "none" },
       { agent: "review-scope", name: "scope", model: glmModel, reports: "none", diff: true },
       { agent: "bug-auditor", name: "bugs", model: fallbackModel, reports: ["scope"] },
       { agent: "clean-code-auditor", name: "clean-code", model: fallbackModel, reports: ["scope"] },
@@ -453,11 +491,16 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
   // attachment) and every one of them ends with a traceable verdict. The three
   // working phases carry the cost; the reporter only re-reads reports that already
   // exist, so it runs on the cheapest GPT 5.6 rather than the most capable model.
+  // The two phases that write get an advisor, because both make a judgement call
+  // that is expensive to get wrong and cheap to check: whether a finding is
+  // genuinely reproducible, and how small the fix can be. Validation runs
+  // unadvised — it reruns the proofs itself, which is a stronger check than a
+  // second opinion on the reasoning.
   fixer: {
     description: "Turn supplied findings into proven regression tests, targeted fixes, and an independently rerun final report",
     steps: [
-      { agent: "fixer-test-author", name: "reproduction", model: fallbackModel, reports: "none", diff: true },
-      { agent: "fixer-implementer", name: "fixes", model: fallbackModel, reports: ["reproduction"] },
+      { agent: "fixer-test-author", name: "reproduction", model: fallbackModel, advisor: solXhighModel, reports: "none", diff: true },
+      { agent: "fixer-implementer", name: "fixes", model: fallbackModel, advisor: solXhighModel, reports: ["reproduction"] },
       { agent: "fixer-validator", name: "validation", model: fallbackModel, reports: ["reproduction", "fixes"] },
     ],
   },

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -304,7 +304,7 @@ describe("config precedence", () => {
   test("an unknown pipeline lists what exists", async () => {
     const dir = await projectWithConfig()
     await expect(parseCommand(["--dir", dir, "--pipeline", "ghost", "prompt"])).rejects.toThrow(
-      'unknown pipeline "ghost" (available: fixer, hunter, hunter-max, implement, implement-advised, implement-lite, quick, refine, review, review-cc, review-lite, ultra-implement, ultra-refine)',
+      'unknown pipeline "ghost" (available: fixer, hunter, hunter-max, implement, implement-advised, implement-lite, quick, refine, review, review-cc, review-lite, ship, ultra-implement, ultra-refine)',
     )
   })
 })

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -31,6 +31,7 @@ import {
   defaultAdversarialModel,
   defaultGptModel,
   defaultGptVariant,
+  defaultImplementAuditModel,
   defaultImplementerModel,
   defaultImplementReviewModel,
   defaultOpusModel,
@@ -370,6 +371,7 @@ describe("agent registry", () => {
       "review-fixer",
       "review-validator",
       "review-report",
+      "sync-with-base",
       "implementation-triage",
       "implementation-final-review",
       "implementation-fixer",
@@ -398,7 +400,7 @@ describe("pipeline selection", () => {
     expect(selectPipelineSpec(config, "implement").steps).toEqual(["tests"])
     expect(selectPipelineSpec(undefined, "implement").steps.length).toBeGreaterThan(1)
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(
-      'unknown pipeline "ghost" (available: fixer, hunter, hunter-max, implement, implement-advised, implement-lite, quick, refine, review, review-cc, review-lite, ultra-implement, ultra-refine)',
+      'unknown pipeline "ghost" (available: fixer, hunter, hunter-max, implement, implement-advised, implement-lite, quick, refine, review, review-cc, review-lite, ship, ultra-implement, ultra-refine)',
     )
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(ConfigError)
   })
@@ -706,10 +708,10 @@ describe("default config init", () => {
     expect(existsSync(join(dir, "agents"))).toBe(false)
     expect(config.pipelines.implement?.steps).toEqual([
       { agent: "implementer", model: defaultImplementerModel, reports: "none" },
-      "patterns",
-      "security",
+      { agent: "patterns", model: defaultImplementAuditModel },
+      { agent: "security", model: defaultImplementAuditModel },
       { agent: "design", model: defaultImplementReviewModel },
-      { agent: "tests", reports: "none" },
+      { agent: "tests", model: defaultImplementAuditModel, reports: "none" },
       { agent: "adversarial", model: defaultAdversarialModel, reports: "all" },
     ])
     expect(config.permissions).toEqual({ allow: [], deny: [] })

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -4,6 +4,7 @@ import {
   builtInAgents,
   builtInPipelines,
   defaultAdversarialModel,
+  defaultImplementAuditModel,
   defaultImplementerModel,
   defaultImplementReviewModel,
   defaultOpusModel,
@@ -65,24 +66,22 @@ describe("default pipeline", () => {
     ])
   })
 
-  test("pins Sol for implementation, GPT for the audits, GLM 5.2 for design, and Kimi K3 for adversarial", () => {
+  test("pins Sol xhigh for implementation, GLM 5.2 xhigh for the audits, and Kimi K3 high for design and adversarial", () => {
     const byName = Object.fromEntries(
       defaultPipeline()
         .steps.filter((step): step is AgentStep => step.type === "agent")
         .map((step) => [step.name, step]),
     )
 
-    expect(byName.implementer).toMatchObject({ model: defaultImplementerModel })
-    expect(byName.implementer?.variant).toBeUndefined()
-    expect(byName.patterns).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
-    expect(byName.security).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
-    expect(byName.design).toMatchObject({ model: defaultImplementReviewModel })
-    expect(byName.design?.variant).toBeUndefined()
-    expect(byName.tests).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
-    expect(byName.adversarial?.model).toBe(defaultAdversarialModel)
+    expect(byName.implementer).toMatchObject({ model: "openai/gpt-5.6-sol", variant: "xhigh" })
+    expect(byName.patterns).toMatchObject({ model: "openrouter/z-ai/glm-5.2", variant: "xhigh" })
+    expect(byName.security).toMatchObject({ model: "openrouter/z-ai/glm-5.2", variant: "xhigh" })
+    expect(byName.design).toMatchObject({ model: "openrouter/moonshotai/kimi-k3", variant: "high" })
+    expect(byName.tests).toMatchObject({ model: "openrouter/z-ai/glm-5.2", variant: "xhigh" })
+    expect(byName.adversarial).toMatchObject({ model: "openrouter/moonshotai/kimi-k3", variant: "high" })
   })
 
-  test("keeps every pinned implement step on its own model even when defaults.model is GPT", () => {
+  test("keeps every implement step on its own model even when defaults.model is GPT", () => {
     const byName = Object.fromEntries(
       resolvePipeline({
         name: "implement",
@@ -94,11 +93,15 @@ describe("default pipeline", () => {
         .map((step) => [step.name, step]),
     )
 
-    // Step models outrank defaults.model, so a global default only moves the unpinned audit steps.
-    expect(byName.implementer?.model).toBe(defaultImplementerModel)
-    expect(byName.design?.model).toBe(defaultImplementReviewModel)
-    expect(byName.adversarial?.model).toBe(defaultAdversarialModel)
-    expect(byName.patterns).toMatchObject({ model: "openai/gpt-5.5", variant: "xhigh" })
+    // Every step is pinned now, so defaults.model moves nothing here at all.
+    const pinned = (value: string) => {
+      const [model, variant] = value.split("#")
+      return variant ? { model, variant } : { model }
+    }
+    expect(byName.implementer).toMatchObject(pinned(defaultImplementerModel))
+    expect(byName.patterns).toMatchObject(pinned(defaultImplementAuditModel))
+    expect(byName.design).toMatchObject(pinned(defaultImplementReviewModel))
+    expect(byName.adversarial).toMatchObject(pinned(defaultAdversarialModel))
   })
 })
 
@@ -144,15 +147,20 @@ describe("built-in implement-lite pipeline", () => {
     expect(byName.adversarial).toMatchObject({ model: "anthropic/claude-opus-5" })
   })
 
-  test("keeps GLM 5.2 scoped to the lite, advised, refine, and hunter pipelines", () => {
-    const glmPipelines = Object.entries(builtInPipelines)
-      .filter(([, spec]) => JSON.stringify(spec).includes("openrouter/z-ai/glm-5.2"))
-      .map(([name]) => name)
+  test("distinguishes itself from implement by the phases that write and judge, not the audits", () => {
+    const lite = Object.fromEntries(implementLite().steps.filter((s): s is AgentStep => s.type === "agent").map((step) => [step.name, step]))
+    const standard = Object.fromEntries(defaultPipeline().steps.filter((s): s is AgentStep => s.type === "agent").map((step) => [step.name, step]))
 
-    // The hunter pipelines use GLM as one specialty voice in their fan-out, not as a cost downgrade.
-    // implement-advised keeps it as the audit executor, which is what makes it comparable to implement-lite.
-    // `implement` itself is GLM-free: its one GLM step was design, which now runs on Kimi K3.
-    expect(glmPipelines).toEqual(["implement-lite", "implement-advised", "review-lite", "refine", "hunter", "hunter-max"])
+    // Both run the audits on GLM 5.2; `implement` just turns its reasoning up.
+    // What the lite variant actually gives up is Sol writing the code and Kimi
+    // judging it at the end.
+    for (const step of ["patterns", "security", "tests"]) {
+      expect(lite[step]?.model).toBe(standard[step]!.model)
+      expect(lite[step]?.variant).toBeUndefined()
+      expect(standard[step]?.variant).toBe("xhigh")
+    }
+    expect(lite.implementer?.model).not.toBe(standard.implementer?.model)
+    expect(lite.adversarial?.model).not.toBe(standard.adversarial?.model)
   })
 })
 
@@ -162,10 +170,15 @@ describe("built-in implement-advised pipeline", () => {
       (step): step is AgentStep => step.type === "agent",
     )
 
-  test("advises the implementation phase only: Terra xhigh writing, Sol at its decision points", () => {
+  test("advises the implementation phase only: Terra xhigh writing, Sol xhigh at its decision points", () => {
     const implementer = advised().find((step) => step.name === "implementer")
 
-    expect(implementer).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh", advisor: "openai/gpt-5.6-sol" })
+    expect(implementer).toMatchObject({
+      model: "openai/gpt-5.6-terra",
+      variant: "xhigh",
+      advisor: "openai/gpt-5.6-sol",
+      advisorVariant: "xhigh",
+    })
   })
 
   test("leaves every phase after the implementer unadvised, so only one step carries the advisor cost", () => {
@@ -179,19 +192,49 @@ describe("built-in implement-advised pipeline", () => {
     expect(steps.filter((step) => step.advisor).length).toBe(1)
   })
 
-  test("leaves the adversarial pass owning its own loop on Opus, with no advisor", () => {
-    const adversarial = advised().find((step) => step.name === "adversarial")
+  test("is implement with one advised step: every other phase matches model for model", () => {
+    const implement = resolvePipeline({ name: "implement", spec: builtInPipelines.implement!, agents: builtInAgents }).steps.filter(
+      (step): step is AgentStep => step.type === "agent",
+    )
+    const byName = Object.fromEntries(implement.map((step) => [step.name, step]))
 
-    expect(adversarial?.model).toBe(defaultOpusModel)
-    expect(adversarial?.advisor).toBeUndefined()
+    // The advised implementation step is the only variable between the two, so a
+    // difference anywhere else would make the comparison meaningless.
+    expect(advised().map((step) => step.name)).toEqual(implement.map((step) => step.name))
+    for (const step of advised()) {
+      if (step.name === "implementer") continue
+      expect({ model: step.model, variant: step.variant }).toEqual({
+        model: byName[step.name]!.model,
+        variant: byName[step.name]!.variant,
+      })
+    }
+  })
+})
+
+describe("built-in ship pipeline", () => {
+  const ship = () =>
+    resolvePipeline({ name: "ship", spec: builtInPipelines.ship!, agents: builtInAgents }).steps.filter(
+      (step): step is AgentStep => step.type === "agent",
+    )
+
+  test("syncs the base in before anything reads the diff", () => {
+    const steps = ship()
+
+    expect(steps[0]).toMatchObject({ name: "sync", agentName: "sync-with-base" })
+    // The sync phase writes: it resolves conflicts and Convoy's phase commit
+    // concludes the merge.
+    expect(steps[0]?.readOnly).toBeUndefined()
+    expect(steps[0]?.inputFiles).toEqual(["prd.md"])
+    // scope is what first reads the diff, and by then it is the merged diff.
+    expect(steps[1]).toMatchObject({ name: "scope", inputDiff: true })
   })
 
-  test("mirrors implement's step names, so the two are directly comparable", () => {
-    expect(advised().map((step) => step.name)).toEqual(
-      resolvePipeline({ name: "implement", spec: builtInPipelines.implement!, agents: builtInAgents })
-        .steps.filter((step): step is AgentStep => step.type === "agent")
-        .map((step) => step.name),
+  test("runs refine's audit chain after the sync", () => {
+    const refine = resolvePipeline({ name: "refine", spec: builtInPipelines.refine!, agents: builtInAgents }).steps.filter(
+      (step): step is AgentStep => step.type === "agent",
     )
+
+    expect(ship().slice(1).map((step) => step.name)).toEqual(refine.map((step) => step.name))
   })
 })
 


### PR DESCRIPTION
## Why

Four pipelines had been running from `~/.convoy/config.yaml`, where a project/global definition shadows the built-in of the same name wholesale (`selectPipelineSpec`). They are the combinations worth defaulting to, so they move into the repo and the local copies are deleted — no more divergence between what the code says and what actually runs.

Every one was verified to resolve **identically** to the local definition it replaces (step names, agents, models, variants, advisors, input files, diff flags) before the local copies were removed.

## `implement`

| Step | Before | After |
|---|---|---|
| `implementer` | `gpt-5.6-sol` | `gpt-5.6-sol#xhigh` |
| `patterns` | *(unpinned → terra#xhigh)* | `glm-5.2#xhigh` |
| `security` | *(unpinned → terra#xhigh)* | `glm-5.2#xhigh` |
| `design` | `kimi-k3` | `kimi-k3#high` |
| `tests` | *(unpinned → terra#xhigh)* | `glm-5.2#xhigh` |
| `adversarial` | `kimi-k3` | `kimi-k3#high` |

The audits stop inheriting the run's model and get pinned to GLM 5.2 xhigh. They read a diff that already exists, which is the work GLM does at parity — so the budget concentrates in the phases that write (Sol xhigh) and judge (Kimi K3 high). New exported `defaultImplementAuditModel` keeps `convoy init`'s inlined copy in sync, and its `- patterns` / `- security` shorthand steps become pinned objects.

## `implement-advised`

Now differs from `implement` in **exactly one thing** — the advised implementation step — which is the entire point of having it. A test enforces this: every phase after the implementer must match `implement` model for model.

That means `adversarial` moves from Opus to Kimi K3 high, contradicting the previous comment that the adversarial pass is "the one place the expensive model should own the loop". That reasoning is replaced rather than left standing next to code that no longer follows it. The advisor also gains its variant: `gpt-5.6-sol#xhigh`.

## `fixer`

`reproduction` and `fixes` gain `gpt-5.6-sol#xhigh` as an advisor — both make a call that is expensive to get wrong and cheap to check (is this finding genuinely reproducible; how small can the fix be). `validation` stays unadvised: it reruns the proofs itself, which is a stronger check than a second opinion on the reasoning.

## `ship` (new)

`refine` preceded by a `sync` phase that merges the advanced base branch in and resolves conflicts — real and semantic — so the audits read the branch as it will actually merge instead of a diff that no longer describes what lands. Brings its `sync-with-base` agent and `prompts/sync-with-base.md`.

Two things it deliberately does **not** ship, because both are machine-local and stay in user config:
- `permissions.allow` for `git merge*`, `git add*`, `git checkout --ours*|--theirs*`. Without them those commands fall through to `"ask"` rather than failing, so the pipeline degrades rather than breaking.
- `hooks.pipelines.ship` to fetch the base first and open the PR after. Convoy never runs remote git itself.

Both are documented in the README row, the `convoy init` template, and the pipeline's own comment.

**One correctness fix while promoting it:** the prompt told the agent to finish with `git add -A && git commit --no-edit`. `git commit*` is on the hard denylist and config `allow` can never resurrect a denied pattern, so that instruction could never have worked. It now stops at `git add -A` and lets Convoy's phase commit conclude the merge — which it does correctly, because `MERGE_HEAD` is still present. The stale "a pre-hook already ran `git fetch`" claim is now conditional too, since a built-in cannot assume the hook exists.

## Verification

`bun test` (817 pass) and `bun run typecheck` are green. Test changes reflect the new defaults rather than working around them; the `implement-lite` test that asserted "GLM stays out of `implement`" is replaced by one asserting what now actually distinguishes lite from standard, and new `ship` tests cover the sync-first ordering and that the rest matches `refine` step for step.

Checked against the real CLI with `--plan` for all four: models, variants and advisor counts match the local definitions, and `ship` still picks up its hooks from user config.

> [!NOTE]
> `~/.convoy/config.yaml` was reduced to `defaults`, `permissions` and `hooks`, and `~/.convoy/agents/sync-with-base.md` deleted. Also dropped `git commit*` from the local allowlist — it was a no-op against the hard denylist and nothing asks for it now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Mo6s1UDncWirFvPUxUE1