### PR TITLE
feat(permissions): add inspect and explain actions to permission modal

### DIFF
--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -5,7 +5,7 @@ import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 import { getSessionEventHub } from "./event-hub"
 import { log } from "./log"
 import { noopProgress, type AutoAccept, type PermissionPromptInfo, type PermissionReply, type ProgressUI } from "./progress"
-import { judgeCommand } from "./safety-judge"
+import { explainCommand, judgeCommand } from "./safety-judge"
 import { createTerminalInput, type TerminalInput } from "./terminal-input"
 
 type PermissionRequest = {
@@ -68,6 +68,8 @@ export type StartGateOptions = {
   advisorCheckpoint?: AdvisorCheckpoint
   /** Serializes terminal input with the phase gate so a --no-tui parallel run never opens two readlines on stdin. */
   terminalInput?: TerminalInput
+  /** The opencode server URL for [i] inspect to attach to. Absent in readline fallback on non-macOS. */
+  serverUrl?: string
 }
 
 export function startPermissionGate(options: StartGateOptions): PermissionGate {
@@ -97,7 +99,7 @@ export function startPermissionGate(options: StartGateOptions): PermissionGate {
     if (handled.has(request.id)) return
     handled.add(request.id)
     queue(() =>
-      handleRequest(options.client, request, options.interactive, progress, options.directory, options.autoAccept, options.judgeModel, controller.signal, options.advisorCheckpoint, terminalInput),
+      handleRequest(options.client, request, options.interactive, progress, options.directory, options.autoAccept, options.judgeModel, controller.signal, options.advisorCheckpoint, terminalInput, options.serverUrl),
     )
   })
 
@@ -136,6 +138,7 @@ async function handleRequest(
   signal?: AbortSignal,
   advisorCheckpoint?: AdvisorCheckpoint,
   terminalInput: TerminalInput = createTerminalInput(),
+  serverUrl?: string,
 ) {
   const summary = describeRequest(request)
 
@@ -170,6 +173,7 @@ async function handleRequest(
   // loop. A "safe" verdict auto-allows; anything else (incl. judge failure,
   // which is fail-closed) drops through to the normal human prompt below.
   let judgeReason: string | undefined
+  let verdictReason: string | undefined
   if (autoAccept?.mode === "smart" && judgeModel) {
     progress.message(`evaluating safety: ${summary}`)
     const verdict = await judgeCommand(client, { request: promptInfo(request), model: judgeModel, directory, signal })
@@ -181,6 +185,7 @@ async function handleRequest(
     }
     log.info(`[permission] smart auto-accept escalating to user: ${summary} — ${verdict.reason}`)
     judgeReason = `flagged by safety judge: ${verdict.reason}`
+    verdictReason = verdict.reason
   }
 
   if (!interactive) {
@@ -195,7 +200,7 @@ async function handleRequest(
   // race a phase-gate readline for the same stdin in a --no-tui parallel run.
   const ask = progress.askPermission?.bind(progress)
   if (ask) {
-    const answer = await ask(promptInfo(request, judgeReason))
+    const answer = await ask(promptInfoForUser(request, judgeReason, verdictReason, judgeModel, client, directory, signal))
     log.info(`[permission] replied ${answer} for ${request.permission}`)
     await reply(client, request.id, directory, answer, answer === "reject" ? "rejected by user" : undefined)
     return
@@ -207,11 +212,46 @@ async function handleRequest(
       log.section("permission request")
       stdout.write(formatRequest(request, judgeReason))
       for (;;) {
-        const raw = (await prompt.ask("approve? [o]nce, [a]lways, [r]eject > ")).trim().toLowerCase()
+        const raw = (await prompt.ask("approve? [o]nce, [a]lways, [r]eject, [e]xplain, [i]nspect > ")).trim().toLowerCase()
         if (raw === "o" || raw === "once" || raw === "y" || raw === "yes") return "once" as Reply
         if (raw === "a" || raw === "always") return "always" as Reply
         if (raw === "r" || raw === "reject" || raw === "n" || raw === "no") return "reject" as Reply
-        stdout.write("Choose o, a, or r.\n")
+        if (raw === "e" || raw === "explain") {
+          if (judgeModel) {
+            try {
+              const explanation = await explainCommand(client, {
+                request: promptInfo(request),
+                model: judgeModel,
+                directory,
+                signal: AbortSignal.any([signal ?? new AbortController().signal, new AbortController().signal]),
+                verdictReason,
+              })
+              stdout.write(`\n${explanation}\n\n`)
+            } catch {
+              stdout.write("\nthe judge could not explain it\n\n")
+            }
+          } else {
+            stdout.write("\nno safety judge configured to explain this\n\n")
+          }
+          continue
+        }
+        if (raw === "i" || raw === "inspect") {
+          if (serverUrl && request.sessionID) {
+            try {
+              const { openOpencodeSessionWindow } = await import("./opencode")
+              await openOpencodeSessionWindow({ url: serverUrl, targetDir: directory, sessionID: request.sessionID })
+              stdout.write(`\nopened session in new window\n\n`)
+            } catch (error) {
+              stdout.write(`\ncouldn't open session: ${error instanceof Error ? error.message : String(error)}\n\n`)
+            }
+          } else if (!serverUrl) {
+            stdout.write("\nno live opencode server to attach to\n\n")
+          } else {
+            stdout.write("\nthis request has no session to inspect\n\n")
+          }
+          continue
+        }
+        stdout.write("Choose o, a, r, e, or i.\n")
       }
     } finally {
       progress.resume()
@@ -232,6 +272,37 @@ function promptInfo(request: PermissionRequest, judgeReason?: string): Permissio
     sessionID: request.sessionID,
     ...(judgeReason ? { judgeReason } : {}),
   }
+}
+
+/**
+ * Builds the `PermissionPromptInfo` for the user-facing prompt (TUI or readline).
+ * This is the same as `promptInfo` but adds the `explain` callback when a judge
+ * model is available. `promptInfo` itself stays free of callbacks because it is
+ * also the `JudgeRequest` that feeds `judgeCommand`.
+ */
+function promptInfoForUser(
+  request: PermissionRequest,
+  judgeReason?: string,
+  verdictReason?: string,
+  judgeModel?: { providerID: string; modelID: string },
+  client?: OpencodeClient,
+  directory?: string,
+  signal?: AbortSignal,
+): PermissionPromptInfo {
+  const info = promptInfo(request, judgeReason)
+  if (judgeModel && client && directory) {
+    info.explain = (explainSignal?: AbortSignal) => {
+      const combined = signal && explainSignal ? AbortSignal.any([signal, explainSignal]) : (signal ?? explainSignal)
+      return explainCommand(client, {
+        request: promptInfo(request),
+        model: judgeModel,
+        directory,
+        signal: combined,
+        verdictReason,
+      })
+    }
+  }
+  return info
 }
 
 async function reply(client: OpencodeClient, requestID: string, directory: string, choice: Reply, message?: string) {

--- a/src/permissions.ts
+++ b/src/permissions.ts
@@ -218,18 +218,14 @@ async function handleRequest(
         if (raw === "r" || raw === "reject" || raw === "n" || raw === "no") return "reject" as Reply
         if (raw === "e" || raw === "explain") {
           if (judgeModel) {
-            try {
-              const explanation = await explainCommand(client, {
-                request: promptInfo(request),
-                model: judgeModel,
-                directory,
-                signal: AbortSignal.any([signal ?? new AbortController().signal, new AbortController().signal]),
-                verdictReason,
-              })
-              stdout.write(`\n${explanation}\n\n`)
-            } catch {
-              stdout.write("\nthe judge could not explain it\n\n")
-            }
+            const explanation = await explainCommand(client, {
+              request: promptInfo(request),
+              model: judgeModel,
+              directory,
+              signal: AbortSignal.any([signal ?? new AbortController().signal, new AbortController().signal]),
+              verdictReason,
+            })
+            stdout.write(`\n${explanation}\n\n`)
           } else {
             stdout.write("\nno safety judge configured to explain this\n\n")
           }

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -122,6 +122,12 @@ export type PermissionPromptInfo = {
   sessionID?: string
   /** Present when smart auto-accept's judge escalated this request; explains why. */
   judgeReason?: string
+  /**
+   * Pide al juez una explicación larga de esta petición ([e] en el dashboard).
+   * La aporta el gate, que es quien tiene el cliente de opencode y el modelo
+   * juez; ausente cuando no hay juez al que preguntar.
+   */
+  explain?(signal?: AbortSignal): Promise<string>
 }
 
 export type HumanReviewAction = "continue" | "iterate" | "abort" | "retry"

--- a/src/progress.ts
+++ b/src/progress.ts
@@ -123,9 +123,9 @@ export type PermissionPromptInfo = {
   /** Present when smart auto-accept's judge escalated this request; explains why. */
   judgeReason?: string
   /**
-   * Pide al juez una explicación larga de esta petición ([e] en el dashboard).
-   * La aporta el gate, que es quien tiene el cliente de opencode y el modelo
-   * juez; ausente cuando no hay juez al que preguntar.
+   * Asks the judge for a prose explanation of this request ([e] in the dashboard).
+   * Provided by the gate, which holds the opencode client and the judge model;
+   * absent when there is no judge to ask.
    */
   explain?(signal?: AbortSignal): Promise<string>
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -599,6 +599,7 @@ export async function run(options: RunOptions) {
       autoAccept,
       judgeModel,
       terminalInput,
+      serverUrl: opencode.url,
       ...(advisorNeeds.agents.size > 0 ? { advisorCheckpoint: advisors.checkpoint } : {}),
     })
 

--- a/src/safety-judge.ts
+++ b/src/safety-judge.ts
@@ -148,7 +148,7 @@ export async function judgeCommand(client: OpencodeClient, input: JudgeInput): P
 }
 
 export type ExplainInput = JudgeInput & {
-  /** La razón del veredicto que escaló la petición, cuando smart mode produjo una. */
+  /** The verdict reason that escalated this request, when smart mode produced one. */
   verdictReason?: string
 }
 

--- a/src/safety-judge.ts
+++ b/src/safety-judge.ts
@@ -24,6 +24,7 @@ export type JudgeInput = {
 }
 
 const defaultTimeoutMs = 20_000
+const defaultExplainTimeoutMs = 45_000
 
 /**
  * The judge runs OUTSIDE the agentic loop: a single stateless prompt with every
@@ -50,9 +51,36 @@ const judgeSystemPrompt = [
   '{"safe": boolean, "reason": "<short explanation, <=140 chars>"}',
 ].join("\n")
 
-export async function judgeCommand(client: OpencodeClient, input: JudgeInput): Promise<SafetyVerdict> {
+/**
+ * System prompt for the deep-explain mode: two short paragraphs asking the judge
+ * to describe what the command does and why it is risky, in plain prose.
+ */
+const explainSystemPrompt = [
+  "You are a safety judge explaining a permission request to a human. Describe what the command",
+  "actually does and what makes it risky. Be specific: mention the concrete risk (data loss,",
+  "exfiltration, credential exposure, destructive side effect) and what would make it safe or not.",
+  "",
+  "Keep your answer to at most 120 words. Use plain text, no markdown, no code fences.",
+].join("\n")
+
+/**
+ * Shared setup/teardown for a judge session: creates a throwaway session, sends
+ * a prompt, and collects the text response. The session is always deleted
+ * (best-effort) in the finally block. Throws on error or timeout.
+ */
+async function runJudgeSession(
+  client: OpencodeClient,
+  input: {
+    directory: string
+    model: { providerID: string; modelID: string }
+    system: string
+    text: string
+    signal?: AbortSignal
+    timeoutMs: number
+  },
+): Promise<string> {
   const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(new Error("safety judge timed out")), input.timeoutMs ?? defaultTimeoutMs)
+  const timeout = setTimeout(() => controller.abort(new Error("safety judge timed out")), input.timeoutMs)
   const onParentAbort = () => controller.abort(input.signal?.reason)
   if (input.signal) {
     if (input.signal.aborted) controller.abort(input.signal.reason)
@@ -73,30 +101,19 @@ export async function judgeCommand(client: OpencodeClient, input: JudgeInput): P
         sessionID,
         directory: input.directory,
         model: input.model,
-        system: judgeSystemPrompt,
+        system: input.system,
         // Every tool off: the judge classifies, it never executes.
         tools: { read: false, write: false, edit: false, bash: false, webfetch: false, todoread: false, todowrite: false },
-        parts: [{ type: "text", text: renderRequest(input.request) }],
+        parts: [{ type: "text", text: input.text }],
       },
       { signal: controller.signal },
     )
     if (response.error || !response.data) throw new Error("safety judge returned no answer")
 
-    const text = collectText(response.data.parts)
-    const verdict = parseVerdict(text)
-    if (!verdict) {
-      log.warn(`[safety-judge] unparseable verdict, escalating: ${truncate(text, 160)}`)
-      return { safe: false, reason: "could not read the safety verdict" }
-    }
-    return verdict
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    log.warn(`[safety-judge] evaluation failed, escalating: ${message}`)
-    return { safe: false, reason: `safety check failed (${message})` }
+    return collectText(response.data.parts)
   } finally {
     clearTimeout(timeout)
     input.signal?.removeEventListener("abort", onParentAbort)
-    // Throwaway session; the run workspace is ephemeral, so deletion is best-effort.
     if (sessionID) {
       try {
         await client.session.delete({ sessionID, directory: input.directory })
@@ -107,13 +124,66 @@ export async function judgeCommand(client: OpencodeClient, input: JudgeInput): P
   }
 }
 
-function renderRequest(request: JudgeRequest): string {
+export async function judgeCommand(client: OpencodeClient, input: JudgeInput): Promise<SafetyVerdict> {
+  try {
+    const text = await runJudgeSession(client, {
+      directory: input.directory,
+      model: input.model,
+      system: judgeSystemPrompt,
+      text: renderRequest(input.request),
+      signal: input.signal,
+      timeoutMs: input.timeoutMs ?? defaultTimeoutMs,
+    })
+    const verdict = parseVerdict(text)
+    if (!verdict) {
+      log.warn(`[safety-judge] unparseable verdict, escalating: ${truncate(text, 160)}`)
+      return { safe: false, reason: "could not read the safety verdict" }
+    }
+    return verdict
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    log.warn(`[safety-judge] evaluation failed, escalating: ${message}`)
+    return { safe: false, reason: `safety check failed (${message})` }
+  }
+}
+
+export type ExplainInput = JudgeInput & {
+  /** La razón del veredicto que escaló la petición, cuando smart mode produjo una. */
+  verdictReason?: string
+}
+
+/**
+ * Asks the judge for a prose explanation of the permission request and its risk.
+ * Unlike `judgeCommand`, this is not fail-closed: on error or timeout it returns
+ * a human-readable fallback string instead of throwing.
+ */
+export async function explainCommand(client: OpencodeClient, input: ExplainInput): Promise<string> {
+  try {
+    const text = await runJudgeSession(client, {
+      directory: input.directory,
+      model: input.model,
+      system: explainSystemPrompt,
+      text: renderRequest(input.request, input.verdictReason),
+      signal: input.signal,
+      timeoutMs: input.timeoutMs ?? defaultExplainTimeoutMs,
+    })
+    return text || "the judge returned an empty explanation"
+  } catch (error) {
+    if (error instanceof Error && error.message === "safety judge timed out") {
+      return "the judge could not explain it (timed out)"
+    }
+    return `the judge could not explain it (${error instanceof Error ? error.message : String(error)})`
+  }
+}
+
+function renderRequest(request: JudgeRequest, verdictReason?: string): string {
   const lines = [`category: ${request.permission}`]
   if (request.command) lines.push(`command: ${request.command}`)
   if (request.target) lines.push(`target: ${request.target}`)
   if (request.patterns && request.patterns.length > 0) lines.push(`patterns: ${request.patterns.join(", ")}`)
   if (request.description) lines.push(`description: ${request.description}`)
   lines.push("", "Is it safe to auto-approve this without human review?")
+  if (verdictReason) lines.push("", `The safety judge previously escalated this request with this reason: ${verdictReason}`)
   return lines.join("\n")
 }
 

--- a/src/tui-actions.ts
+++ b/src/tui-actions.ts
@@ -58,6 +58,8 @@ export type ActionID =
   | "permission-reject"
   | "permission-escape"
   | "permission-auto-accept"
+  | "permission-inspect"
+  | "permission-explain"
   | "review-continue"
   | "review-open"
   | "review-abort"
@@ -379,6 +381,26 @@ export function dashboardActions(state: DashboardActionState): Action[] {
       hint: "confirm",
       style: "spaced",
       help: "send the selected answer",
+      priority: 3,
+    },
+    {
+      id: "permission-inspect",
+      group: "permissions",
+      available: state.permissionPending,
+      keys: "i",
+      hint: "nspect",
+      style: "glued",
+      help: "open the opencode session that asked",
+      priority: 3,
+    },
+    {
+      id: "permission-explain",
+      group: "permissions",
+      available: state.permissionPending,
+      keys: "e",
+      hint: "xplain",
+      style: "glued",
+      help: "ask the safety judge why",
       priority: 3,
     },
     {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -293,9 +293,20 @@ const transcriptCap = 24_000
 // memoize their wrapped lines.
 const animationTickMs = 80
 
+type PermissionExplainState =
+  | { status: "loading" }
+  | { status: "ready"; lines: string[]; scroll: number }
+  | { status: "error"; message: string }
+
 type PendingPermission = {
   info: PermissionPromptInfo
   resolve: (reply: PermissionReply) => void
+  /** Estado de [e]; ausente hasta que el usuario lo pide. */
+  explain?: PermissionExplainState
+  /** Corta la explicación en vuelo cuando se responde o se drena el prompt. */
+  explainAbort?: AbortController
+  /** Resultado de [i], para dar feedback dentro del modal (el feed queda tapado). */
+  inspect?: { backend?: SessionWindowBackend; error?: string }
 }
 
 type PendingHumanReview = {
@@ -1384,7 +1395,10 @@ export class TuiProgress implements ProgressUI {
         this.manualFocus = true
       }
       this.resetContentScroll()
-      for (const pending of this.permissionQueue.splice(0)) pending.resolve("reject")
+      for (const pending of this.permissionQueue.splice(0)) {
+        pending.explainAbort?.abort()
+        pending.resolve("reject")
+      }
       this.addEvent(
         "convoy",
         outcome.status === "completed" ? "system" : "error",
@@ -1636,7 +1650,10 @@ export class TuiProgress implements ProgressUI {
     // up; resolving here keeps that promise from leaking.
     this.finished?.resolve()
     for (const pending of this.humanReviewQueue.splice(0)) pending.resolve("abort")
-    for (const pending of this.permissionQueue.splice(0)) pending.resolve("reject")
+    for (const pending of this.permissionQueue.splice(0)) {
+      pending.explainAbort?.abort()
+      pending.resolve("reject")
+    }
     if (this.renderer.isDestroyed) return
     this.renderer.destroy()
   }
@@ -2104,7 +2121,100 @@ export class TuiProgress implements ProgressUI {
       case "escape":
         this.resolvePermission("reject")
         break
+      case "e":
+        this.requestPermissionExplain()
+        break
+      case "i":
+        this.openPermissionSessionWindow()
+        break
+      case "up":
+      case "k":
+        this.scrollPermissionExplain(-1)
+        break
+      case "down":
+      case "j":
+        this.scrollPermissionExplain(1)
+        break
     }
+    this.render()
+  }
+
+  /**
+   * The [e] deep-explain: asks the judge for a prose explanation of the head
+   * request and paints it inside the modal. o/a/r keep working while loading.
+   */
+  private requestPermissionExplain() {
+    const pending = this.permissionQueue[0]
+    if (!pending) return
+    const explain = pending.info.explain
+    if (!explain) {
+      this.addEvent("convoy", "permission", "no safety judge configured to explain this")
+      this.render()
+      return
+    }
+    if (pending.explain?.status === "loading") return
+    const controller = new AbortController()
+    pending.explainAbort = controller
+    pending.explain = { status: "loading" }
+    this.addEvent("convoy", "permission", "asking the safety judge to explain")
+    this.render()
+    explain(controller.signal)
+      .then((text) => {
+        // The user may have answered while the judge was thinking; the modal
+        // renders the head of the queue, so drop a stale result by identity.
+        if (this.permissionQueue[0] !== pending) return
+        pending.explain = { status: "ready", lines: wrapLines(text.split("\n"), permissionModalWidth(this.renderer.width) - 6), scroll: 0 }
+        this.render()
+      })
+      .catch((error: unknown) => {
+        if (this.permissionQueue[0] !== pending) return
+        if (controller.signal.aborted) return
+        pending.explain = { status: "error", message: error instanceof Error ? error.message : String(error) }
+        this.render()
+      })
+  }
+
+  private scrollPermissionExplain(delta: number) {
+    const pending = this.permissionQueue[0]
+    if (pending?.explain?.status !== "ready") return
+    const lines = pending.explain.lines
+    const maxRows = permissionExplainMaxRows(this.renderer.height)
+    const maxScroll = Math.max(0, lines.length - maxRows)
+    pending.explain = { status: "ready", lines, scroll: Math.max(0, Math.min(pending.explain.scroll + delta, maxScroll)) }
+  }
+
+  /**
+   * The [i] inspect: opens the opencode session that asked for this permission
+   * in a new window. The attached window sees the same pending request and can
+   * answer it; whichever reply lands first wins, the other fails and is logged
+   * by the existing error branch in `reply()` (src/permissions.ts). The gate
+   * must NOT be paused: the request is already being held, and pause() only
+   * affects requests that arrive afterwards.
+   */
+  private openPermissionSessionWindow() {
+    const pending = this.permissionQueue[0]
+    if (!pending) return
+    if (!pending.info.sessionID) {
+      pending.inspect = { error: "this request has no session to inspect" }
+      this.render()
+      return
+    }
+    if (!this.serverUrl) {
+      pending.inspect = { error: "no live opencode server to attach to" }
+      this.render()
+      return
+    }
+    const targetDir = this.targetDir || process.cwd()
+    this.addEvent("convoy", "permission", `[i]: opening session ${shortID(pending.info.sessionID)}`)
+    openOpencodeSessionWindow({ url: this.serverUrl, targetDir, sessionID: pending.info.sessionID })
+      .then((backend) => {
+        pending.inspect = { backend }
+        this.render()
+      })
+      .catch((error: unknown) => {
+        pending.inspect = { error: error instanceof Error ? error.message : String(error) }
+        this.render()
+      })
     this.render()
   }
 
@@ -2118,6 +2228,7 @@ export class TuiProgress implements ProgressUI {
     // prompts for the user (re-judging an open prompt would be surprising).
     if (next === "all") {
       for (const pending of this.permissionQueue.splice(0)) {
+        pending.explainAbort?.abort()
         this.addEvent("convoy", "permission", `auto-allowed: ${permissionSummary(pending.info)}`)
         pending.resolve("once")
       }
@@ -2129,6 +2240,7 @@ export class TuiProgress implements ProgressUI {
   private resolvePermission(reply: PermissionReply) {
     const pending = this.permissionQueue.shift()
     if (!pending) return
+    pending.explainAbort?.abort()
     this.permissionChoice = 0
     const verdict = reply === "once" ? "allowed once" : reply === "always" ? "always allowed" : "rejected"
     this.addEvent("convoy", "permission", `${verdict}: ${permissionSummary(pending.info)}`)
@@ -2401,6 +2513,7 @@ export class TuiProgress implements ProgressUI {
     // its spinner covers the message-writing call and the signing commit.
     if (this.finishModal?.kind === "working") return true
     if (this.finished) return false
+    if (this.permissionQueue[0]?.explain?.status === "loading") return true
     return this.phases.some((phase) => phase.status === "running")
   }
 
@@ -3462,7 +3575,7 @@ export class TuiProgress implements ProgressUI {
     this.overlay.visible = true
     this.modal.title = " ⚿ permission required "
 
-    const boxWidth = Math.max(44, Math.min(68, this.renderer.width - 8))
+    const boxWidth = permissionModalWidth(this.renderer.width)
     const width = boxWidth - 6
     const info = pending.info
     const lines: StyledText[] = []
@@ -3479,6 +3592,39 @@ export class TuiProgress implements ProgressUI {
     if (info.description) lines.push(t`${fg(theme.faint)(truncate(info.description, width))}`)
     if (info.judgeReason) lines.push(new StyledText([fg(theme.yellow)("⚠ "), fg(theme.yellow)(truncate(info.judgeReason, width - 2))]))
     if (info.sessionID) lines.push(t`${fg(theme.faint)(`session ${shortID(info.sessionID)}`)}`)
+
+    // [e] explain section: loading spinner, ready text, or error
+    const explain = pending.explain
+    if (explain) {
+      if (explain.status === "loading") {
+        lines.push(plain(""))
+        lines.push(new StyledText([fg(theme.accent)(spinnerFrame(Date.now())), fg(theme.dim)(" judge  thinking…")]))
+      } else if (explain.status === "ready") {
+        lines.push(plain(""))
+        const maxRows = permissionExplainMaxRows(this.renderer.height)
+        const visible = explain.lines.slice(explain.scroll, explain.scroll + maxRows)
+        for (const line of visible) {
+          lines.push(t`${fg(theme.dim)(line)}`)
+        }
+        if (explain.lines.length > maxRows) {
+          lines.push(plain(""), t`${fg(theme.dim)(`↑↓ scroll  (${explain.scroll + 1}–${Math.min(explain.scroll + maxRows, explain.lines.length)} of ${explain.lines.length})`)}`)
+        }
+      } else if (explain.status === "error") {
+        lines.push(plain(""))
+        lines.push(t`${fg(theme.yellow)(explain.message)}`)
+      }
+    }
+
+    // [i] inspect feedback line
+    if (pending.inspect) {
+      lines.push(plain(""))
+      if (pending.inspect.backend) {
+        lines.push(t`${fg(theme.faint)(`inspect  opened in ${pending.inspect.backend}`)}`)
+      } else if (pending.inspect.error) {
+        lines.push(t`${fg(theme.yellow)(`inspect  ${pending.inspect.error}`)}`)
+      }
+    }
+
     lines.push(plain(""))
 
     const buttons: TextChunk[] = []
@@ -4053,4 +4199,14 @@ async function fileReadable(path: string) {
   } catch {
     return false
   }
+}
+
+/** The box width for the permission modal, matching the extraction in renderPermissionModal. */
+function permissionModalWidth(rendererWidth: number): number {
+  return Math.max(44, Math.min(68, rendererWidth - 8))
+}
+
+/** Max rows of explain text visible in the permission modal. */
+function permissionExplainMaxRows(rendererHeight: number): number {
+  return Math.max(3, rendererHeight - 16)
 }

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -301,11 +301,11 @@ type PermissionExplainState =
 type PendingPermission = {
   info: PermissionPromptInfo
   resolve: (reply: PermissionReply) => void
-  /** Estado de [e]; ausente hasta que el usuario lo pide. */
+  /** State of [e]; absent until the user requests it. */
   explain?: PermissionExplainState
-  /** Corta la explicación en vuelo cuando se responde o se drena el prompt. */
+  /** Aborts an in-flight explanation when the request is answered or the queue is drained. */
   explainAbort?: AbortController
-  /** Resultado de [i], para dar feedback dentro del modal (el feed queda tapado). */
+  /** Result of [i], for in-modal feedback (the feed is hidden behind the overlay). */
   inspect?: { backend?: SessionWindowBackend; error?: string }
 }
 

--- a/test/permissions.test.ts
+++ b/test/permissions.test.ts
@@ -14,6 +14,8 @@ type GateHarness = {
   progress: ProgressUI
   replies: ReplyCall[]
   asked: PermissionPromptInfo[]
+  /** The text of every judge prompt the fake client received, in order. */
+  prompts: string[]
 }
 
 const askedRequest = {
@@ -32,6 +34,7 @@ const askedRequest = {
 function harness(opts: { judgeAnswer?: string; askReply?: PermissionReply; permission?: string }): GateHarness {
   const replies: ReplyCall[] = []
   const asked: PermissionPromptInfo[] = []
+  const prompts: string[] = []
   let delivered = false
   const request = { ...askedRequest, ...(opts.permission ? { permission: opts.permission, patterns: [opts.permission] } : {}) }
 
@@ -54,7 +57,10 @@ function harness(opts: { judgeAnswer?: string; askReply?: PermissionReply; permi
     },
     session: {
       create: async () => ({ data: { id: "judge-session" }, error: undefined }),
-      prompt: async () => ({ data: { info: {}, parts: [{ type: "text", text: opts.judgeAnswer ?? "" }] }, error: undefined }),
+      prompt: async ({ parts }: { parts: Array<{ type: string; text?: string }> }) => {
+        prompts.push(parts.find((p) => p.type === "text")?.text ?? "")
+        return { data: { info: {}, parts: [{ type: "text", text: opts.judgeAnswer ?? "" }] }, error: undefined }
+      },
       delete: async () => ({ data: undefined, error: undefined }),
     },
   } as unknown as OpencodeClient
@@ -67,7 +73,7 @@ function harness(opts: { judgeAnswer?: string; askReply?: PermissionReply; permi
     },
   }
 
-  return { client, progress, replies, asked }
+  return { client, progress, replies, asked, prompts }
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 2_000) {
@@ -137,6 +143,78 @@ describe("permission gate auto-accept modes", () => {
     const { asked } = await drive({ mode: "smart", judgeAnswer: "not json", askReply: "reject" })
     expect(asked).toHaveLength(1)
     expect(asked[0]?.judgeReason).toBeDefined()
+  })
+})
+
+describe("permission gate explain callback", () => {
+  test("the PermissionPromptInfo carries explain when a judge model is configured", async () => {
+    const { asked } = await drive({ mode: "smart", judgeAnswer: '{"safe": false, "reason": "deletes files"}', askReply: "reject" })
+    expect(asked).toHaveLength(1)
+    expect(typeof asked[0]?.explain).toBe("function")
+  })
+
+  test("without a judge model the info has no explain callback", async () => {
+    const h = harness({ askReply: "reject" })
+    const gate = startPermissionGate({
+      client: h.client,
+      progress: h.progress,
+      interactive: true,
+      directory: "/tmp",
+      autoAccept: { mode: "off" },
+    })
+    try {
+      await waitFor(() => h.replies.length > 0)
+    } finally {
+      await gate.stop()
+    }
+    expect(h.asked[0]?.explain).toBeUndefined()
+  })
+
+  test("calling explain() reaches the judge with the verdictReason", async () => {
+    const h = harness({ judgeAnswer: '{"safe": false, "reason": "dangerous command"}', askReply: "reject" })
+    const gate = startPermissionGate({
+      client: h.client,
+      progress: h.progress,
+      interactive: true,
+      directory: "/tmp",
+      autoAccept: { mode: "smart" },
+      judgeModel: { providerID: "openai", modelID: "gpt-5.5" },
+    })
+    try {
+      await waitFor(() => h.asked.length > 0)
+    } finally {
+      await gate.stop()
+    }
+    const info = h.asked[0]!
+    expect(typeof info.explain).toBe("function")
+    const text = await info.explain!()
+    expect(text).toBeTruthy()
+    // The judgeCommand prompt text (prompts[0]) is the plain request without
+    // verdictReason, while the explain call (prompts[1]) includes it.
+    expect(h.prompts[0]).not.toContain("previously escalated")
+    expect(h.prompts[1]).toContain("dangerous command")
+  })
+
+  test("the JudgeRequest that goes to judgeCommand is the plain promptInfo without callbacks", async () => {
+    const h = harness({ judgeAnswer: '{"safe": false, "reason": "risky"}', askReply: "reject" })
+    const gate = startPermissionGate({
+      client: h.client,
+      progress: h.progress,
+      interactive: true,
+      directory: "/tmp",
+      autoAccept: { mode: "smart" },
+      judgeModel: { providerID: "openai", modelID: "gpt-5.5" },
+    })
+    try {
+      await waitFor(() => h.asked.length > 0)
+    } finally {
+      await gate.stop()
+    }
+    // The judgeCommand prompt (prompts[0]) is the rendered request text:
+    // it should not contain any explain-related content.
+    expect(h.prompts[0]).toContain("category: bash")
+    expect(h.prompts[0]).toContain("command: ls -la")
+    expect(h.prompts[0]).toContain("Is it safe to auto-approve")
   })
 })
 

--- a/test/safety-judge.test.ts
+++ b/test/safety-judge.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import type { OpencodeClient } from "@opencode-ai/sdk/v2"
 
-import { judgeCommand, parseVerdict } from "../src/safety-judge"
+import { explainCommand, judgeCommand, parseVerdict } from "../src/safety-judge"
 
 describe("parseVerdict", () => {
   test("reads a clean JSON verdict", () => {
@@ -77,5 +77,54 @@ describe("judgeCommand", () => {
     const client = fakeClient({ promptText: '{"safe": true}', onDelete: (id) => (deleted = id) })
     await judgeCommand(client, { request, model, directory: "/tmp" })
     expect(deleted).toBe("judge-session")
+  })
+})
+
+describe("explainCommand", () => {
+  test("returns the model's prose explanation", async () => {
+    const client = fakeClient({ promptText: "This command lists files in the current directory. It is safe because it is read-only and does not modify any data." })
+    const text = await explainCommand(client, { request, model, directory: "/tmp" })
+    expect(text).toContain("lists files")
+    expect(text).toContain("read-only")
+  })
+
+  test("cleans up the throwaway session", async () => {
+    let deleted: string | undefined
+    const client = fakeClient({ promptText: "safe command", onDelete: (id) => (deleted = id) })
+    await explainCommand(client, { request, model, directory: "/tmp" })
+    expect(deleted).toBe("judge-session")
+  })
+
+  test("returns a readable fallback on error, does not throw", async () => {
+    const client = fakeClient({ promptThrows: true })
+    const text = await explainCommand(client, { request, model, directory: "/tmp" })
+    expect(text).toContain("the judge could not explain it")
+  })
+
+  test("returns a readable fallback on timeout", async () => {
+    // A prompt that never resolves would trigger the timeout; we simulate
+    // by making the prompt throw a timeout error through the abort controller.
+    const client = fakeClient({ promptThrows: true })
+    const text = await explainCommand(client, { request, model, directory: "/tmp" })
+    expect(text).toContain("the judge could not explain it")
+  })
+
+  test("includes verdictReason in the rendered request when provided", async () => {
+    let capturedText = ""
+    const client: OpencodeClient = {
+      session: {
+        create: async () => ({ data: { id: "judge-session" }, error: undefined }),
+        prompt: async ({ parts }: { parts: Array<{ type: string; text?: string }> }) => {
+          capturedText = parts.find((p) => p.type === "text")?.text ?? ""
+          return { data: { info: {}, parts: [{ type: "text", text: "explanation" }] }, error: undefined }
+        },
+        delete: async ({ sessionID }: { sessionID: string }) => {
+          return { data: undefined, error: undefined }
+        },
+      },
+    } as unknown as OpencodeClient
+    await explainCommand(client, { request, model, directory: "/tmp", verdictReason: "deletes files" })
+    expect(capturedText).toContain("deletes files")
+    expect(capturedText).toContain("previously escalated")
   })
 })

--- a/test/safety-judge.test.ts
+++ b/test/safety-judge.test.ts
@@ -32,6 +32,7 @@ describe("parseVerdict", () => {
 type FakeClientOptions = {
   promptText?: string
   promptThrows?: boolean
+  promptHangs?: boolean
   onDelete?: (id: string) => void
 }
 
@@ -39,8 +40,17 @@ function fakeClient(opts: FakeClientOptions): OpencodeClient {
   return {
     session: {
       create: async () => ({ data: { id: "judge-session" }, error: undefined }),
-      prompt: async () => {
+      prompt: async (_args: unknown, { signal }: { signal?: AbortSignal } = {}) => {
         if (opts.promptThrows) throw new Error("provider unavailable")
+        if (opts.promptHangs) {
+          // Never resolves on its own; the timeout fires the abort and the SDK
+          // rejects with the abort reason ("safety judge timed out").
+          return new Promise<never>((_resolve, reject) => {
+            if (!signal) return
+            if (signal.aborted) reject(signal.reason)
+            else signal.addEventListener("abort", () => reject(signal.reason), { once: true })
+          })
+        }
         return { data: { info: {}, parts: [{ type: "text", text: opts.promptText ?? "" }] }, error: undefined }
       },
       delete: async ({ sessionID }: { sessionID: string }) => {
@@ -102,11 +112,11 @@ describe("explainCommand", () => {
   })
 
   test("returns a readable fallback on timeout", async () => {
-    // A prompt that never resolves would trigger the timeout; we simulate
-    // by making the prompt throw a timeout error through the abort controller.
-    const client = fakeClient({ promptThrows: true })
-    const text = await explainCommand(client, { request, model, directory: "/tmp" })
-    expect(text).toContain("the judge could not explain it")
+    // A prompt that hangs until the abort fires: the timeout expires and the
+    // SDK rejects with the abort reason ("safety judge timed out").
+    const client = fakeClient({ promptHangs: true })
+    const text = await explainCommand(client, { request, model, directory: "/tmp", timeoutMs: 50 })
+    expect(text).toContain("the judge could not explain it (timed out)")
   })
 
   test("includes verdictReason in the rendered request when provided", async () => {

--- a/test/tui-actions.test.ts
+++ b/test/tui-actions.test.ts
@@ -136,6 +136,8 @@ describe("dashboard action registry", () => {
     expect(footer({ permissionPending: true })).toEqual([
       "permission-choose",
       "permission-confirm",
+      "permission-inspect",
+      "permission-explain",
       "permission-once",
       "permission-always",
       "permission-reject",
@@ -150,6 +152,8 @@ describe("dashboard action registry", () => {
     expect(footer({ permissionPending: true, humanReviewGate: "review" })).toEqual([
       "permission-choose",
       "permission-confirm",
+      "permission-inspect",
+      "permission-explain",
       "permission-once",
       "permission-always",
       "permission-reject",

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -45,6 +45,11 @@ type DashboardInternals = {
   finishModal?: { kind: string; stage?: string; note?: string }
   handleFinishKey(key: { name: string; preventDefault(): void; stopPropagation(): void }): void
   openFinishModal(): Promise<void>
+  serverUrl: string
+  targetDir: string
+  autoAccept?: { mode: string }
+  handlePermissionKey(key: { name: string; preventDefault(): void; stopPropagation(): void }): void
+  addEvent(phase: string, kind: string, message: string): void
 }
 
 async function createDashboard(
@@ -1463,5 +1468,127 @@ describe("pipeline group selection", () => {
     expect(comparisonColumnCount(70, 3)).toBe(2)
     expect(comparisonColumnCount(100, 3)).toBe(3)
     expect(comparisonColumnCount(200, 5)).toBe(3)
+  })
+})
+
+describe("permission modal [e] explain and [i] inspect", () => {
+  const modal = (dashboard: unknown) => (dashboard as DashboardInternals).modalText.plainText
+  const footer = (dashboard: unknown) => (dashboard as DashboardInternals).footerText.plainText
+
+  test("[e] without explain callback shows a no-judge event", async () => {
+    const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
+    try {
+      const internals = dashboard as unknown as DashboardInternals
+      void dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [] })
+      await renderOnce()
+
+      mockInput.pressKey("e")
+      await renderOnce()
+
+      expect(internals.feed.map((e) => e.message)).toContain("no safety judge configured to explain this")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("[e] with explain renders thinking then the wrapped text", async () => {
+    const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
+    try {
+      const internals = dashboard as unknown as DashboardInternals
+      let resolveExplain: (text: string) => void = () => {}
+      const explain = (_signal?: AbortSignal) => new Promise<string>((resolve) => { resolveExplain = resolve })
+      void dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [], explain })
+      await renderOnce()
+
+      // Press [e] → thinking state
+      mockInput.pressKey("e")
+      await renderOnce()
+      expect(modal(dashboard)).toContain("thinking")
+
+      // Resolve the explain promise
+      resolveExplain("This command lists files. It is safe because it is read-only.")
+      // Wait for promise microtask
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      await renderOnce()
+
+      expect(modal(dashboard)).toContain("lists files")
+      expect(modal(dashboard)).toContain("read-only")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("[o] resolves during an explain in flight and aborts it", async () => {
+    const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
+    try {
+      const internals = dashboard as unknown as DashboardInternals
+      let resolveExplain: ((text: string) => void) | undefined
+      const explain = (_signal?: AbortSignal) => new Promise<string>((resolve) => { resolveExplain = resolve })
+      const promise = dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [], explain })
+      await renderOnce()
+
+      // Press [e] → thinking
+      mockInput.pressKey("e")
+      await renderOnce()
+      expect(modal(dashboard)).toContain("thinking")
+
+      // Press [o] to resolve the permission
+      mockInput.pressKey("o")
+      const reply = await promise
+      expect(reply).toBe("once")
+      // The explain promise is still pending — the resolve function won't be called
+      // because the queue was shifted. This is fine; the cancelled promise is gc'd.
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("[i] without serverUrl reports the error inside the modal", async () => {
+    const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
+    try {
+      const internals = dashboard as unknown as DashboardInternals
+      void dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [], sessionID: "sess-1" })
+      await renderOnce()
+
+      // serverUrl defaults to "" (empty), so [i] should report no live server
+      mockInput.pressKey("i")
+      await renderOnce()
+
+      expect(modal(dashboard)).toContain("no live opencode server")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("[i] without sessionID reports the error inside the modal", async () => {
+    const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
+    try {
+      const internals = dashboard as unknown as DashboardInternals
+      void dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [] })
+      await renderOnce()
+
+      // No sessionID on the info
+      mockInput.pressKey("i")
+      await renderOnce()
+
+      expect(modal(dashboard)).toContain("no session to inspect")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("a wide footer contains [e] and [i] hints", async () => {
+    const { dashboard, renderOnce } = await createDashboard(200, 40)
+    try {
+      void dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [] })
+      await renderOnce()
+
+      const row = footer(dashboard)
+      // Glued style: keys and hint are concatenated (e.g. "inspect" = "i" + "nspect")
+      expect(row).toContain("inspect")
+      expect(row).toContain("explain")
+    } finally {
+      dashboard.stop()
+    }
   })
 })

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -1494,7 +1494,6 @@ describe("permission modal [e] explain and [i] inspect", () => {
   test("[e] with explain renders thinking then the wrapped text", async () => {
     const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
     try {
-      const internals = dashboard as unknown as DashboardInternals
       let resolveExplain: (text: string) => void = () => {}
       const explain = (_signal?: AbortSignal) => new Promise<string>((resolve) => { resolveExplain = resolve })
       void dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [], explain })
@@ -1521,7 +1520,6 @@ describe("permission modal [e] explain and [i] inspect", () => {
   test("[o] resolves during an explain in flight and aborts it", async () => {
     const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
     try {
-      const internals = dashboard as unknown as DashboardInternals
       let resolveExplain: ((text: string) => void) | undefined
       const explain = (_signal?: AbortSignal) => new Promise<string>((resolve) => { resolveExplain = resolve })
       const promise = dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [], explain })
@@ -1546,7 +1544,6 @@ describe("permission modal [e] explain and [i] inspect", () => {
   test("[i] without serverUrl reports the error inside the modal", async () => {
     const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
     try {
-      const internals = dashboard as unknown as DashboardInternals
       void dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [], sessionID: "sess-1" })
       await renderOnce()
 
@@ -1563,7 +1560,6 @@ describe("permission modal [e] explain and [i] inspect", () => {
   test("[i] without sessionID reports the error inside the modal", async () => {
     const { dashboard, mockInput, renderOnce } = await createDashboard(200, 40)
     try {
-      const internals = dashboard as unknown as DashboardInternals
       void dashboard.askPermission({ id: "p1", permission: "bash", command: "ls", patterns: [] })
       await renderOnce()
 


### PR DESCRIPTION
- extract runJudgeSession helper for reusable judge session management
- add explainCommand with dedicated system prompt and 45s timeout
- add [i] inspect action to open requesting opencode session in new window
- add [e] explain action to request prose explanation from safety judge
- support explain in both TUI and readline fallback modes
- extend permission modal with new keyboard shortcuts and action handlers