### PR TITLE
refactor(pipelines): consolidate the built-ins around the real workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ Convoy takes a PRD and turns it into a structured, reviewable implementation: a 
 
 Typical uses:
 
-- **Ship a feature from a PRD.** `convoy --prompt-file prd.md` runs the default `implement` pipeline; what lands has already been pattern-aligned, security-audited, design-polished, tested, and adversarially reviewed — one commit per phase, so you review a story, not a blob.
-- **Harden a branch you already have** — hand-written, or another agent's output. `convoy -p refine "what this branch does"` audits the current diff (scope, bugs, clean code, security), triages the findings adversarially, applies only the accepted fixes, and validates them.
-- **Get a second opinion before merging.** `convoy -p review "pre-merge check"` changes no code: each audit runs in parallel on two different models and everything is synthesized into one prioritized findings report at `reports/report.md`.
-- **Turn up the rigor for risky changes.** `ultra-implement` and `ultra-refine` fan every review out across two models, then finish with a fixer that applies only blocking findings and a final validator.
-- **Encode your team's actual workflow.** Pipelines are YAML in `.convoy/config.yaml`: define, say, a `ship` pipeline — refine the branch, sync it with its base, draft the PR — and run `convoy -p ship`.
+- **Build a feature from a PRD.** `convoy --prompt-file prd.md` runs the default `implement` pipeline; the implementation phase writes with an advisor model at its shoulder, and what lands has already been pattern-aligned, security-audited, design-polished, tested, and adversarially reviewed — one commit per phase, so you review a story, not a blob.
+- **Close a branch out.** `convoy -p ship "what this branch does"` merges the advanced base in and resolves the conflicts, grades the merged result against the quality rubric, and keeps fixing and re-scoring until it clears 85/100 — so the pull request you open has a number behind it, not a vibe.
+- **Get a second opinion before merging.** `convoy -p review "pre-merge check"` changes no code: each audit runs in parallel on two different models, everything is synthesized into one prioritized findings report at `reports/report.md`, and the run ends with a verified score.
+- **Turn a findings list into fixes.** `convoy -p fixer` takes a report and proves each finding with a focused regression test *before* touching production code, then reports a per-finding verdict.
+- **Encode your team's actual workflow.** Pipelines are YAML in `.convoy/config.yaml`: define your own steps, agents, and models, with named human gates anywhere, and run `convoy -p <name>`.
 
 Use it as a **CLI** or as a **TUI**, interchangeably: every run can be launched with plain flags and prompt files (`--no-tui` gives you plain logs for pipes and CI), or driven entirely from the TUI — `convoy` with no arguments opens the interactive launcher, every run gets a live dashboard, `convoy runs` browses past runs, and `convoy config` edits global and project config in place.
 
