### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convoy",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps `package.json` to `0.4.0`. The release workflow verifies the pushed tag matches this version, so this has to land before `v0.4.0` is tagged.

**Minor rather than patch:** all three changes since `v0.3.1` alter the behaviour of existing runs, and two change a documented default.

## What's in it

**[#48](https://github.com/Inakitajes/convoy/pull/48) — validators can run the checks they report on.** `readOnly` agents may now carry `verify`, which restores bash under the same policy writable steps get while write and edit stay closed and the clean-baseline check still holds. The three built-in validators ship with it on. `fixer` drops from four steps to three: with validation actually executing, `fixer-reporter` was a second per-finding matrix written by a model that ran nothing.

**[#49](https://github.com/Inakitajes/convoy/pull/49) — the worktree default follows the current branch.** ⚠️ **Behaviour change:** an unset `defaults.worktree` no longer means "always isolate". It now isolates on a trunk (`main`/`master`/`develop`/`trunk` or whatever `origin/HEAD` resolves to) and runs in place on any other branch. Anyone relying on the old default needs `defaults.worktree: true` explicitly.

**[#50](https://github.com/Inakitajes/convoy/pull/50) — the tuned pipelines become the defaults.** ⚠️ **Behaviour change:** `implement` pins its audits to GLM 5.2 xhigh instead of inheriting the run's model, with `implementer` on Sol xhigh and `design`/`adversarial` on Kimi K3 high; `implement-advised` now differs from `implement` in exactly one step and moves `adversarial` from Opus to Kimi K3 high; `fixer` gains a Sol xhigh advisor on its two writing phases. `ship` is new — `refine` preceded by a phase that merges the advanced base in, so audits read the branch as it will actually merge. It expects `permissions.allow` for `git merge*`/`git add*`/`git checkout --ours*` and optional `hooks.pipelines.ship` for fetch/PR, both machine-local.

## Verification

`bun test` (817 pass) and `bun run typecheck` green at `0.4.0`. Nothing else changed in this commit — the release workflow builds from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144Mo6s1UDncWirFvPUxUE1