### PR TITLE
feat(pipeline): add per-pipeline maxConcurrentAgents

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -576,7 +576,7 @@ export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOpt
     notify: parsed.notify,
     notifications: config?.notifications ?? {},
     humanReview,
-    maxConcurrentAgents: parsed.maxConcurrent ?? defaults.maxConcurrentAgents ?? defaultMaxConcurrentAgents,
+    maxConcurrentAgents: parsed.maxConcurrent ?? pipeline.maxConcurrentAgents ?? defaults.maxConcurrentAgents ?? defaultMaxConcurrentAgents,
     baseRef: await resolveBaseRef(parsed, defaults),
     targetDir: parsed.targetDir,
     // A resumed run continues in the directory its metadata recorded — which is

--- a/src/config.ts
+++ b/src/config.ts
@@ -631,13 +631,14 @@ function validatePipelines(v: Validator, raw: unknown): Record<string, PipelineS
   for (const [name, value] of Object.entries(record)) {
     const path = `pipelines.${name}`
     const entry = v.record(value, path)
-    v.knownKeys(entry, path, ["description", "steps"])
+    v.knownKeys(entry, path, ["description", "maxConcurrentAgents", "steps"])
 
     if (!Array.isArray(entry.steps) || entry.steps.length === 0) v.fail(`${path}.steps`, "must be a non-empty list of steps")
     const steps = (entry.steps as unknown[]).map((step, index) => validateStep(v, step, `${path}.steps[${index}]`))
 
     pipelines[name] = {
       ...(entry.description !== undefined ? { description: v.nonEmptyString(entry.description, `${path}.description`) } : {}),
+      ...(entry.maxConcurrentAgents !== undefined ? { maxConcurrentAgents: v.positiveInt(entry.maxConcurrentAgents, `${path}.maxConcurrentAgents`) } : {}),
       steps,
     }
   }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -331,6 +331,12 @@ export type StepSpec = string | AgentStepSpec | HumanStepSpec | ParallelStepSpec
 
 export type PipelineSpec = {
   description?: string
+  /**
+   * Cap on agents running at once within a concurrent group (`parallel:` block
+   * or `models:` fan-out) for this pipeline only. Beats `defaults.maxConcurrentAgents`;
+   * loses to the `--max-concurrent` CLI flag. Unset inherits the defaults chain.
+   */
+  maxConcurrentAgents?: number
   steps: StepSpec[]
 }
 
@@ -688,7 +694,7 @@ export function resolvePipeline(input: ResolvePipelineInput): Pipeline {
     throw new Error(`pipeline "${input.name}" has no agent steps`)
   }
 
-  return { name: input.name, ...(input.spec.description ? { description: input.spec.description } : {}), steps }
+  return { name: input.name, ...(input.spec.description ? { description: input.spec.description } : {}), ...(input.spec.maxConcurrentAgents !== undefined ? { maxConcurrentAgents: input.spec.maxConcurrentAgents } : {}), steps }
 }
 
 export function isParallelSpec(raw: StepSpec): raw is ParallelStepSpec {

--- a/src/types.ts
+++ b/src/types.ts
@@ -177,6 +177,8 @@ export type Step = AgentStep | HumanStep
 export type Pipeline = {
   name: string
   description?: string
+  /** Per-pipeline cap on concurrent agents within a group; unset inherits the defaults/CLI chain. */
+  maxConcurrentAgents?: number
   steps: Step[]
 }
 


### PR DESCRIPTION
## What

Adds a `maxConcurrentAgents` field to pipeline definitions so a pipeline can set its own cap on concurrent agents within a `parallel:` block or `models:` fan-out, without affecting other pipelines or the global `defaults.maxConcurrentAgents`.

## Why

Pipelines like `hunter-nan` (24 concurrent audits = 6 tracks × 4 models) can exceed a provider's rate limit (e.g. a subscription capped at 5 parallel requests). Currently the only options are global (`defaults.maxConcurrentAgents`, which throttles every pipeline) or per-invocation (`--max-concurrent`, which is easy to forget). A per-pipeline cap lets the throttled pipeline run safely by default while others keep the built-in 30.

## Precedence

```
--max-concurrent  >  pipeline.maxConcurrentAgents  >  defaults.maxConcurrentAgents  >  30 (built-in)
```

## Changes

- `src/pipeline.ts` — `PipelineSpec` and `resolvePipeline` carry the optional `maxConcurrentAgents` through to the resolved `Pipeline`
- `src/types.ts` — `Pipeline` type gains `maxConcurrentAgents?: number`
- `src/config.ts` — `validatePipelines` accepts and validates `maxConcurrentAgents` as a positive integer (0 and negatives rejected)
- `src/cli.ts` — precedence chain inserts `pipeline.maxConcurrentAgents` between the CLI flag and `defaults`

## Example

```yaml
pipelines:
  hunter-nan:
    maxConcurrentAgents: 4
    steps:
      - parallel:
          - agent: hunter-correctness
            models: [nan/qwen3.6#high, nan/gemma4#high, ...]
          # ...
```

## Verification

- `tsc --noEmit` — clean
- 153 config/pipeline tests pass
- `maxConcurrentAgents: 4` resolves correctly on the pipeline; unset pipelines inherit defaults
- Validation rejects `0` and `-1` with a clear error