-**Pipelines are data, not code.** Convoy ships a family of built-in pipelines (`implement` — the default — plus `implement-lite`, `implement-advised`, `implement-scored`, `ultra-implement`, `refine`, `ultra-refine`, `ship`, `fixer`, `goal-fix`, and the report-only `review`, `review-lite`, `review-scored`, `review-cc`, `hunter`, and `hunter-max`; see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with named human gates anywhere — in `.convoy/config.yaml`.
+**Pipelines are data, not code.** Convoy ships ten built-in pipelines (`implement` — the default — plus `implement-lite`, `ship`, `fixer`, `goal-fix`, and the report-only `review`, `review-lite`, `review-cc`, `hunter`, and `hunter-max`; see [Built-in pipelines](#built-in-pipelines)), and a project can define its own — any number of steps, its own agents, its own models, with named human gates anywhere — in `.convoy/config.yaml`.
 
 Beyond sequencing agents, Convoy owns the operational layer around OpenCode: repo context attachment, runtime guard rails, a live permission gate, commit safety, phase reports, diff tracking, and a TUI that shows cost, tokens, and provider limits while the run is live.
 
@@ -40,6 +40,9 @@ Convoy is written in Bun + TypeScript and uses `@opencode-ai/sdk` to control Ope
 `implement` is the pipeline convoy runs when you don't pass `-p/--pipeline`.
 
 ```
+                    ┌── advisor: gpt-5.6-sol#xhigh
+                    │   (consulted at decision points)
+                    ▼
 PRD ──► implementer ──► patterns ──► security ──► design ──► tests ──► adversarial
          │               │            │            │          │         │
          └───────────────┴────────────┴────────────┴──────────┴─────────┘
@@ -48,43 +51,53 @@ PRD ──► implementer ──► patterns ──► security ──► design
 
 | Step | Agent | Model | What it does |
 |---|---|---|---|
-| `implementer` | `implementer` | `openai/gpt-5.6-sol#xhigh` | Implements the feature respecting repo patterns |
+| `implementer` | `implementer` | `openai/gpt-5.6-terra#xhigh` **← advised by** `openai/gpt-5.6-sol#xhigh` | Implements the feature respecting repo patterns, consulting the advisor at its decision points |
 | `patterns` | `pattern-auditor` | `openrouter/z-ai/glm-5.2#xhigh` | Refactors without changing behavior, aligns with the rest of the code |
 | `security` | `security-auditor` | `openrouter/z-ai/glm-5.2#xhigh` | Audits and fixes security issues |
 | `design` | `design-polisher` | `openrouter/moonshotai/kimi-k3#high` | Polishes UI following the repo's design system, and strips generic "AI slop" styling |
 | `tests` | `test-engineer` | `openrouter/z-ai/glm-5.2#xhigh` | Automated tests + relevant E2E/integration coverage |
-| `adversarial` | `adversarial-reviewer` | `openrouter/moonshotai/kimi-k3#high` | Final adversarial review before PR creation |
+| `adversarial` | `adversarial-reviewer` | `openrouter/moonshotai/kimi-k3#high` | Final adversarial review |
+
+Only the implementation phase is advised — Terra xhigh writes while Sol xhigh reviews its decisions, pairing the two GPT 5.6 variants that disagree most usefully. Every other phase runs unadvised (`advisor: false`, set explicitly so a project's `defaults.advisor` can't quietly re-advise them), so the second opinion is spent where a wrong call is most expensive to undo. See [Advisor steps](#project-configuration-convoyconfigyaml).
+
+`implement` deliberately does **not** score its output. Its job is a first draft worth shaping by hand; grading a draft you already intend to rework buys nothing. Measurement lives in [`ship`](#quality-scoring), at the end of the cycle.
 
 ## Built-in pipelines
 
 Convoy ships these pipelines; select one with `-p/--pipeline` (no config needed). A project can add or override any of them in `.convoy/config.yaml`.
 
+They are built around one cycle. Two of its four steps are Convoy's:
+
+```
+   plan            build              shape            close
+(your editor) ──► convoy ──► (your editor, by hand) ──► convoy -p ship ──► PR
+                 implement                              sync · score · loop
+```
+
+You write the plan, `implement` turns it into something functional, you shape it by hand until you like it, and `ship` proves it merges and clears the quality bar before the pull request exists. Everything else in the table serves that cycle from the side: `review` and the `hunter`s tell you where you stand without changing anything, and `fixer` turns a findings list into proven fixes.
+
 | Pipeline | Changes code? | What it does |
 |---|---|---|
-| `implement` | yes | **The default** (runs with no `-p`). Implement a PRD, then audit, polish, test, and adversarial review (the table above). |
-| `implement-lite` | yes | Same workflow and agents as `implement`, and the same GLM 5.2 audits — but at base reasoning instead of xhigh, with `implementer` dropping to GLM 5.2 too and `adversarial` to Opus. The cheaper run: what it gives up is Sol writing the code and Kimi judging it. |
-| `implement-scored` | yes | `implement`, then **measures** the result: two independent quality-scorers grade the final diff against the quality rubric (fresh agents, no shared context with the builder) and a consensus step reconciles their scores and verifies the claims by running the checks itself. The run's deliverable lands in `reports/score-report.md` with a machine-readable score block. See [Quality scoring](#quality-scoring). |
-| `implement-advised` | yes | `implement` with exactly one thing changed: the `implementer` phase runs on GPT 5.6 Terra xhigh and **consults GPT 5.6 Sol xhigh as an advisor** at its decision points. Every other phase is `implement`'s, model for model and unadvised, so the advised implementation step is the single variable between the two. |
-| `ultra-implement` | yes | Like `implement`, but the pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, and the run ends with an audit-only final review, a fixer that applies only blocking findings, and a final validator. |
-| `refine` | yes | Audit the current diff (scope → bugs → clean-code → security), triage the findings adversarially, apply the accepted fixes, then validate them. |
-| `ultra-refine` | yes | Like `refine`, but every read-only audit is fanned out across two models before triage, fixes, and validation. |
-| `ship` | yes | `refine`, but preceded by a `sync` phase that merges the advanced base branch in and resolves the conflicts — real and semantic — so the audits read the branch as it will actually merge rather than a diff that no longer describes what lands. Two things it expects from your config, because both are machine-local: `permissions.allow` entries for `git merge*`, `git add*` and `git checkout --ours*`/`--theirs*` (without them those commands fall through to "ask" rather than failing), and, optionally, `hooks.pipelines.ship` to fetch the base beforehand and open the PR afterwards — Convoy never runs remote git itself. |
-| `review` | **no — report only** | Scope the diff, run the bug / clean-code(+patterns) / security audits **in parallel across two models each**, then a single step synthesizes everything into one prioritized findings report. Makes no changes; the run's output is `reports/report.md`, which you read to decide whether to follow up with a `refine` run. |
-| `review-lite` | **no — report only** | Same shape as `review`, but nothing runs on Opus: `openrouter/z-ai/glm-5.2` scopes the diff and writes the final report, and each parallel audit fans out across `openrouter/z-ai/glm-5.2` + `openrouter/moonshotai/kimi-k3`. The cheap way to get a full review report. |
+| `implement` | yes | **The default** (runs with no `-p`). Implement a PRD with an **advised** implementation phase — Terra xhigh writes and consults Sol xhigh at its decision points — then audit, polish, test, and adversarial review (the table above). Does not score: that is `ship`'s job. |
+| `implement-lite` | yes | `implement`'s shape on low-cost models: every code-writing phase drops to GLM 5.2, Kimi K3 advises the implementer and polishes design, and `adversarial` runs on Opus. The advisor is the last thing to go, because it is what makes a cheap implementer worth running. |
+| `ship` | yes | **The close of the cycle.** A `sync` phase merges the advanced base branch in and resolves the conflicts — real and semantic — so what gets graded is the branch as it will actually merge. Then two independent quality-scorers grade it against the rubric and a consensus step reconciles and verifies. `ship` declares `goal: 85` in its own spec, so the fix/re-score loop runs **without you passing `--goal`**: it keeps closing gaps until the score clears 85, plateaus, or hits the iteration cap. See [Quality scoring](#quality-scoring) and [Goal mode](#goal-mode). Two things it expects from your config, because both are machine-local: `permissions.allow` entries for `git merge*`, `git add*` and `git checkout --ours*`/`--theirs*` (without them those commands fall through to "ask" rather than failing), and, optionally, `hooks.pipelines.ship` to fetch the base beforehand and open the PR afterwards — Convoy never runs remote git itself. Post-hooks receive `CONVOY_GOAL_REACHED`, so the PR step can require the bar was actually met. |
 | `fixer` | yes | The follow-up to a report-only run. Give it a set of findings (as the prompt or an attachment) and it proves each one with a focused regression test **before** touching production code, applies minimal fixes only for the findings that actually went red, then independently reruns those proofs and the surrounding checks to report a final per-finding verdict (`fixed`, `already-resolved`, `not-reproducible`, `not-automatable`, `blocked`, `not-fixed`). The validation phase runs the commands itself (see [verifying agents](#project-configuration-convoyconfigyaml)) rather than taking the fix phase's word for it, and never promotes an unproven finding to fixed. |
-| `goal-fix` | yes | The goal loop's fix iteration: applies exactly the gaps the previous scoring round reported, then re-scores. Not run directly — `--goal` drives it. See [Goal mode](#goal-mode). |
-| `review-cc` | **no — report only** | Same shape as `review`, but each audit is paired with a second run on the locally installed [`claude` CLI](https://code.claude.com) (`runner: claude-code`) instead of a second API model — cross-vendor diversity billed to a Claude subscription rather than per token. Requires `claude` on `PATH`. |
-| `review-scored` | **no — report only** | `review`, then **measures** the result: the same parallel audits, followed by two independent quality-scorers and a consensus step that reconciles and verifies the score. The deliverables are the findings report and the machine-readable score in `reports/score-report.md`. Makes no changes. |
+| `goal-fix` | yes | The goal loop's fix iteration: applies exactly the gaps the previous scoring round reported, then re-scores. Not run directly — `ship`'s goal, or an explicit `--goal`, drives it. See [Goal mode](#goal-mode). |
+| `review` | **no — report only** | Scope the diff, run the bug / clean-code(+patterns) / security audits **in parallel across two models each**, synthesize one prioritized findings report, then **measure**: two independent quality-scorers grade the same diff against the rubric and a consensus step reconciles and verifies. The deliverables are `reports/report.md` and the machine-readable score in `reports/score-report.md`. Makes no changes. |
+| `review-lite` | **no — report only** | Same shape as `review`, but nothing runs on Opus: `openrouter/z-ai/glm-5.2` scopes the diff, writes the report and reconciles the score, and the audit and scorer fan-outs pair GLM 5.2 with `openrouter/moonshotai/kimi-k3`. The cheap way to get a full review and a number. |
+| `review-cc` | **no — report only** | `review`'s audits, but each is paired with a second run on the locally installed [`claude` CLI](https://code.claude.com) (`runner: claude-code`) instead of a second API model — cross-vendor diversity billed to a Claude subscription rather than per token. Ends at the findings report rather than a score: its point is a second opinion from a different vendor, not a measurement. Requires `claude` on `PATH`. |
 | `hunter` | **no — report only** | Repo-wide audit across six specialty tracks (correctness, memory, performance, security, reliability, supply chain), each run on GPT 5.6 Terra xhigh plus one specialty model, then reconciled into a single deduplicated, prioritized consensus report. |
 | `hunter-max` | **no — report only** | Like `hunter`, but every track fans out across all five models (30 concurrent audits). Highest recall, slowest and most expensive — reach for it on code you can't afford to get wrong. |
 
-`refine`/`ultra-refine` are the change-applying counterparts of `review`: run `review` first to get a report, then `refine` if you want the fixes applied. `ship` is `refine` for a branch whose base has moved on — it syncs first, so the audit is of the merged result. `fixer` is the stricter alternative to `refine` when you already have a specific list of findings and want each one individually proven, fixed, and accounted for rather than triaged in bulk.
+`review` is what you run when you want to know where a branch stands without touching it; `ship` is what you run when you have decided the branch is done and want it to clear a bar. `fixer` is the bridge between a report and the fixes: it takes a specific list of findings and proves, applies and accounts for each one individually.
 
 `review*` pipelines default to the current branch/PR diff; `hunter*` default to the whole repository unless the prompt scopes them to a branch, PR, or area.
 
 ## Quality scoring
 
-`implement-scored` and `review-scored` end the run with a **measurement**, not just a findings list. The problem with open-ended review is that it is open-ended: an agent asked to "find problems" will always find one more, and its severities are ranked against whatever it happened to find — so a cosmetic nit can come back labeled `critical`. Scoring inverts that: the agent grades against a **fixed, closed contract** — the rubric — and every number must carry evidence a maintainer can check.
+`ship`, `review` and `review-lite` end the run with a **measurement**, not just a findings list. The problem with open-ended review is that it is open-ended: an agent asked to "find problems" will always find one more, and its severities are ranked against whatever it happened to find — so a cosmetic nit can come back labeled `critical`. Scoring inverts that: the agent grades against a **fixed, closed contract** — the rubric — and every number must carry evidence a maintainer can check.
+
+This is why `ship` has no separate audit phases. The scorer already grades bugs, security, maintainability and scope against the rubric; an open-ended audit in front of it only produces findings the score then has to re-weigh.
 
 ### The rubric
 
@@ -123,24 +136,26 @@ The final score lands in `reports/score-report.md` with a machine-readable block
 ```
 ````
 
-Verdicts map to the score: `ready` (≥90) · `ready-with-caveats` (75–89) · `not-ready` (60–74) · `failing` (<60). This block is the interface a goal loop will act on; today it is the interface you read to decide whether to merge or to follow up with a `fixer`/`refine` run.
+Verdicts map to the score: `ready` (≥90) · `ready-with-caveats` (75–89) · `not-ready` (60–74) · `failing` (<60). This block is the interface the goal loop acts on, and the one you read after a `review` to decide whether to merge or to follow up with a `fixer` run.
 
-**Calibrate before you trust it.** The first few scored runs will grade "differently" from your judgment. Run `review-scored` against 2–3 PRs you already know are good or bad, compare your expectation to the score, and adjust `.convoy/quality-rubric.md` (weights, anchors, deductions) until the score matches your call. The rubric is a contract; like any contract, it is only useful once you agree with it.
+**Calibrate before you trust it.** The first few scored runs will grade "differently" from your judgment. Run `review` against 2–3 PRs you already know are good or bad, compare your expectation to the score, and adjust `.convoy/quality-rubric.md` (weights, anchors, deductions) until the score matches your call. The rubric is a contract; like any contract, it is only useful once you agree with it — and since `ship` gates your pull requests on it, calibrate it before you rely on that gate.
 
 ## Goal mode
 
-Goal mode answers the "when is it enough?" question mechanically: **don't stop until the implementation scores at or above a target**, or until the score stops improving.
+Goal mode answers the "when is it enough?" question mechanically: **don't stop until the branch scores at or above a target**, or until the score stops improving.
+
+`ship` declares `goal: 85` in its own spec, so this is simply what `ship` does — no flag required:
 
 ```bash
-convoy -p implement-scored --prompt-file prd.md --goal 90
+convoy -p ship "what this branch does"          # loops to 85
+convoy -p ship "..." --goal 92                  # the flag overrides the pipeline's target
 ```
 
 Each iteration is a full run in the same worktree, so the diff accumulates:
 
 ```
-Iteration 0:  implement → audits → tests → adversarial → SCORERS → consensus   score 71
-Iteration 1:  goal-fix (exactly the reported gaps) → SCORERS → consensus        score 86
-Iteration 2:  goal-fix (the remaining gap) → SCORERS → consensus                score 92  ✅
+Iteration 0:  sync → SCORERS → consensus                                 score 71
+Iteration 1:  goal-fix (exactly the reported gaps) → SCORERS → consensus  score 86  ✅
 ```
 
 - The **goal-fixer** receives only the previous scoring round's work order — the score, the per-dimension gaps, and the must-fix findings — as a per-step phase brief. Its job is to close exactly those gaps and nothing else: no new scope, no speculative improvements, no restructuring.
@@ -151,9 +166,25 @@ Iteration 2:  goal-fix (the remaining gap) → SCORERS → consensus            
   3. **Iteration cap** — `--goal-max-iterations` (default 3) is exhausted.
   4. A run fails or produces no parseable score.
 
-Flags: `--goal <1-100>`, `--goal-max-iterations <n>`, `--goal-plateau <n>`. The same values can live on a pipeline in `.convoy/config.yaml` (`goal:`, `goalMaxIterations:`, `goalPlateau:`) and the CLI flags override them. Goal mode requires a pipeline that both ends in a `quality-score-report` step and has at least one writable step — `implement-scored` qualifies; `implement` alone (no score) and `review-scored` (report-only, no writable step) will each refuse `--goal` with a clear error, because the goal-fixer edits the repository.
+Flags: `--goal <1-100>`, `--goal-max-iterations <n>`, `--goal-plateau <n>`. The same values can live on a pipeline in `.convoy/config.yaml` (`goal:`, `goalMaxIterations:`, `goalPlateau:`) — which is exactly how the built-in `ship` sets its target — and the CLI flags override them. Goal mode requires a pipeline that both ends in a `quality-score-report` step and has at least one writable step: `ship` qualifies; `implement` (no score) and `review`/`review-lite` (report-only, no writable step) will each refuse `--goal` with a clear error, because the goal-fixer edits the repository.
 
 Goal mode is a bounded loop, not an open cheque: the plateau and the iteration cap exist precisely so the loop cannot chase a score forever. If it stops below the goal, the branch is left at the best measured state and the final score report tells you what is still missing.
+
+**The loop finishing is not the same as the goal being met.** A run that plateaus or exhausts its iterations below the target still ends successfully — it did what it was asked, it just could not get there. Post-hooks are therefore run **once, after the whole loop**, and receive `CONVOY_GOAL_REACHED` (`true`/`false`), `CONVOY_GOAL_SCORE` and `CONVOY_GOAL_TARGET`, so a hook that opens a pull request can require the bar was actually cleared:
+
+```yaml
+hooks:
+  pipelines:
+    ship:
+      post:
+        - name: open PR
+          command: |
+            if [ "$CONVOY_GOAL_REACHED" = "true" ]; then
+              git push -u origin HEAD && gh pr create --fill
+            else
+              echo "scored $CONVOY_GOAL_SCORE, needed $CONVOY_GOAL_TARGET — no PR opened"
+            fi
+```
 
 In the TUI, the final run's finish screen shows the score it just produced and, from the second iteration on, the trajectory so far (`71 → 84 → 92`); when the loop ends the terminal prints the full trajectory and why it stopped. (When the loop stops early — goal met or plateau before the iteration cap — the finish screen is skipped and the trajectory is logged instead, so the loop stays unattended between iterations.)
 
@@ -544,7 +575,7 @@ The rules:
 - **Resume is frozen**: the resolved pipeline is persisted in the run's `metadata.json`; `--resume` replays it even if the config changed since.
 - **Dirty-tree recovery**: a writable phase interrupted before its commit (Ctrl+C, a failed commit step, a killed process) leaves uncommitted work in the tree, which normally blocks `--resume`. In an interactive terminal, resume offers to commit that work as the interrupted phase (`convoy(<phase>): …`), mark it done, and continue with the following phases. Read-only phases are never recoverable as agent output: preserved changes must be resolved manually, and resume also verifies their recorded HEAD/branch baseline. Decline (or a non-TTY resume) keeps the old "commit/stash first" behavior.
 - **Permissions are additive**: `permissions.deny` extends the hard denylist, `permissions.allow` extends the allowlist, deny always wins, and there is deliberately no way for a repo to grant itself `--yolo`.
-- **Hooks are trusted local shell commands**: `hooks.pre` runs after the run workspace/dashboard is initialized and before the pipeline starts (pre-hooks are skipped on `--resume`); `hooks.post` runs at the end according to `when`. Top-level hooks apply to every pipeline, and `hooks.pipelines.<name>` entries are appended for that pipeline. Hooks run via `$SHELL -lc` from the target repo by default, receive `CONVOY_RUN_ID`, `CONVOY_RUN_DIR`, `CONVOY_TARGET_DIR`, `CONVOY_PIPELINE`, `CONVOY_PROMPT_FILE`, and post-hooks also receive `CONVOY_RUN_STATUS`. A failing hook fails the run unless `continueOnError: true` is set. Each hook is also a row in the dashboard pipeline — pre-hooks ahead of the steps, post-hooks after — with live running/✓/✗/skipped status, and the tail of its output lands in that row's `logs` tab; the rows are recorded in the run metadata, so re-opened runs show them too.
+- **Hooks are trusted local shell commands**: `hooks.pre` runs after the run workspace/dashboard is initialized and before the pipeline starts (pre-hooks are skipped on `--resume`); `hooks.post` runs at the end according to `when`. Top-level hooks apply to every pipeline, and `hooks.pipelines.<name>` entries are appended for that pipeline. Hooks run via `$SHELL -lc` from the target repo by default, receive `CONVOY_RUN_ID`, `CONVOY_RUN_DIR`, `CONVOY_TARGET_DIR`, `CONVOY_PIPELINE`, `CONVOY_PROMPT_FILE`, and post-hooks also receive `CONVOY_RUN_STATUS`, plus `CONVOY_RUN_SCORE` on a scored pipeline and `CONVOY_GOAL_REACHED`/`CONVOY_GOAL_SCORE`/`CONVOY_GOAL_TARGET` when a [goal loop](#goal-mode) ran (in which case post-hooks run once, after the loop, not once per iteration). A failing hook fails the run unless `continueOnError: true` is set. Each hook is also a row in the dashboard pipeline — pre-hooks ahead of the steps, post-hooks after — with live running/✓/✗/skipped status, and the tail of its output lands in that row's `logs` tab; the rows are recorded in the run metadata, so re-opened runs show them too.
 
 ## Global configuration
 

--- a/prompts/bug-auditor.md
+++ b/prompts/bug-auditor.md
@@ -1,6 +1,6 @@
 # Bug Auditor
 
-You are the **bug-auditor** agent of Convoy's `review` and `refine` pipelines. This is an audit-only phase: do not modify the repository.
+You are the **bug-auditor** agent of Convoy's review pipelines. This is an audit-only phase: do not modify the repository.
 
 ## Review scope
 

--- a/prompts/clean-code-auditor.md
+++ b/prompts/clean-code-auditor.md
@@ -1,6 +1,6 @@
 # Clean Code Auditor
 
-You are the **clean-code-auditor** agent of Convoy's `review` and `refine` pipelines. This is an audit-only phase: do not modify the repository. You cover both repo-pattern alignment and general maintainability.
+You are the **clean-code-auditor** agent of Convoy's review pipelines. This is an audit-only phase: do not modify the repository. You cover both repo-pattern alignment and general maintainability.
 
 ## Review scope
 

--- a/prompts/review-adversary.md
+++ b/prompts/review-adversary.md
@@ -1,6 +1,6 @@
 # Review Adversary
 
-You are the **review-adversary** agent of Convoy's `refine` pipeline. This is an audit-only phase: do not modify the repository.
+You are the **review-adversary** agent of Convoy's audit-then-apply pipelines. This is an audit-only phase: do not modify the repository.
 
 ## Review scope
 

--- a/prompts/review-fixer.md
+++ b/prompts/review-fixer.md
@@ -1,6 +1,6 @@
 # Review Fixer
 
-You are the **review-fixer** agent of Convoy's `refine` pipeline. This is the only phase in this pipeline that may modify the target repository.
+You are the **review-fixer** agent of Convoy's audit-then-apply pipelines. This is the only phase in such a pipeline that may modify the target repository.
 
 ## Objective
 

--- a/prompts/review-report.md
+++ b/prompts/review-report.md
@@ -1,6 +1,6 @@
 # Review Report
 
-You are the **review-report** agent of Convoy's `review` pipeline. This is an audit-only phase: **do not modify the repository**. Your report is the entire deliverable of this run — the human reads it to decide whether to launch a separate fix run (`refine`) afterwards.
+You are the **review-report** agent of Convoy's `review` pipeline. This is an audit-only phase: **do not modify the repository**. Your report is the entire deliverable of this run — the human reads it to decide whether to launch a separate fix run (`fixer`, which takes your findings as its input) afterwards.
 
 ## Review scope
 

--- a/prompts/review-scope.md
+++ b/prompts/review-scope.md
@@ -1,6 +1,6 @@
 # Review Scope
 
-You are the **review-scope** agent of Convoy's `review` and `refine` pipelines. This is an audit-only phase: do not modify the repository.
+You are the **review-scope** agent of Convoy's review pipelines. This is an audit-only phase: do not modify the repository.
 
 ## Review scope
 

--- a/prompts/review-validator.md
+++ b/prompts/review-validator.md
@@ -1,6 +1,6 @@
 # Review Validator
 
-You are the **review-validator** agent of Convoy's `refine` pipeline. You can run commands to check the work, but cannot modify the repository.
+You are the **review-validator** agent of Convoy's audit-then-apply pipelines. You can run commands to check the work, but cannot modify the repository.
 
 ## Objective
 

--- a/prompts/security-reviewer.md
+++ b/prompts/security-reviewer.md
@@ -1,6 +1,6 @@
 # Security Reviewer
 
-You are the **security-reviewer** agent of Convoy's `review` and `refine` pipelines. This is an audit-only phase: do not modify the repository.
+You are the **security-reviewer** agent of Convoy's review pipelines. This is an audit-only phase: do not modify the repository.
 
 ## Review scope
 

--- a/prompts/sync-with-base.md
+++ b/prompts/sync-with-base.md
@@ -1,6 +1,6 @@
 # Sync With Base
 
-You are the **sync-with-base** agent, the first phase of Convoy's `ship` pipeline. You run **before** any audit. Your job is to bring the branch up to date with its base branch and resolve every conflict, so the later phases review the branch as it will actually merge.
+You are the **sync-with-base** agent, the first phase of Convoy's `ship` pipeline. You run **before** the branch is measured. Your job is to bring the branch up to date with its base branch and resolve every conflict, so the quality scorers that follow grade the branch as it will actually merge — and so the score that gates the pull request describes the merged result, not a diff that no longer applies.
 
 This is a phase that **may modify the target repository**.
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -163,7 +163,7 @@ export async function parseAndRun(argv: string[]) {
   // running it directly gives the goal-fixer no work order (no brief, no
   // previous score). Refuse it here so the contract is enforced, not just documented.
   if (plan.pipeline.name === "goal-fix") {
-    throw new Error("goal-fix is the goal loop's internal fix pipeline and is not run directly; use --goal with a scored pipeline (e.g. convoy -p implement-scored --goal 90) instead.")
+    throw new Error("goal-fix is the goal loop's internal fix pipeline and is not run directly; run a scored pipeline that drives it instead (convoy -p ship, or --goal with another scored pipeline).")
   }
   // Refuse an ineligible --goal before the plan is reviewed, preflighted, or a
   // worktree is created — the operator must not consent to a plan that cannot
@@ -227,12 +227,12 @@ export function goalModeFor(options: { goal?: number; goalFixPipeline?: Pipeline
 export function goalModeRejectionError(decision: GoalModeDecision & { mode: "rejected" }, plan: RunPlan): Error {
   if (decision.reason === "no-consensus") {
     return new Error(
-      `--goal ${decision.goal} requires a scored pipeline: the pipeline must end in a quality-score-report step (implement-scored or a custom scored pipeline).`,
+      `--goal ${decision.goal} requires a scored pipeline: the pipeline must end in a quality-score-report step (ship, review, review-lite, or a custom scored pipeline).`,
     )
   }
   if (decision.reason === "not-writable") {
     return new Error(
-      `--goal ${decision.goal} requires a pipeline that can edit the repository: "${plan.pipeline.name}" is report-only (every step is read-only), but goal mode runs the writable goal-fixer. Use a scored pipeline with a writing step (e.g. implement-scored), or drop --goal to review without fixing.`,
+      `--goal ${decision.goal} requires a pipeline that can edit the repository: "${plan.pipeline.name}" is report-only (every step is read-only), but goal mode runs the writable goal-fixer. Use a scored pipeline with a writing step (e.g. ship), or drop --goal to review without fixing.`,
     )
   }
   if (decision.reason === "bad-fix-pipeline") {
@@ -1017,8 +1017,10 @@ Flags:
                            (default: worktree on a trunk branch, current tree on any other)
   --branch <name>          Name for the worktree branch, instead of asking the naming model
   --goal <1-100>           Goal mode: keep fixing until the quality score reaches this value.
-                           Requires a writable scored pipeline (implement-scored, or any
-                           pipeline ending in a quality-score-report step with a writing step).
+                           Requires a writable scored pipeline (any pipeline ending in a
+                           quality-score-report step with a writing step). The ship pipeline
+                           declares its own goal of 85, so it loops without this flag; pass
+                           --goal to override that target.
                            Each fix iteration applies exactly the gaps the previous scoring
                            round reported and re-scores; the loop stops at the goal, at a
                            plateau, or at the iteration cap. See the Quality scoring section.

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ import {
   defaultGptModel,
   defaultGptVariant,
   defaultAdversarialModel,
+  defaultImplementAdvisorModel,
   defaultImplementAuditModel,
   defaultImplementerModel,
   defaultImplementReviewModel,
@@ -279,42 +280,47 @@ defaults:
 #     model: openai/gpt-5.6-terra#xhigh
 
 # Convoy ships these pipelines built in; pick one with -p/--pipeline without redeclaring it here:
-#   implement            the default: build the feature, then audit, polish, test, and adversarial review
-#   implement-lite       like implement, but swaps GPT 5.6 Terra xhigh phases for GLM 5.2
-#   implement-scored     like implement, then measures the result: two independent scorers + a verified consensus score
-#   implement-advised    like implement, but the implementer consults GPT 5.6 Sol as an advisor
-#   ultra-implement      like implement, with dual-model parallel audits and a final review/fix/validate stage
-#   goal-fix             the goal loop's fix iteration (not run directly; --goal drives it)
-#   refine               audit the current diff, then apply the triaged fixes (changes code)
-#   ultra-refine         like refine, with every audit fanned out across two models
-#   ship                 merge the advanced base in (resolving conflicts), then refine the merged branch
+#   implement            the default: advised implementation, then audit, polish, test, and adversarial review
+#   implement-lite       like implement, but drops the code-writing phases to GLM 5.2 (Kimi K3 advises)
+#   ship                 the close: merge the advanced base in (resolving conflicts), score the merged
+#                        result against the rubric, and loop until it clears 85/100
 #                        wants permissions.allow: git merge*, git add*, git checkout --ours*|--theirs*
 #                        and, optionally, hooks.pipelines.ship to fetch the base first / open the PR after
-#   review               report-only: parallel audits across two models plus one prioritized report (no changes)
-#   review-lite          like review, but swaps GPT 5.6 Terra xhigh for GLM 5.2 (scope + audit fan-out); report stays on Opus
-#   review-scored        like review, then scores the result against the quality rubric (report-only)
+#                        (post-hooks get CONVOY_GOAL_REACHED, so the PR step can require the bar was met)
+#   goal-fix             the goal loop's fix iteration (not run directly; ship's goal or --goal drives it)
+#   fixer                turn a list of findings into proven regression tests, minimal fixes, and a verdict each
+#   review               report-only: parallel audits across two models, one prioritized report, then a verified score
+#   review-lite          like review, but every phase runs on GLM 5.2 / Kimi K3 instead of Opus
 #   review-cc            like review, but pairs each audit with a Claude Code run (needs the \`claude\` CLI on PATH)
 #   hunter               report-only repo audit: six specialty tracks on two models each, then one consensus report
 #   hunter-max           like hunter, with every track fanned across all five models (30 audits — slow and expensive)
 # The default \`implement\` pipeline is inlined below as an editable starting point; redefining a name here overrides the built-in.
 pipelines:
   implement:
-    description: Implementation, pattern/security audits, design polish, tests, and adversarial review
+    description: Advised implementation, pattern/security audits, design polish, tests, and adversarial review
     steps:
       - agent: implementer
         model: ${defaultImplementerModel}
+        advisor: ${defaultImplementAdvisorModel}
         reports: none
+      # advisor: false rather than an omitted key — omitting it would inherit
+      # defaults.advisor and quietly re-advise phases that don't want it.
       - agent: patterns
         model: ${defaultImplementAuditModel}
+        advisor: false
       - agent: security
         model: ${defaultImplementAuditModel}
+        advisor: false
       - agent: design
         model: ${defaultImplementReviewModel}
+        advisor: false
       - agent: tests
         model: ${defaultImplementAuditModel}
+        advisor: false
         reports: none
       - agent: adversarial
         model: ${defaultAdversarialModel}
+        advisor: false
         reports: all
 
 # Optional shell hooks. Top-level hooks run for every pipeline; hooks under
@@ -959,7 +965,17 @@ export function defaultConfigTemplate(): ConvoyConfig {
  */
 export function materializePipelineSpec(spec: PipelineSpec, effectiveDefaultModel?: string): PipelineSpec {
   const steps = spec.steps.map<StepSpec>((raw) => materializeStep(raw, effectiveDefaultModel))
-  return { ...(spec.description ? { description: spec.description } : {}), steps }
+  // The goal settings travel with the copy: `ship` carries its target in its
+  // spec, so dropping them here would turn "customize this built-in" into
+  // "silently disable its loop".
+  return {
+    ...(spec.description ? { description: spec.description } : {}),
+    ...(spec.maxConcurrentAgents !== undefined ? { maxConcurrentAgents: spec.maxConcurrentAgents } : {}),
+    ...(spec.goal !== undefined ? { goal: spec.goal } : {}),
+    ...(spec.goalMaxIterations !== undefined ? { goalMaxIterations: spec.goalMaxIterations } : {}),
+    ...(spec.goalPlateau !== undefined ? { goalPlateau: spec.goalPlateau } : {}),
+    steps,
+  }
 }
 
 function materializeStep(raw: StepSpec, effectiveDefaultModel: string | undefined): StepSpec {

--- a/src/goal-loop.ts
+++ b/src/goal-loop.ts
@@ -22,8 +22,11 @@
 import { buildRunPlan } from "./run-plan"
 import { log } from "./log"
 import { createCleanRepoSnapshot, currentHead, restoreRepoSnapshot, statusPorcelain, type RepoSnapshot } from "./git"
+import { hooksForPipeline, runHooks, type GoalHookOutcome } from "./hooks"
+import { noopProgress } from "./progress"
 import { isUserAbortError, run, type RunResult } from "./runner"
 import { defaultGoalMaxIterations, defaultGoalPlateau } from "./quality-score"
+import { cleanupWorkspace, type Workspace } from "./workspace"
 import type { RunOptions, RunPlan } from "./types"
 
 export type GoalLoopConfig = {
@@ -49,7 +52,7 @@ export type GoalLoopOutcome = {
   restored: boolean
 }
 
-type GoalLoopDeps = {
+export type GoalLoopDeps = {
   run: typeof run
   /** Captures the repository's clean state; returns undefined when the tree is dirty. */
   captureSnapshot: (cwd: string) => Promise<RepoSnapshot | undefined>
@@ -59,6 +62,10 @@ type GoalLoopDeps = {
   isCleanRepo: (cwd: string) => Promise<boolean>
   /** Returns the current HEAD commit SHA, or undefined when git fails. */
   currentHead: (cwd: string) => Promise<string | undefined>
+  /** Runs a stage's hooks; the loop uses it for the post-hooks its runs deferred. */
+  runHooks: typeof runHooks
+  /** Deletes a run workspace the loop kept alive for the deferred post-hooks. */
+  cleanupWorkspace: (workspace: Workspace) => Promise<void>
 }
 
 /**
@@ -72,6 +79,8 @@ const defaultGoalLoopDeps: GoalLoopDeps = {
   restoreSnapshot: restoreRepoSnapshot,
   isCleanRepo: async (cwd) => (await statusPorcelain(cwd)).trim() === "",
   currentHead,
+  runHooks,
+  cleanupWorkspace,
 }
 
 /** The best measured state: the score and the repo state it was measured on. */
@@ -80,11 +89,96 @@ type BestState = {
   snapshot?: RepoSnapshot
 }
 
+/**
+ * Owns the post-hooks its runs deferred. A loop is one piece of work spread over
+ * several runs, so the pipeline's post-hooks fire once — after the last
+ * iteration, against the *base* pipeline's hook set rather than goal-fix's, and
+ * carrying the loop's outcome. That outcome is the part a hook cannot otherwise
+ * see: a loop that plateaus below the target still ends as a successful run, so
+ * `when: success` alone cannot tell "cleared the bar" from "gave up short of
+ * it". CONVOY_GOAL_REACHED can.
+ *
+ * Nothing fires when a run throws: the runner already ran the failure hooks on
+ * its way out, and it did so without CONVOY_GOAL_*, so a gated hook stays inert.
+ */
 export async function runGoalLoop(
   options: RunOptions,
   plan: RunPlan,
   config: GoalLoopConfig,
   deps: GoalLoopDeps = defaultGoalLoopDeps,
+): Promise<GoalLoopOutcome> {
+  const kept = new KeptWorkspaces()
+  try {
+    const outcome = await runGoalIterations(options, plan, config, deps, kept)
+    await runDeferredPostHooks(options, plan, config, deps, kept.latest, outcome)
+    return outcome
+  } finally {
+    await kept.cleanup(deps.cleanupWorkspace)
+  }
+}
+
+/**
+ * Holds the workspace of the most recent deferred run, deleting each one it
+ * supersedes. Only the last survives the loop, because only the last is the one
+ * the post-hooks resolve CONVOY_RUN_DIR against.
+ */
+class KeptWorkspaces {
+  latest?: Workspace
+  private stale: Workspace[] = []
+
+  adopt(result: RunResult): void {
+    if (this.latest) this.stale.push(this.latest)
+    this.latest = result.workspace
+  }
+
+  async cleanup(remove: (workspace: Workspace) => Promise<void>): Promise<void> {
+    const all = [...this.stale, ...(this.latest ? [this.latest] : [])]
+    this.stale = []
+    this.latest = undefined
+    for (const workspace of all) {
+      await remove(workspace).catch((error) => log.warn(`goal loop: couldn't clean ${workspace.dir}: ${String(error)}`))
+    }
+  }
+}
+
+async function runDeferredPostHooks(
+  options: RunOptions,
+  plan: RunPlan,
+  config: GoalLoopConfig,
+  deps: GoalLoopDeps,
+  workspace: Workspace | undefined,
+  outcome: GoalLoopOutcome,
+): Promise<void> {
+  // No workspace means every run was mocked or none produced one; there is
+  // nothing to resolve CONVOY_RUN_DIR against, so there is nothing to run.
+  if (!workspace) return
+  const hookSet = hooksForPipeline(options.hooks, plan.pipeline.name)
+  if (hookSet.post.length === 0) return
+  const goal: GoalHookOutcome = {
+    reached: outcome.reached,
+    target: config.goal,
+    ...(outcome.bestScore !== undefined ? { score: outcome.bestScore } : {}),
+  }
+  await deps.runHooks("post", hookSet.post, {
+    workspace,
+    targetDir: options.targetDir,
+    pipelineName: plan.pipeline.name,
+    prompt: options.prompt,
+    status: "success",
+    // The dashboard is gone by the time the loop finishes, so these hooks report
+    // through the log rather than as pipeline rows.
+    progress: noopProgress,
+    goal,
+    ...(outcome.bestScore !== undefined ? { score: outcome.bestScore } : {}),
+  })
+}
+
+async function runGoalIterations(
+  options: RunOptions,
+  plan: RunPlan,
+  config: GoalLoopConfig,
+  deps: GoalLoopDeps,
+  kept: KeptWorkspaces,
 ): Promise<GoalLoopOutcome> {
   const { run: runRun, captureSnapshot, restoreSnapshot, isCleanRepo, currentHead } = deps
   const scores: number[] = []
@@ -101,7 +195,8 @@ export async function runGoalLoop(
   // maxIterations is 0 the initial run is the only run, so the finish screen
   // is allowed to show the score and trajectory.
   const initialContinues = config.maxIterations > 0
-  let previous: RunResult = await runRun({ ...options, plan, ...(initialContinues ? { goalContinues: true } : {}) })
+  let previous: RunResult = await runRun({ ...options, plan, deferPostHooks: true, ...(initialContinues ? { goalContinues: true } : {}) })
+  kept.adopt(previous)
   lastHead = await currentHead(options.targetDir)
   let score = previous.qualityScore?.score
   if (score === undefined) {
@@ -129,6 +224,7 @@ export async function runGoalLoop(
     const fixOptions = goalFixOptions(options, previous, scores, continues)
     try {
       previous = await runRun({ ...fixOptions, plan: buildRunPlan(fixOptions) })
+      kept.adopt(previous)
       lastHead = await currentHead(options.targetDir)
     } catch (error) {
       // A user abort (Ctrl+C) is a deliberate stop, not a failure to recover
@@ -190,6 +286,9 @@ function goalFixOptions(options: RunOptions, prev: RunResult, trajectory: number
   return {
     ...options,
     pipeline,
+    // Like the initial run: the loop, not the iteration, decides when the work
+    // is finished and the post-hooks may fire.
+    deferPostHooks: true,
     // The finish screen shows the trajectory building across iterations.
     goalTrajectory: [...trajectory],
     // When this iteration will be followed by another, never hold the finish

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -18,6 +18,23 @@ export type RunHookContext = {
   status?: HookRunStatus
   progress: ProgressUI
   signal?: AbortSignal
+  /** Consensus quality score, when the pipeline ended in a quality-score-report step. */
+  score?: number
+  /** Outcome of the goal loop, when these post-hooks run after one. */
+  goal?: GoalHookOutcome
+}
+
+/**
+ * What a goal loop leaves for its post-hooks. `reached` is the distinction the
+ * run status cannot make: a loop that plateaus or exhausts its iterations below
+ * the target still *succeeds*, so a hook that gates on success alone would treat
+ * "scored 62, needed 85" as a pass.
+ */
+export type GoalHookOutcome = {
+  reached: boolean
+  target: number
+  /** Best measured score; absent when no iteration produced a parseable one. */
+  score?: number
 }
 
 type HookCommandResult = {
@@ -142,6 +159,14 @@ async function runHookCommand(stage: HookStage, hook: HookSpec, context: RunHook
     CONVOY_TARGET_DIR: context.targetDir,
     CONVOY_PROMPT_FILE: join(context.workspace.dir, "prd.md"),
     ...(context.status ? { CONVOY_RUN_STATUS: context.status } : {}),
+    ...(context.score !== undefined ? { CONVOY_RUN_SCORE: String(context.score) } : {}),
+    ...(context.goal
+      ? {
+          CONVOY_GOAL_REACHED: context.goal.reached ? "true" : "false",
+          CONVOY_GOAL_TARGET: String(context.goal.target),
+          ...(context.goal.score !== undefined ? { CONVOY_GOAL_SCORE: String(context.goal.score) } : {}),
+        }
+      : {}),
   }
 
   const proc = Bun.spawn([shell, "-lc", hook.command], {

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -263,8 +263,8 @@ function pipelineChoices(config: ConvoyConfig | undefined, agents: readonly Agen
         valid: true,
         advisedSteps: pipeline.steps.filter((step) => step.type === "agent" && Boolean(step.resolvedAdvisor ?? step.advisor)).length,
         // Goal mode needs both a consensus score step and a writable step: a
-        // report-only scored pipeline (review-scored) would be mutated by the
-        // goal-fixer, contradicting its "makes no changes" contract.
+        // report-only scored pipeline (review, review-lite) would be mutated by
+        // the goal-fixer, contradicting its "makes no changes" contract.
         scored: Boolean(consensusStep(pipeline)) && hasWritableStep(pipeline),
       }
     } catch (error) {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -7,8 +7,6 @@ export const defaultOpusModel = "anthropic/claude-opus-5"
 
 const fallbackModel = `${defaultGptModel}#${defaultGptVariant}`
 
-/** Second model the built-in ultra pipelines fan their audits across; a project can override per step. */
-const sonnetModel = "openrouter/anthropic/claude-sonnet-5"
 /** Lower-cost replacement for the GPT xhigh phases in the lightweight pipelines. */
 const glmModel = "openrouter/z-ai/glm-5.2"
 /** GLM 5.2 with its reasoning turned up: what the audit phases of `implement` run on. */
@@ -20,13 +18,15 @@ const grokModel = "openrouter/x-ai/grok-4.5"
 const kimiModel = "openrouter/moonshotai/kimi-k3"
 /** Kimi K3 with reasoning raised one notch: the design and adversarial passes earn it, the cheap fan-outs don't. */
 const kimiHighModel = `${kimiModel}#high`
-/** GPT 5.6 Sol: the implementation workhorse, and at xhigh the consensus reporter for the review/hunter pipelines. */
+/** GPT 5.6 Sol: the advisor `implement` consults, and at xhigh the consensus reporter for the review/ship/hunter pipelines. */
 const solModel = "openai/gpt-5.6-sol"
 const solXhighModel = `${solModel}#xhigh`
 
 // Per-step models the built-in `implement` pipeline pins. Exported so `convoy init`'s
 // inlined copy of that pipeline stays in sync with the built-in it claims to mirror.
-export const defaultImplementerModel = solXhighModel
+export const defaultImplementerModel = fallbackModel
+/** The model `implement`'s implementer consults at its decision points. */
+export const defaultImplementAdvisorModel = solXhighModel
 export const defaultImplementAuditModel = glmXhighModel
 export const defaultImplementReviewModel = kimiHighModel
 export const defaultAdversarialModel = kimiHighModel
@@ -79,7 +79,9 @@ export const builtInAgents: readonly AgentSpec[] = [
     temperature: 0.1,
     builtIn: true,
   },
-  // Review pipelines: shared audit agents (report-only `review` and change-applying `refine`/`ultra-refine`).
+  // Review pipelines: shared audit agents. The triage/fix/validate trio below is
+  // no longer wired into a built-in, but stays in the catalogue for the project
+  // pipelines that compose an audit-then-apply run of their own.
   {
     name: "review-scope",
     description: "Audit-only collector for branch scope and repository patterns",
@@ -153,7 +155,8 @@ export const builtInAgents: readonly AgentSpec[] = [
     temperature: 0.1,
     builtIn: true,
   },
-  // ultra-implement: final-review stage over the whole PR.
+  // Final-review stage over the whole PR: unused by the built-ins, kept for
+  // project pipelines that want a triage/fix/validate tail after implementation.
   {
     name: "implementation-triage",
     description: "Synthesizes parallel pattern/security/adversarial findings into one action plan",
@@ -389,39 +392,20 @@ export const defaultPipelineName = "implement"
 export const builtInPipelines: Record<string, PipelineSpec> = {
   // The audits are pinned to GLM 5.2 xhigh rather than left to inherit the run's
   // model: they read a diff that already exists, which is the work GLM does at
-  // parity with the expensive models, so the budget belongs in the phases that
-  // write (Sol xhigh) and judge (Kimi K3 high).
+  // parity with the expensive models, so the budget belongs in the phase that
+  // writes (Terra xhigh, advised) and the one that judges (Kimi K3 high).
+  //
+  // The advisor←executor pattern is the default, aimed at the one phase that
+  // earns it: Terra xhigh writes the code and consults Sol xhigh at its decision
+  // points, pairing the two GPT 5.6 variants that disagree most usefully. Every
+  // other phase runs unadvised, so the implementation step is where the second
+  // opinion is spent. Measurement deliberately lives in `ship`, not here: this
+  // pipeline's job is a first draft worth shaping by hand, and grading a draft
+  // you already intend to rework buys nothing.
   implement: {
-    description: "Implementation, pattern/security audits, design polish, tests, and adversarial review",
+    description: "Advised implementation on Terra xhigh consulting Sol, then pattern/security audits, design polish, tests, and adversarial review",
     steps: [
-      { agent: "implementer", model: defaultImplementerModel, reports: "none" },
-      { agent: "patterns", model: defaultImplementAuditModel },
-      { agent: "security", model: defaultImplementAuditModel },
-      { agent: "design", model: defaultImplementReviewModel },
-      { agent: "tests", model: defaultImplementAuditModel, reports: "none" },
-      { agent: "adversarial", model: defaultAdversarialModel, reports: "all" },
-    ],
-  },
-  "implement-lite": {
-    description: "Like implement, but drops every code-writing phase to GLM 5.2 to reduce cost; design runs on Kimi K3 and adversarial on Opus",
-    steps: [
-      { agent: "implementer", model: glmModel, reports: "none" },
-      { agent: "patterns", model: glmModel },
-      { agent: "security", model: glmModel },
-      { agent: "design", model: kimiModel },
-      { agent: "tests", model: glmModel, reports: "none" },
-      { agent: "adversarial", model: defaultOpusModel, reports: "all" },
-    ],
-  },
-  // The advisor←executor pattern as a runnable default, aimed at the one phase
-  // that earns it: Terra xhigh writes the code and consults Sol xhigh at its
-  // decision points, pairing the two GPT 5.6 variants that disagree most
-  // usefully. Every other phase is `implement`'s, unchanged and unadvised, so
-  // the advised implementation step is the single variable between the two.
-  "implement-advised": {
-    description: "Like implement, but the implementation phase runs on Terra xhigh and consults Sol as an advisor at its decision points; the audits run unadvised",
-    steps: [
-      { agent: "implementer", model: fallbackModel, advisor: solXhighModel, reports: "none" },
+      { agent: "implementer", model: defaultImplementerModel, advisor: defaultImplementAdvisorModel, reports: "none" },
       // `false` rather than an absent key: absent would inherit a project's
       // defaults.advisor and quietly re-advise these phases.
       { agent: "patterns", model: defaultImplementAuditModel, advisor: false },
@@ -431,36 +415,28 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
       { agent: "adversarial", model: defaultAdversarialModel, advisor: false, reports: "all" },
     ],
   },
-  // implement + the measurement layer: the final diff is graded by two
-  // independent quality-scorers (fresh agents, no shared context with the
-  // builder) against the fixed rubric, and a consensus step reconciles them and
-  // verifies their claims by running the checks itself. The result lands in
-  // reports/score-report.md with a machine-readable score block that a goal
-  // loop (--goal) can act on.
-  "implement-scored": {
-    description: "Like implement, then measures the result: two independent quality-scorers grade the final diff against the rubric and a consensus step reconciles and verifies the score",
+  // implement's shape on low-cost models, advisor included: the second opinion
+  // is what makes a cheap implementer worth running, so it is the last thing to
+  // drop. Kimi advises rather than a second GLM: it is already in this pipeline
+  // as the design model, so the cross-vendor disagreement costs no new provider.
+  "implement-lite": {
+    description: "Like implement, but drops every code-writing phase to GLM 5.2 to reduce cost; Kimi K3 advises the implementer and polishes design, and adversarial runs on Opus",
     steps: [
-      { agent: "implementer", model: defaultImplementerModel, reports: "none" },
-      { agent: "patterns", model: defaultImplementAuditModel },
-      { agent: "security", model: defaultImplementAuditModel },
-      { agent: "design", model: defaultImplementReviewModel },
-      { agent: "tests", model: defaultImplementAuditModel, reports: "none" },
-      { agent: "adversarial", model: defaultAdversarialModel, reports: "all" },
-      {
-        parallel: [
-          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "all" },
-        ],
-      },
-      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: "all" },
+      { agent: "implementer", model: glmModel, advisor: kimiHighModel, reports: "none" },
+      { agent: "patterns", model: glmModel, advisor: false },
+      { agent: "security", model: glmModel, advisor: false },
+      { agent: "design", model: kimiModel, advisor: false },
+      { agent: "tests", model: glmModel, advisor: false, reports: "none" },
+      { agent: "adversarial", model: defaultOpusModel, advisor: false, reports: "all" },
     ],
   },
   // The goal loop's fix iteration: applies exactly the gaps the previous
   // scoring round reported (delivered as a per-step phase brief on the fixer),
   // then re-scores with the same independent scorer fan-out and consensus. The
   // loop keeps the same worktree, so the diff accumulates; nothing here is run
-  // directly by a user, only by --goal.
+  // directly by a user, only by the loop `ship` starts (or an explicit --goal).
   "goal-fix": {
-    description: "The goal loop's fix iteration: apply exactly the gaps from the previous scoring round, then re-score. Not run directly; use --goal.",
+    description: "The goal loop's fix iteration: apply exactly the gaps from the previous scoring round, then re-score. Not run directly; ship's goal or --goal drives it.",
     steps: [
       { agent: "goal-fixer", name: "fix", reports: "none", diff: true },
       {
@@ -476,9 +452,14 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
       { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: ["score"] },
     ],
   },
+  // Report-only review + the measurement layer: after the parallel audits, two
+  // independent quality-scorers grade the same diff against the rubric and a
+  // consensus step reconciles and verifies. The score block is the deliverable
+  // alongside the findings report — a review that ends in a findings list ends
+  // in an open-ended question, so every review here also ends in a number.
   review: {
     description:
-      "Report-only PR review: scope, then parallel bug/clean-code/security audits across two models, then one prioritized findings report. Makes no changes.",
+      "Report-only PR review plus a verified quality score: scope, parallel bug/clean-code/security audits across two models, a prioritized findings report, then two independent quality-scorers and a consensus step. Makes no changes.",
     steps: [
       { agent: "review-scope", name: "scope", model: defaultOpusModel, reports: "none", diff: true },
       {
@@ -489,11 +470,21 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
         ],
       },
       { agent: "review-report", name: "report", model: defaultOpusModel, reports: "all" },
+      {
+        parallel: [
+          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "all" },
+        ],
+      },
+      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: "all" },
     ],
   },
+  // review's shape with nothing on Opus. The scorer models are pinned rather
+  // than left to the agent defaults precisely because those defaults are Opus:
+  // omitting them here would quietly reintroduce the cost this pipeline exists
+  // to avoid.
   "review-lite": {
     description:
-      "Like review, but every phase runs on a low-cost model: GLM 5.2 scopes and writes the report, and the audit fan-out pairs GLM 5.2 with Kimi K3 instead of Opus.",
+      "Like review, but every phase runs on a low-cost model: GLM 5.2 scopes, writes the report and reconciles the score, and the audit and scorer fan-outs pair GLM 5.2 with Kimi K3 instead of Opus.",
     steps: [
       { agent: "review-scope", name: "scope", model: glmModel, reports: "none", diff: true },
       {
@@ -504,77 +495,43 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
         ],
       },
       { agent: "review-report", name: "report", model: glmModel, reports: "all" },
+      {
+        parallel: [
+          { agent: "quality-scorer", name: "score", models: [glmXhighModel, kimiHighModel], reports: "all" },
+        ],
+      },
+      { agent: "quality-score-report", name: "score-report", model: glmXhighModel, reports: "all" },
     ],
   },
-  refine: {
-    description: "Audit-only PR review, adversarial finding triage, targeted fixes, and final validation — applies changes.",
-    steps: [
-      { agent: "review-scope", name: "scope", model: glmModel, reports: "none", diff: true },
-      { agent: "bug-auditor", name: "bugs", model: fallbackModel, reports: ["scope"] },
-      { agent: "clean-code-auditor", name: "clean-code", model: fallbackModel, reports: ["scope"] },
-      { agent: "security-reviewer", name: "security", model: fallbackModel, reports: ["scope"] },
-      { agent: "review-adversary", name: "triage", model: defaultOpusModel, reports: ["scope", "bugs", "clean-code", "security"] },
-      { agent: "review-fixer", name: "fixes", model: fallbackModel, reports: ["triage"] },
-      { agent: "review-validator", name: "validator", model: fallbackModel, reports: "all" },
-    ],
-  },
-  // refine's audits, but against the branch as it will actually merge: the sync
-  // phase lands the advanced base first, so the auditors read the merged result
-  // instead of a diff that no longer describes what lands.
+  // The close of the process: the branch is already shaped the way you want it,
+  // and what is left is proving it merges and clears the bar. Sync lands the
+  // advanced base first, so the scorers grade the branch as it will actually
+  // merge rather than a diff that no longer describes what lands. Then the
+  // measurement, and — because `goal` is declared here rather than left to the
+  // caller — the fix/re-score loop runs on its own until the score clears 85.
+  //
+  // There are no separate audit phases: the scorer already grades bugs,
+  // security, maintainability and scope against the rubric, and an open-ended
+  // audit in front of it only produces findings the score then has to re-weigh.
   //
   // Two things it expects from config rather than shipping itself, because both
   // are machine-local. Conflict resolution needs `git merge*`, `git add*` and
   // `git checkout --ours*|--theirs*` in `permissions.allow` — without them those
   // commands fall through to "ask" rather than failing. And fetching the base
   // beforehand or opening the PR afterwards belongs in `hooks.pipelines.ship`,
-  // since Convoy never runs remote git itself.
+  // since Convoy never runs remote git itself; post-hooks receive
+  // CONVOY_GOAL_REACHED so the PR step can require the bar to have been met.
   ship: {
-    description: "Sync the branch with its base (merge + conflict resolution), then audit the merged diff, triage, fix, and validate",
+    description: "Sync the branch with its base (merge + conflict resolution), measure the merged result against the quality rubric, and iterate until it clears 85/100",
+    goal: 85,
     steps: [
       { agent: "sync-with-base", name: "sync", model: fallbackModel, reports: "none" },
-      { agent: "review-scope", name: "scope", model: glmModel, reports: "none", diff: true },
-      { agent: "bug-auditor", name: "bugs", model: fallbackModel, reports: ["scope"] },
-      { agent: "clean-code-auditor", name: "clean-code", model: fallbackModel, reports: ["scope"] },
-      { agent: "security-reviewer", name: "security", model: fallbackModel, reports: ["scope"] },
-      { agent: "review-adversary", name: "triage", model: defaultOpusModel, reports: ["scope", "bugs", "clean-code", "security"] },
-      { agent: "review-fixer", name: "fixes", model: fallbackModel, reports: ["triage"] },
-      { agent: "review-validator", name: "validator", model: fallbackModel, reports: "all" },
-    ],
-  },
-  "ultra-refine": {
-    description: "Like refine, but every read-only audit runs in parallel across two models before triage, targeted fixes, and validation.",
-    steps: [
-      { agent: "review-scope", name: "scope", models: [sonnetModel, fallbackModel], reports: "none", diff: true },
       {
         parallel: [
-          { agent: "bug-auditor", name: "bugs", models: [sonnetModel, fallbackModel], reports: ["scope"] },
-          { agent: "clean-code-auditor", name: "clean-code", models: [sonnetModel, fallbackModel], reports: ["scope"] },
-          { agent: "security-reviewer", name: "security", models: [sonnetModel, fallbackModel], reports: ["scope"] },
+          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "all" },
         ],
       },
-      { agent: "review-adversary", name: "triage", model: defaultOpusModel, reports: ["scope", "bugs", "clean-code", "security"] },
-      { agent: "review-fixer", name: "fixes", model: sonnetModel, reports: ["triage"] },
-      { agent: "review-validator", name: "validator", model: defaultOpusModel, reports: "all" },
-    ],
-  },
-  "ultra-implement": {
-    description:
-      "Like implement, but pattern/security/adversarial reviews of the initial diff run in parallel across two models feeding a triage step, then design and tests, then an audit-only final review, a fixer that applies only blocking findings, and a final validator.",
-    steps: [
-      { agent: "implementer", reports: "none" },
-      {
-        parallel: [
-          { agent: "patterns", models: [sonnetModel, fallbackModel] },
-          { agent: "security", models: [sonnetModel, fallbackModel] },
-          { agent: "adversarial", models: [sonnetModel, fallbackModel] },
-        ],
-      },
-      { agent: "implementation-triage", name: "triage", model: defaultOpusModel },
-      { agent: "design", model: kimiModel },
-      { agent: "tests", reports: "none" },
-      { agent: "implementation-final-review", name: "final-review", model: defaultOpusModel, reports: "all" },
-      { agent: "implementation-fixer", name: "fixes", reports: ["final-review"] },
-      { agent: "implementation-validator", name: "validator", model: defaultOpusModel, reports: "all" },
+      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: "all" },
     ],
   },
   // The follow-up to a report-only run: feed it the findings (as the prompt or an
@@ -610,31 +567,6 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
         ],
       },
       { agent: "review-report", name: "report", model: solXhighModel, reports: "all" },
-    ],
-  },
-  // Report-only review + the measurement layer: after the parallel audits, two
-  // independent quality-scorers grade the same diff against the rubric and a
-  // consensus step reconciles and verifies. The score block is the deliverable
-  // alongside the findings report.
-  "review-scored": {
-    description:
-      "Report-only PR review plus a verified quality score: scope, parallel bug/clean-code/security audits across two models, a prioritized findings report, then two independent quality-scorers and a consensus step. Makes no changes.",
-    steps: [
-      { agent: "review-scope", name: "scope", model: defaultOpusModel, reports: "none", diff: true },
-      {
-        parallel: [
-          { agent: "clean-code-auditor", name: "clean-code", models: [fallbackModel, defaultOpusModel], reports: ["scope"] },
-          { agent: "security-reviewer", name: "security", models: [fallbackModel, defaultOpusModel], reports: ["scope"] },
-          { agent: "bug-auditor", name: "bugs", models: [fallbackModel, defaultOpusModel], reports: ["scope"] },
-        ],
-      },
-      { agent: "review-report", name: "report", model: defaultOpusModel, reports: "all" },
-      {
-        parallel: [
-          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "all" },
-        ],
-      },
-      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: "all" },
     ],
   },
   hunter: {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -375,6 +375,12 @@ export type RunResult = {
   dir: string
   /** Parsed consensus score when the pipeline ended in a quality-score-report step. */
   qualityScore?: QualityScore
+  /**
+   * Set only under `deferPostHooks`: the workspace was left on disk so the
+   * caller can run this run's post-hooks against it, and is the caller's to
+   * clean up afterwards.
+   */
+  workspace?: Workspace
 }
 
 export async function run(options: RunOptions) {
@@ -693,16 +699,27 @@ export async function run(options: RunOptions) {
     if (runScoreResult) {
       log.info(`quality score: ${runScoreResult.score.score}/100 (${runScoreResult.score.verdict})`)
     }
-    postHooksStarted = true
-    await runHooks("post", hookSet.post, {
-      workspace,
-      targetDir: options.targetDir,
-      pipelineName: pipeline.name,
-      prompt: options.prompt,
-      status: "success",
-      progress,
-      signal: shutdown.signal,
-    })
+    // Under a goal loop the run is one iteration of a longer piece of work, so
+    // "the work finished" is the loop's call to make, not this run's.
+    if (!options.deferPostHooks) {
+      postHooksStarted = true
+      await runHooks("post", hookSet.post, {
+        workspace,
+        targetDir: options.targetDir,
+        pipelineName: pipeline.name,
+        prompt: options.prompt,
+        status: "success",
+        progress,
+        signal: shutdown.signal,
+        ...(runScoreResult ? { score: runScoreResult.score.score } : {}),
+      })
+    } else if (hookSet.post.length > 0) {
+      // Their dashboard rows exist either way, so resolve them here rather than
+      // leaving them pending forever — the same treatment pre-hooks get on a
+      // resume. The caller runs them once the loop is done.
+      for (const name of hookPhaseNames("post", hookSet.post)) progress.phaseSkipped(name)
+      log.info("post-hooks deferred to the end of the goal loop")
+    }
     await caffeinate.stop()
     await holdFinishScreen(progress, shutdown, {
       status: "completed",
@@ -715,9 +732,18 @@ export async function run(options: RunOptions) {
       // finish screen: the loop runs unattended instead of waiting on a keypress.
       ...(options.goalContinues ? { goalContinues: true } : {}),
     })
-    return { runID: workspace.runID, dir: workspace.dir, ...(runScoreResult ? { qualityScore: runScoreResult.score } : {}) }
+    return {
+      runID: workspace.runID,
+      dir: workspace.dir,
+      ...(runScoreResult ? { qualityScore: runScoreResult.score } : {}),
+      ...(options.deferPostHooks ? { workspace } : {}),
+    }
   } catch (error) {
     let failure = error
+    // Deferral does not apply here: a failed run ends the loop, so there is no
+    // later point to defer to, and the failure hooks must still fire. They run
+    // without CONVOY_GOAL_* — the loop never reached an outcome — so a hook that
+    // gates on CONVOY_GOAL_REACHED correctly stays inert.
     if (!postHooksStarted && !isUserAbortError(failure)) {
       postHooksStarted = true
       try {
@@ -765,6 +791,10 @@ export async function run(options: RunOptions) {
 
     if (runErr) {
       log.warn(`Run dir preserved at ${workspace.dir}`)
+    } else if (options.deferPostHooks) {
+      // The deferred post-hooks still resolve CONVOY_RUN_DIR and `cwd: run`
+      // against this workspace, so it outlives the run; the caller deletes it
+      // once it has run them.
     } else if (options.keepRunDir || progress.keepRunDirRequested?.()) {
       log.info(`Run dir kept at ${workspace.dir}`)
     } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,6 +74,16 @@ export type RunOptions = {
    * of blocking on a keypress between every iteration.
    */
   goalContinues?: boolean
+  /**
+   * Goal loop: hand this run's post-hooks back to the caller instead of running
+   * them. A loop is one piece of work spread over several runs, so post-hooks —
+   * which mean "the work is finished" — must fire once, after the last
+   * iteration, with the loop's outcome available to them. Deferring also keeps
+   * the run workspace alive so the caller can still resolve CONVOY_RUN_DIR; the
+   * caller owns cleaning it up. Pre-hooks are unaffected: they run before work,
+   * and running them ahead of each fix round is harmless.
+   */
+  deferPostHooks?: boolean
   /** Resolved pipeline for new runs; resumed runs replay the pipeline frozen in their metadata. */
   pipeline: Pipeline
   /** Resolved agent registry (built-ins plus project agents) used to assemble the opencode config. */

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -501,11 +501,11 @@ describe("resolveRunOptions", () => {
 
 describe("goalModeFor", () => {
   // A pipeline is goal-eligible only when it has a quality-score-report step
-  // (consensus) AND a writable step. report-only scored pipelines (review-scored)
-  // have the consensus step but no writable step, so --goal is refused — the
+  // (consensus) AND a writable step. report-only scored pipelines (review) have
+  // the consensus step but no writable step, so --goal is refused — the
   // goal-fixer would mutate a pipeline whose contract says "makes no changes".
-  const implementScored = resolvePipeline({ name: "implement-scored", spec: builtInPipelines["implement-scored"]!, agents: builtInAgents })
-  const reviewScored = resolvePipeline({ name: "review-scored", spec: builtInPipelines["review-scored"]!, agents: builtInAgents })
+  const ship = resolvePipeline({ name: "ship", spec: builtInPipelines.ship!, agents: builtInAgents })
+  const reviewScored = resolvePipeline({ name: "review", spec: builtInPipelines.review!, agents: builtInAgents })
   const implement = resolvePipeline({ name: "implement", spec: builtInPipelines.implement!, agents: builtInAgents })
   const goalFix = resolvePipeline({ name: "goal-fix", spec: builtInPipelines["goal-fix"]!, agents: builtInAgents })
 
@@ -514,16 +514,16 @@ describe("goalModeFor", () => {
   }
 
   test("is off when no goal is set", () => {
-    expect(goalModeFor({}, planWith(implementScored))).toEqual({ mode: "off" })
+    expect(goalModeFor({}, planWith(ship))).toEqual({ mode: "off" })
   })
 
   test("is on for a scored pipeline with a writable step and a resolved fix pipeline", () => {
-    const decision = goalModeFor({ goal: 90, goalFixPipeline: goalFix }, planWith(implementScored))
+    const decision = goalModeFor({ goal: 90, goalFixPipeline: goalFix }, planWith(ship))
     expect(decision).toEqual({ mode: "on", goal: 90 })
   })
 
   test("rejects --goal on a report-only scored pipeline (no writable step)", () => {
-    // review-scored ends in a quality-score-report step but every step is
+    // review ends in a quality-score-report step but every step is
     // read-only, so --goal would run the writable goal-fixer against a pipeline
     // documented as "makes no changes" — refuse it with a clear reason.
     const decision = goalModeFor({ goal: 90, goalFixPipeline: goalFix }, planWith(reviewScored))
@@ -538,7 +538,7 @@ describe("goalModeFor", () => {
   })
 
   test("rejects --goal when the goal-fix pipeline could not be resolved", () => {
-    const decision = goalModeFor({ goal: 90 }, planWith(implementScored))
+    const decision = goalModeFor({ goal: 90 }, planWith(ship))
     expect(decision.mode).toBe("rejected")
     if (decision.mode === "rejected") expect(decision.reason).toBe("no-fix-pipeline")
   })
@@ -548,23 +548,23 @@ describe("goalModeFor", () => {
     // the fixer running blind (no brief reaches it); reject so the
     // misconfiguration is surfaced, not silently swallowed.
     const badFix = { ...goalFix, steps: goalFix.steps.filter((s) => !(s.type === "agent" && s.agentName === "goal-fixer")) }
-    const decision = goalModeFor({ goal: 90, goalFixPipeline: badFix }, planWith(implementScored))
+    const decision = goalModeFor({ goal: 90, goalFixPipeline: badFix }, planWith(ship))
     expect(decision.mode).toBe("rejected")
     if (decision.mode === "rejected") expect(decision.reason).toBe("bad-fix-pipeline")
   })
 
   test("rejects --goal when the fix pipeline lacks a consensus step", () => {
     const noConsensus = { ...goalFix, steps: goalFix.steps.filter((s) => !(s.type === "agent" && s.agentName === "quality-score-report")) }
-    const decision = goalModeFor({ goal: 90, goalFixPipeline: noConsensus }, planWith(implementScored))
+    const decision = goalModeFor({ goal: 90, goalFixPipeline: noConsensus }, planWith(ship))
     expect(decision.mode).toBe("rejected")
     if (decision.mode === "rejected") expect(decision.reason).toBe("bad-fix-pipeline")
   })
 
   test("the bad-fix-pipeline rejection error mentions the project override", () => {
     const badFix = { ...goalFix, steps: [] }
-    const decision = goalModeFor({ goal: 90, goalFixPipeline: badFix }, planWith(implementScored))
+    const decision = goalModeFor({ goal: 90, goalFixPipeline: badFix }, planWith(ship))
     if (decision.mode === "rejected") {
-      const error = goalModeRejectionError(decision, planWith(implementScored))
+      const error = goalModeRejectionError(decision, planWith(ship))
       expect(error.message).toContain("goal-fixer step")
       expect(error.message).toContain("quality-score-report step")
     }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -32,6 +32,7 @@ import {
   defaultGptModel,
   defaultGptVariant,
   defaultImplementAuditModel,
+  defaultImplementAdvisorModel,
   defaultImplementerModel,
   defaultImplementReviewModel,
   defaultOpusModel,
@@ -462,7 +463,7 @@ describe("pipeline selection", () => {
     expect(selectPipelineSpec(config, "implement").steps).toEqual(["tests"])
     expect(selectPipelineSpec(undefined, "implement").steps.length).toBeGreaterThan(1)
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(
-      'unknown pipeline "ghost" (available: fixer, goal-fix, hunter, hunter-max, implement, implement-advised, implement-lite, implement-scored, quick, refine, review, review-cc, review-lite, review-scored, ship, ultra-implement, ultra-refine)',
+      'unknown pipeline "ghost" (available: fixer, goal-fix, hunter, hunter-max, implement, implement-lite, quick, review, review-cc, review-lite, ship)',
     )
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(ConfigError)
   })
@@ -693,8 +694,8 @@ describe("serialization", () => {
     const template = defaultConfigTemplate()
     expect(template.defaults.model).toBe(`${defaultGptModel}#${defaultGptVariant}`)
     const steps = template.pipelines.implement!.steps
-    expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && !isHumanStepSpec(step) && step.agent === "design")).toEqual({ agent: "design", model: defaultImplementReviewModel })
-    expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && !isHumanStepSpec(step) && step.agent === "adversarial")).toEqual({ agent: "adversarial", model: defaultAdversarialModel, reports: "all" })
+    expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && !isHumanStepSpec(step) && step.agent === "design")).toEqual({ agent: "design", model: defaultImplementReviewModel, advisor: false })
+    expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && !isHumanStepSpec(step) && step.agent === "adversarial")).toEqual({ agent: "adversarial", model: defaultAdversarialModel, advisor: false, reports: "all" })
     const reparsed = parse(serializeConvoyConfig(template))
     expect(reparsed.defaults).toEqual(template.defaults)
     expect(reparsed.pipelines).toEqual(template.pipelines)
@@ -801,13 +802,16 @@ describe("default config init", () => {
     expect(config.agents).toEqual({})
     // Seeding prompts would shadow every built-in for good, so init writes none.
     expect(existsSync(join(dir, "agents"))).toBe(false)
+    // The inlined copy mirrors the built-in exactly, advisor opt-outs included:
+    // without them, a project that later sets defaults.advisor would advise
+    // phases the built-in deliberately leaves unadvised.
     expect(config.pipelines.implement?.steps).toEqual([
-      { agent: "implementer", model: defaultImplementerModel, reports: "none" },
-      { agent: "patterns", model: defaultImplementAuditModel },
-      { agent: "security", model: defaultImplementAuditModel },
-      { agent: "design", model: defaultImplementReviewModel },
-      { agent: "tests", model: defaultImplementAuditModel, reports: "none" },
-      { agent: "adversarial", model: defaultAdversarialModel, reports: "all" },
+      { agent: "implementer", model: defaultImplementerModel, advisor: defaultImplementAdvisorModel, reports: "none" },
+      { agent: "patterns", model: defaultImplementAuditModel, advisor: false },
+      { agent: "security", model: defaultImplementAuditModel, advisor: false },
+      { agent: "design", model: defaultImplementReviewModel, advisor: false },
+      { agent: "tests", model: defaultImplementAuditModel, advisor: false, reports: "none" },
+      { agent: "adversarial", model: defaultAdversarialModel, advisor: false, reports: "all" },
     ])
     expect(config.permissions).toEqual({ allow: [], deny: [] })
     expect(config.hooks).toEqual({ pre: [], post: [], pipelines: {} })
@@ -1022,10 +1026,16 @@ describe("materializing built-in pipelines", () => {
     if (originalGroup === undefined || !isParallelSpec(originalGroup)) throw new Error("expected a parallel block")
     const originalMember = originalGroup.parallel[0]
     if (typeof originalMember === "string") throw new Error("expected a member object")
-    expect(original.steps).toHaveLength(3)
+    expect(original.steps).toHaveLength(5)
     expect(originalGroup.parallel).toHaveLength(3)
     expect(originalMember.models).toHaveLength(2)
     expect(originalMember.name).toBe("clean-code")
+  })
+
+  test("carries the goal settings into the copy, so customizing ship does not disable its loop", () => {
+    const spec = { description: "d", goal: 85, goalMaxIterations: 4, goalPlateau: 2, steps: ["patterns"] }
+    expect(materializePipelineSpec(spec)).toMatchObject({ goal: 85, goalMaxIterations: 4, goalPlateau: 2 })
+    expect(materializePipelineSpec(builtInPipelines.ship!).goal).toBe(85)
   })
 
   test("inlines built-in agent model preferences only when a default model would shadow them", () => {

--- a/test/goal-loop.test.ts
+++ b/test/goal-loop.test.ts
@@ -2,16 +2,18 @@ import { describe, expect, test } from "bun:test"
 
 import { builtInAgents, builtInPipelines, resolvePipeline } from "../src/pipeline"
 import { buildRunPlan } from "../src/run-plan"
-import { goalBriefFor, runGoalLoop } from "../src/goal-loop"
+import { goalBriefFor, runGoalLoop, type GoalLoopDeps } from "../src/goal-loop"
 import { UserAbortError } from "../src/runner"
-import type { AgentStep, RunOptions, RunPlan } from "../src/types"
+import type { AgentStep, HookSpec, RunOptions, RunPlan } from "../src/types"
+import type { RunHookContext } from "../src/hooks"
 import type { RunResult } from "../src/runner"
 import type { RepoSnapshot } from "../src/git"
 import type { QualityScore } from "../src/quality-score"
+import type { Workspace } from "../src/workspace"
 
 const dimensions: QualityScore["dimensions"] = { prd: 92, tests: 70, security: 95, maintainability: 88, operational: 90, scope: 85 }
 
-const initialPipeline = resolvePipeline({ name: "implement-scored", spec: builtInPipelines["implement-scored"]!, agents: builtInAgents })
+const initialPipeline = resolvePipeline({ name: "ship", spec: builtInPipelines.ship!, agents: builtInAgents })
 const goalFixPipeline = resolvePipeline({ name: "goal-fix", spec: builtInPipelines["goal-fix"]!, agents: builtInAgents })
 
 function makeOptions(overrides: Partial<RunOptions> = {}): RunOptions {
@@ -100,14 +102,45 @@ function makeSnapshotFakes(overrides: Partial<SnapshotFakes> = {}): SnapshotFake
   }
 }
 
+/** Hook deps for the cases that assert on runs and snapshots rather than hooks. */
+const inertHookDeps: Pick<GoalLoopDeps, "runHooks" | "cleanupWorkspace"> = {
+  runHooks: (async () => {}) as GoalLoopDeps["runHooks"],
+  cleanupWorkspace: async () => {},
+}
+
+/** Records the post-hooks the loop runs and the workspaces it cleans up. */
+type HookFakes = {
+  posts: { hooks: readonly HookSpec[]; context: RunHookContext }[]
+  cleaned: Workspace[]
+}
+
+function makeHookFakes(): HookFakes & { deps: Pick<GoalLoopDeps, "runHooks" | "cleanupWorkspace"> } {
+  const state: HookFakes = { posts: [], cleaned: [] }
+  return {
+    ...state,
+    posts: state.posts,
+    cleaned: state.cleaned,
+    deps: {
+      runHooks: (async (stage, hooks, context) => {
+        if (stage === "post") state.posts.push({ hooks, context })
+      }) as GoalLoopDeps["runHooks"],
+      cleanupWorkspace: async (workspace) => {
+        state.cleaned.push(workspace)
+      },
+    },
+  }
+}
+
 /** Builds deps from a fake run queue and the snapshot fakes, wired through a shared state object. */
 async function makeDeps(scores: (number | undefined)[], snapshotFakes: Partial<SnapshotFakes> = {}) {
   const { calls, fakeRun } = await fakeRunQueue(scores)
   const fakes = makeSnapshotFakes(snapshotFakes)
+  const hooks = makeHookFakes()
   return {
     calls,
-    deps: { run: fakeRun, ...fakes.deps },
+    deps: { run: fakeRun, ...fakes.deps, ...hooks.deps },
     fakes,
+    hooks,
   }
 }
 
@@ -346,7 +379,7 @@ describe("runGoalLoop", () => {
     }
     const fakes = makeSnapshotFakes({ isClean: true })
     await expect(
-      runGoalLoop(makeOptions(), buildRunPlan(makeOptions()), { goal: 90, maxIterations: 3, plateau: 3 }, { run: failingRun, ...fakes.deps }),
+      runGoalLoop(makeOptions(), buildRunPlan(makeOptions()), { goal: 90, maxIterations: 3, plateau: 3 }, { run: failingRun, ...fakes.deps, ...inertHookDeps }),
     ).rejects.toThrow("boom")
   })
 
@@ -362,7 +395,7 @@ describe("runGoalLoop", () => {
     }
     const fakes = makeSnapshotFakes({ isClean: true })
     await expect(
-      runGoalLoop(makeOptions(), buildRunPlan(makeOptions()), { goal: 90, maxIterations: 3, plateau: 3 }, { run: abortingRun, ...fakes.deps }),
+      runGoalLoop(makeOptions(), buildRunPlan(makeOptions()), { goal: 90, maxIterations: 3, plateau: 3 }, { run: abortingRun, ...fakes.deps, ...inertHookDeps }),
     ).rejects.toThrow("Ctrl+C")
     expect(fakes.restores).toHaveLength(0)
   })
@@ -376,7 +409,7 @@ describe("runGoalLoop", () => {
     }
     const fakes = makeSnapshotFakes({ isClean: true })
     await expect(
-      runGoalLoop(makeOptions(), buildRunPlan(makeOptions()), { goal: 90, maxIterations: 3, plateau: 3 }, { run: failingFixRun, ...fakes.deps }),
+      runGoalLoop(makeOptions(), buildRunPlan(makeOptions()), { goal: 90, maxIterations: 3, plateau: 3 }, { run: failingFixRun, ...fakes.deps, ...inertHookDeps }),
     ).rejects.toThrow("fix iteration exploded")
     // A non-abort failure after a measured initial run restores to the best state.
     expect(fakes.restores).toHaveLength(1)
@@ -406,6 +439,7 @@ describe("runGoalLoop", () => {
       restoreSnapshot: async () => {},
       isCleanRepo: async () => true,
       currentHead: async () => "sha-1",
+      ...inertHookDeps,
     }
     const outcome = await runGoalLoop(makeOptions(), buildRunPlan(makeOptions()), { goal: 90, maxIterations: 5, plateau: 3 }, deps)
     expect(calls).toHaveLength(3)
@@ -476,5 +510,85 @@ describe("goal-fix re-scoring is blind to the previous score", () => {
     expect(consensus?.inputFiles).not.toContain("reports/fix.md")
     expect(consensus?.inputFiles).toContain("reports/score__openai-gpt-5-6-sol-xhigh.md")
     expect(consensus?.inputFiles).toContain("reports/score__anthropic-claude-opus-5.md")
+  })
+})
+
+describe("post-hooks deferred past the loop", () => {
+  const workspaceAt = (runID: string): Workspace => ({ runID, dir: `/runs/${runID}` }) as Workspace
+
+  /** A run queue whose results carry workspaces, as a deferred real run would. */
+  function deferringRunQueue(scores: number[]) {
+    const calls: RunOptions[] = []
+    const queue = [...scores]
+    let n = 0
+    const fakeRun = async (options: RunOptions): Promise<RunResult> => {
+      calls.push(options)
+      const next = queue.shift()
+      const workspace = workspaceAt(`run-${n++}`)
+      return { runID: workspace.runID, dir: workspace.dir, workspace, ...(next === undefined ? {} : { qualityScore: scoreAt(next) }) }
+    }
+    return { calls, fakeRun }
+  }
+
+  async function loopWith(scores: number[], goal: number, post: HookSpec[] = [{ command: "open-pr" }]) {
+    const { calls, fakeRun } = deferringRunQueue(scores)
+    const hooks = makeHookFakes()
+    const options = makeOptions({ hooks: { pre: [], post: [], pipelines: { ship: { pre: [], post } } } })
+    const outcome = await runGoalLoop(options, buildRunPlan(options), { goal, maxIterations: 3, plateau: 3 }, {
+      run: fakeRun,
+      ...makeSnapshotFakes().deps,
+      ...hooks.deps,
+    })
+    return { calls, hooks, outcome }
+  }
+
+  test("every run defers its post-hooks, so nothing fires between iterations", async () => {
+    const { calls } = await loopWith([71, 86, 92], 90)
+
+    expect(calls).toHaveLength(3)
+    for (const call of calls) expect(call.deferPostHooks).toBe(true)
+  })
+
+  test("the base pipeline's post-hooks run exactly once, after the loop", async () => {
+    const { hooks } = await loopWith([71, 92], 90)
+
+    expect(hooks.posts).toHaveLength(1)
+    // ship's hooks, not the goal-fix iteration's, even though goal-fix ran last.
+    expect(hooks.posts[0]?.context.pipelineName).toBe("ship")
+    expect(hooks.posts[0]?.hooks.map((hook) => hook.command)).toEqual(["open-pr"])
+  })
+
+  test("reports the goal as reached, with the score, when the loop cleared the bar", async () => {
+    const { hooks, outcome } = await loopWith([71, 92], 90)
+
+    expect(outcome.reached).toBe(true)
+    expect(hooks.posts[0]?.context.goal).toEqual({ reached: true, target: 90, score: 92 })
+  })
+
+  test("reports the goal as NOT reached when the loop ran out of road below it", async () => {
+    // The run still succeeds — that is exactly why a hook cannot gate on run
+    // status alone, and must read CONVOY_GOAL_REACHED instead.
+    const { hooks, outcome } = await loopWith([40, 50, 60, 70], 90)
+
+    expect(outcome.reached).toBe(false)
+    expect(hooks.posts[0]?.context.status).toBe("success")
+    expect(hooks.posts[0]?.context.goal).toMatchObject({ reached: false, target: 90 })
+  })
+
+  test("the hooks resolve against the last run's workspace, and every kept workspace is cleaned up", async () => {
+    const { hooks } = await loopWith([71, 92], 90)
+
+    expect(hooks.posts[0]?.context.workspace.runID).toBe("run-1")
+    // Both the initial run's workspace and the final one, once the hooks that
+    // needed the latter have run.
+    expect(hooks.cleaned.map((workspace) => workspace.runID)).toEqual(["run-0", "run-1"])
+  })
+
+  test("skips the hook stage entirely when the pipeline has no post-hooks", async () => {
+    const { hooks } = await loopWith([71, 92], 90, [])
+
+    expect(hooks.posts).toHaveLength(0)
+    // The workspaces are still cleaned up: nothing needed them.
+    expect(hooks.cleaned).toHaveLength(2)
   })
 })

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import { branchActionForKey, branchProposalNote, cursorPosition, defaultGoalTarget, adjustGoalTarget, hookLines, launcherStepModelLabel, promptEnterAction, reviewActionForKey, sanitizePaste, stepTree, typedText, wrapPromptLines } from "../src/launch-tui"
 
-import { builtInAgents, builtInPipelines, resolvePipeline } from "../src/pipeline"
+import { builtInAgents, builtInPipelines, hasWritableStep, resolvePipeline } from "../src/pipeline"
 import { consensusStep } from "../src/quality-score"
 import type { KeyEvent } from "@opentui/core"
 
@@ -327,16 +327,29 @@ describe("launch TUI goal mode", () => {
 
   test("consensusStep detects scored built-in pipelines", () => {
     // Scored: pipelines that end in a quality-score-report step
-    for (const name of ["implement-scored", "review-scored", "goal-fix"]) {
+    for (const name of ["ship", "review", "review-lite", "goal-fix"]) {
       const pipeline = resolvePipeline({ name, spec: builtInPipelines[name]!, agents: builtInAgents })
       expect(consensusStep(pipeline)).toBeDefined()
     }
   })
 
   test("consensusStep rejects non-scored built-in pipelines", () => {
-    for (const name of ["implement", "implement-lite", "review", "refine", "ultra-implement", "hunter"]) {
+    for (const name of ["implement", "implement-lite", "fixer", "review-cc", "hunter"]) {
       const pipeline = resolvePipeline({ name, spec: builtInPipelines[name]!, agents: builtInAgents })
       expect(consensusStep(pipeline)).toBeUndefined()
     }
+  })
+
+  test("only ship is goal-eligible: review scores but cannot be fixed, implement can be fixed but is not scored", () => {
+    // Goal mode needs both halves; the launcher's `scored` flag is the AND of them.
+    const eligible = (name: string) => {
+      const pipeline = resolvePipeline({ name, spec: builtInPipelines[name]!, agents: builtInAgents })
+      return Boolean(consensusStep(pipeline)) && hasWritableStep(pipeline)
+    }
+
+    expect(eligible("ship")).toBe(true)
+    expect(eligible("review")).toBe(false)
+    expect(eligible("review-lite")).toBe(false)
+    expect(eligible("implement")).toBe(false)
   })
 })

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -66,19 +66,58 @@ describe("default pipeline", () => {
     ])
   })
 
-  test("pins Sol xhigh for implementation, GLM 5.2 xhigh for the audits, and Kimi K3 high for design and adversarial", () => {
+  test("pins Terra xhigh for implementation, GLM 5.2 xhigh for the audits, and Kimi K3 high for design and adversarial", () => {
     const byName = Object.fromEntries(
       defaultPipeline()
         .steps.filter((step): step is AgentStep => step.type === "agent")
         .map((step) => [step.name, step]),
     )
 
-    expect(byName.implementer).toMatchObject({ model: "openai/gpt-5.6-sol", variant: "xhigh" })
+    expect(byName.implementer).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
     expect(byName.patterns).toMatchObject({ model: "openrouter/z-ai/glm-5.2", variant: "xhigh" })
     expect(byName.security).toMatchObject({ model: "openrouter/z-ai/glm-5.2", variant: "xhigh" })
     expect(byName.design).toMatchObject({ model: "openrouter/moonshotai/kimi-k3", variant: "high" })
     expect(byName.tests).toMatchObject({ model: "openrouter/z-ai/glm-5.2", variant: "xhigh" })
     expect(byName.adversarial).toMatchObject({ model: "openrouter/moonshotai/kimi-k3", variant: "high" })
+  })
+
+  test("advises the implementation phase only: Sol xhigh at Terra's decision points", () => {
+    const byName = Object.fromEntries(
+      defaultPipeline()
+        .steps.filter((step): step is AgentStep => step.type === "agent")
+        .map((step) => [step.name, step]),
+    )
+
+    expect(byName.implementer).toMatchObject({ advisor: "openai/gpt-5.6-sol", advisorVariant: "xhigh" })
+    for (const name of ["patterns", "security", "design", "tests", "adversarial"]) {
+      expect(byName[name]?.advisor).toBeUndefined()
+    }
+    // Exactly one step carries the advisor cost.
+    expect(defaultPipeline().steps.filter((step) => step.type === "agent" && step.advisor).length).toBe(1)
+  })
+
+  test("the audits opt out of the advisor explicitly, so defaults.advisor cannot re-advise them", () => {
+    // `advisor: false` and an omitted key resolve identically until a project
+    // sets defaults.advisor — which is exactly the case this pins down.
+    const byName = Object.fromEntries(
+      resolvePipeline({
+        name: "implement",
+        spec: builtInPipelines.implement!,
+        agents: builtInAgents,
+        defaultAdvisor: "openrouter/anthropic/claude-opus-5",
+      })
+        .steps.filter((step): step is AgentStep => step.type === "agent")
+        .map((step) => [step.name, step]),
+    )
+
+    expect(byName.implementer).toMatchObject({ advisor: "openai/gpt-5.6-sol", advisorVariant: "xhigh" })
+    for (const name of ["patterns", "security", "design", "tests", "adversarial"]) {
+      expect(byName[name]?.advisor).toBeUndefined()
+    }
+  })
+
+  test("does not score: measurement belongs to ship, not to the first draft", () => {
+    expect(stepNames(defaultPipeline())).not.toContain("score-report")
   })
 
   test("keeps every implement step on its own model even when defaults.model is GPT", () => {
@@ -164,87 +203,35 @@ describe("built-in implement-lite pipeline", () => {
   })
 })
 
-describe("built-in implement-advised pipeline", () => {
-  const advised = () =>
-    resolvePipeline({ name: "implement-advised", spec: builtInPipelines["implement-advised"]!, agents: builtInAgents }).steps.filter(
-      (step): step is AgentStep => step.type === "agent",
-    )
 
-  test("advises the implementation phase only: Terra xhigh writing, Sol xhigh at its decision points", () => {
-    const implementer = advised().find((step) => step.name === "implementer")
+describe("built-in ship pipeline", () => {
+  const ship = () => resolvePipeline({ name: "ship", spec: builtInPipelines.ship!, agents: builtInAgents })
+  const shipSteps = () => ship().steps.filter((step): step is AgentStep => step.type === "agent")
 
-    expect(implementer).toMatchObject({
-      model: "openai/gpt-5.6-terra",
-      variant: "xhigh",
-      advisor: "openai/gpt-5.6-sol",
-      advisorVariant: "xhigh",
-    })
-  })
-
-  test("leaves every phase after the implementer unadvised, so only one step carries the advisor cost", () => {
-    const steps = advised()
-    const rest = steps.filter((step) => step.name !== "implementer")
-
-    expect(rest.length).toBeGreaterThan(0)
-    for (const step of rest) {
-      expect(step.advisor).toBeUndefined()
-    }
-    expect(steps.filter((step) => step.advisor).length).toBe(1)
-  })
-
-  test("is implement with one advised step: every other phase matches model for model", () => {
-    const implement = resolvePipeline({ name: "implement", spec: builtInPipelines.implement!, agents: builtInAgents }).steps.filter(
-      (step): step is AgentStep => step.type === "agent",
-    )
-    const byName = Object.fromEntries(implement.map((step) => [step.name, step]))
-
-    // The advised implementation step is the only variable between the two, so a
-    // difference anywhere else would make the comparison meaningless.
-    expect(advised().map((step) => step.name)).toEqual(implement.map((step) => step.name))
-    for (const step of advised()) {
-      if (step.name === "implementer") continue
-      expect({ model: step.model, variant: step.variant }).toEqual({
-        model: byName[step.name]!.model,
-        variant: byName[step.name]!.variant,
-      })
-    }
-  })
-})
-
-describe("built-in implement-scored pipeline", () => {
-  const scored = () =>
-    resolvePipeline({ name: "implement-scored", spec: builtInPipelines["implement-scored"]!, agents: builtInAgents }).steps.filter(
-      (step): step is AgentStep => step.type === "agent",
-    )
-
-  test("is implement plus the measurement layer: scorer fan-out and a consensus step", () => {
-    expect(scored().map((step) => step.name)).toEqual([
-      "implementer",
-      "patterns",
-      "security",
-      "design",
-      "tests",
-      "adversarial",
+  test("is sync then the measurement layer: no open-ended audits in between", () => {
+    expect(shipSteps().map((step) => step.name)).toEqual([
+      "sync",
       "score__openai-gpt-5-6-sol-xhigh",
       "score__anthropic-claude-opus-5",
       "score-report",
     ])
   })
 
-  test("keeps implement's six phases exactly, model for model", () => {
-    const implement = resolvePipeline({ name: "implement", spec: builtInPipelines.implement!, agents: builtInAgents }).steps.filter(
-      (step): step is AgentStep => step.type === "agent",
-    )
-    const byName = Object.fromEntries(implement.map((step) => [step.name, step]))
+  test("syncs the base in before anything reads the diff, so the score describes the merged result", () => {
+    const [sync] = shipSteps()
 
-    expect(scored().slice(0, 6).map((step) => step.name)).toEqual(implement.map((step) => step.name))
-    for (const step of scored().slice(0, 6)) {
-      expect({ model: step.model, variant: step.variant }).toEqual({ model: byName[step.name]!.model, variant: byName[step.name]!.variant })
-    }
+    expect(sync).toMatchObject({ agentName: "sync-with-base", model: "openai/gpt-5.6-terra", variant: "xhigh" })
+    // The merge writes to the repository: goal mode refuses a report-only
+    // pipeline, so this step is also what makes ship goal-eligible.
+    expect(sync?.readOnly).toBeFalsy()
   })
 
-  test("fans the scorers across Sol xhigh + opus as forced read-only, grading with all reports", () => {
-    const scorers = scored().filter((step) => step.stepName === "score")
+  test("declares its own goal, so the fix/re-score loop runs without --goal", () => {
+    expect(ship().goal).toBe(85)
+  })
+
+  test("fans the scorers across Sol xhigh + opus as forced read-only", () => {
+    const scorers = shipSteps().filter((step) => step.stepName === "score")
 
     expect(scorers).toHaveLength(2)
     expect(scorers.map((step) => ({ model: step.model, variant: step.variant }))).toEqual([
@@ -256,21 +243,15 @@ describe("built-in implement-scored pipeline", () => {
       expect(step.agentName).toBe("quality-scorer__ro")
       expect(step.readOnly).toBe(true)
       expect(step.verify).toBeUndefined()
-      expect(step.inputFiles).toEqual([
-        "prd.md",
-        "reports/implementer.md",
-        "reports/patterns.md",
-        "reports/security.md",
-        "reports/design.md",
-        "reports/tests.md",
-        "reports/adversarial.md",
-      ])
+      // No review-scope step feeds these, so the diff has to arrive by the
+      // "every step after the first gets it" default.
       expect(step.inputDiff).toBe(true)
+      expect(step.inputFiles).toEqual(["prd.md", "reports/sync.md"])
     }
   })
 
   test("consensus step keeps bash to verify the scorers' claims and reads every report", () => {
-    const report = scored().find((step) => step.name === "score-report")
+    const report = shipSteps().find((step) => step.name === "score-report")
 
     expect(report).toMatchObject({
       agentName: "quality-score-report",
@@ -281,20 +262,15 @@ describe("built-in implement-scored pipeline", () => {
     })
     expect(report?.inputFiles).toEqual([
       "prd.md",
-      "reports/implementer.md",
-      "reports/patterns.md",
-      "reports/security.md",
-      "reports/design.md",
-      "reports/tests.md",
-      "reports/adversarial.md",
+      "reports/sync.md",
       "reports/score__openai-gpt-5-6-sol-xhigh.md",
       "reports/score__anthropic-claude-opus-5.md",
     ])
   })
 })
 
-describe("built-in review-scored pipeline", () => {
-  const scored = () => resolvePipeline({ name: "review-scored", spec: builtInPipelines["review-scored"]!, agents: builtInAgents })
+describe("built-in review pipeline", () => {
+  const scored = () => resolvePipeline({ name: "review", spec: builtInPipelines.review!, agents: builtInAgents })
 
   test("is report-only: every step is read-only and there is no human gate", () => {
     const pipeline = scored()
@@ -353,71 +329,6 @@ describe("built-in review-scored pipeline", () => {
   })
 })
 
-describe("built-in ship pipeline", () => {
-  const ship = () =>
-    resolvePipeline({ name: "ship", spec: builtInPipelines.ship!, agents: builtInAgents }).steps.filter(
-      (step): step is AgentStep => step.type === "agent",
-    )
-
-  test("syncs the base in before anything reads the diff", () => {
-    const steps = ship()
-
-    expect(steps[0]).toMatchObject({ name: "sync", agentName: "sync-with-base" })
-    // The sync phase writes: it resolves conflicts and Convoy's phase commit
-    // concludes the merge.
-    expect(steps[0]?.readOnly).toBeUndefined()
-    expect(steps[0]?.inputFiles).toEqual(["prd.md"])
-    // scope is what first reads the diff, and by then it is the merged diff.
-    expect(steps[1]).toMatchObject({ name: "scope", inputDiff: true })
-  })
-
-  test("runs refine's audit chain after the sync", () => {
-    const refine = resolvePipeline({ name: "refine", spec: builtInPipelines.refine!, agents: builtInAgents }).steps.filter(
-      (step): step is AgentStep => step.type === "agent",
-    )
-
-    expect(ship().slice(1).map((step) => step.name)).toEqual(refine.map((step) => step.name))
-  })
-})
-
-describe("built-in review pipeline", () => {
-  const review = () => resolvePipeline({ name: "review", spec: builtInPipelines.review!, agents: builtInAgents })
-
-  test("is report-only: every step is read-only and there is no human gate", () => {
-    const pipeline = review()
-    const agents = pipeline.steps.filter((step): step is AgentStep => step.type === "agent")
-    expect(agents.length).toBeGreaterThan(0)
-    expect(agents.every((step) => step.readOnly)).toBe(true)
-    expect(pipeline.steps.some((step) => step.type === "human")).toBe(false)
-  })
-
-  test("fans each audit across GPT 5.6 Terra xhigh + opus and feeds a single report step with every audit", () => {
-    const pipeline = review()
-    expect(stepNames(pipeline)).toEqual([
-      "scope",
-      "clean-code__openai-gpt-5-6-terra-xhigh",
-      "clean-code__anthropic-claude-opus-5",
-      "security__openai-gpt-5-6-terra-xhigh",
-      "security__anthropic-claude-opus-5",
-      "bugs__openai-gpt-5-6-terra-xhigh",
-      "bugs__anthropic-claude-opus-5",
-      "report",
-    ])
-
-    const report = pipeline.steps.find((step): step is AgentStep => step.type === "agent" && step.stepName === "report")
-    expect(report?.inputFiles).toEqual([
-      "prd.md",
-      "reports/scope.md",
-      "reports/clean-code__openai-gpt-5-6-terra-xhigh.md",
-      "reports/clean-code__anthropic-claude-opus-5.md",
-      "reports/security__openai-gpt-5-6-terra-xhigh.md",
-      "reports/security__anthropic-claude-opus-5.md",
-      "reports/bugs__openai-gpt-5-6-terra-xhigh.md",
-      "reports/bugs__anthropic-claude-opus-5.md",
-    ])
-  })
-})
-
 describe("built-in review-lite pipeline", () => {
   const reviewLite = () => resolvePipeline({ name: "review-lite", spec: builtInPipelines["review-lite"]!, agents: builtInAgents })
 
@@ -440,6 +351,9 @@ describe("built-in review-lite pipeline", () => {
       "bugs__openrouter-z-ai-glm-5-2",
       "bugs__openrouter-moonshotai-kimi-k3",
       "report",
+      "score__openrouter-z-ai-glm-5-2-xhigh",
+      "score__openrouter-moonshotai-kimi-k3-high",
+      "score-report",
     ])
 
     const byName = Object.fromEntries(
@@ -460,25 +374,20 @@ describe("built-in review-lite pipeline", () => {
   })
 
   test("never reaches for Opus, which is what separates it from review", () => {
+    // The scorer agents default to Opus, so the scorer steps have to pin their
+    // models explicitly; an omitted `models:` would reintroduce exactly the cost
+    // this pipeline exists to avoid.
     expect(JSON.stringify(builtInPipelines["review-lite"])).not.toContain("opus")
+    const scorers = reviewLite().steps.filter((step): step is AgentStep => step.type === "agent" && step.stepName === "score")
+    expect(scorers).toHaveLength(2)
+    for (const step of scorers) {
+      expect(step.model).not.toContain("opus")
+    }
   })
-})
 
-describe("built-in refine pipeline", () => {
-  test("scopes with GLM 5.2, audits/fixes/validates with GPT 5.6 Terra xhigh, and triages with opus", () => {
-    const byName = Object.fromEntries(
-      resolvePipeline({ name: "refine", spec: builtInPipelines.refine!, agents: builtInAgents })
-        .steps.filter((step): step is AgentStep => step.type === "agent")
-        .map((step) => [step.name, step]),
-    )
-
-    expect(byName.scope).toMatchObject({ model: "openrouter/z-ai/glm-5.2" })
-    expect(byName.bugs).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
-    expect(byName["clean-code"]).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
-    expect(byName.security).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
-    expect(byName.triage).toMatchObject({ model: "anthropic/claude-opus-5" })
-    expect(byName.fixes).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
-    expect(byName.validator).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
+  test("measures like review does, on its own models", () => {
+    const report = reviewLite().steps.find((step): step is AgentStep => step.type === "agent" && step.name === "score-report")
+    expect(report).toMatchObject({ agentName: "quality-score-report", model: "openrouter/z-ai/glm-5.2", variant: "xhigh", readOnly: true, verify: true })
   })
 })
 


### PR DESCRIPTION
Convoy shipped **16 built-in pipelines**. Most went unused: historical variants (`ultra-*`), the same idea at three budgets (`review` / `review-lite` / `review-scored`), and experiments that had already proven themselves and should stop being opt-in (`implement-advised`, `implement-scored`).

The advisor and scoring techniques are not variants — they are how the tool should work by default. This makes them so, and cuts the set down to the cycle it actually serves:

```
   plan            build              shape            close
(your editor) ──► convoy ──► (your editor, by hand) ──► convoy -p ship ──► PR
                 implement                              sync · score · loop
```

## 16 built-ins → 10

| Pipeline | Change |
|---|---|
| `implement` | **Advised by default** — Terra xhigh writes consulting Sol xhigh; every other phase carries `advisor: false` explicitly so a project's `defaults.advisor` can't quietly re-advise it. Absorbs `implement-advised`. Deliberately does **not** score. |
| `implement-lite` | Gains the advisor too. The second opinion is what makes a cheap implementer worth running, so it's the last thing to drop. |
| `ship` | **Rebuilt as the close of the cycle**: `sync` → 2 scorers → consensus, declaring `goal: 85` in its own spec so the fix/re-score loop runs *without* `--goal`. |
| `review` / `review-lite` | The scored variants, under the plain names. |
| `fixer` · `goal-fix` · `review-cc` · `hunter` · `hunter-max` | Unchanged. |

**Removed:** `refine`, `ultra-implement`, `ultra-refine`, plus the names `implement-advised`, `implement-scored`, `review-scored` (absorbed).

### Why `ship` has no audit phases

The scorer already grades bugs, security, maintainability and scope against the rubric. An open-ended audit in front of it only produces findings the score then has to re-weigh — the two overlap rather than compose.

### Why `implement` doesn't score

Its job is a first draft worth shaping by hand. Grading a draft you already intend to rework buys nothing. Measurement belongs at the end of the cycle, in `ship`.

## Two defects this surfaced

**Post-hooks fired at the wrong time.** They run inside `run()`, and `runGoalLoop` calls `run()` once per iteration — so `ship`'s PR hook would have fired after the *initial* run, before the loop fixed anything. Worse, since `goal-loop.ts` returns rather than throwing, exhausting iterations below the target is still a **successful** run, so `when: success` could not distinguish "cleared 85" from "gave up at 62".

Loop runs now defer their post-hooks. The loop runs them **once**, after the last iteration, against the **base** pipeline's hook set (not `goal-fix`'s, which runs last), with `CONVOY_GOAL_REACHED` / `CONVOY_GOAL_SCORE` / `CONVOY_GOAL_TARGET` in the environment:

```yaml
hooks:
  pipelines:
    ship:
      post:
        - name: open PR
          command: |
            if [ "$CONVOY_GOAL_REACHED" = "true" ]; then
              git push -u origin HEAD && gh pr create --fill
            fi
```

Pre-hooks are untouched: they run *before* work, and running them ahead of each fix round is harmless. Failure hooks are untouched too — a failed run ends the loop, so there is no later point to defer to, and they fire without `CONVOY_GOAL_*` so a gated hook correctly stays inert.

**`materializePipelineSpec` dropped `goal`.** Copying `ship` into config via `convoy config` would have silently disabled its loop. Fixed, with a test.

## A pin that looks redundant but isn't

Several steps pin `anthropic/claude-opus-5` where that's already the agent's `defaultModel`. Removing them would let an `agents:` override reach those steps — but the model chain is `step ?? agent.model ?? defaults.model ?? agent.defaultModel`, so a step without a pin becomes shadowable by `defaults.model`. They stay, and `test/pipeline.test.ts` still guards it.

## Verification

- All ten pipelines resolve; the six removed names fail with `unknown pipeline`.
- `-p ship --plan` reports `Goal mode: target 85/100 · up to 3 fix iterations` with no `--goal` passed.
- `--plan` on `implement` reports `Advisors: 1/6 steps advised`.
- `review-lite` resolves with zero Opus steps, scorers included.
- **1746 tests pass**; coverage **91.45% lines / 93.3% functions** (gate: 90/90).

**Not verified:** a real end-to-end `ship` run against a live branch — that needs real work on a branch and real token spend. The path to exercise the not-reached branch of the PR hook is `--goal 99`.

## Breaking

Reusing `review` and `review-lite` for the scored variants is the one silent change: an existing `convoy -p review` keeps working but costs more and emits an extra `reports/score-report.md`. That's the intent — scoring stops being opt-in — but it belongs in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014jarAazGx4nTVEAVYtZi1d