### PR TITLE
feat(runs): retry a run from step 0 with its original config

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,9 +357,11 @@ convoy --resume 20260519-103045-x7q2
 # with status, date, cost, and prompt) plus a details panel with the per-phase
 # breakdown. A run still executing shows a green ● "running" and can be
 # attached. ↑/↓ select, [enter] re-open its dashboard (attach if it's live,
-# else reconstruct it for inspection), [r]esume (re-runs the failed/unfinished
-# phases), [s]ummary/reports overlay, subshell in the run [d]ir under
-# ~/.convoy/runs (exit to return), [q]uit.
+# else reconstruct it for inspection), [r]etry starts a brand-new run from
+# step 0 using the selected run's original prompt and pipeline config (a
+# confirmation modal asks y/n), [R]esume re-runs only the failed/unfinished
+# phases of the existing run, [s]ummary/reports overlay, subshell in the run
+# [d]ir under ~/.convoy/runs (exit to return), [q]uit.
 # Pass a run ID to open the browser with that run preselected.
 # Without a TTY (pipes/CI) it falls back to a plain listing.
 convoy runs

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises"
+import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import { buildAgentRegistry, ejectAgentPrompt, emptyHooksConfig, globalConfigPath, loadMergedConvoyConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ConvoyDefaults } from "./config"
@@ -396,6 +396,14 @@ async function openRunsBrowser(initialRunID?: string) {
   let currentRunID = initialRunID
   for (;;) {
     const resolution = await browseRuns(currentRunID)
+    if (resolution.type === "retry") {
+      const options = await retryOptions(resolution.runID, resolution.targetDir)
+      const plan = options.plan ?? buildRunPlan({ ...options, promptSource: "retry" })
+      if (!(await confirmRunPlan(plan))) return
+      await preflightRunPlan(plan)
+      await run({ ...options, plan })
+      return
+    }
     if (resolution.type === "resume") {
       const options = await resumeOptions(resolution.runID, resolution.targetDir)
       const plan = options.plan ?? buildRunPlan({ ...options, promptSource: "resume" })
@@ -439,6 +447,40 @@ async function resumeOptions(runID: string, targetDir?: string): Promise<RunOpti
   }
   options.plan = buildRunPlan({ ...options, promptSource: "resume" })
   return options
+}
+
+// Retry is a fresh run that reuses the selected run's original prompt and
+// pipeline config: a new run dir from step 0, not a resume of the old one.
+// Like resume, the prompt and pipeline come back from the run's metadata so the
+// user doesn't have to retype or reconfigure anything.
+async function retryOptions(runID: string, targetDir?: string): Promise<RunOptions> {
+  // The recorded target may have been a worktree that's since been removed; a
+  // retry starts a fresh run, so falling back to the current directory keeps it
+  // runnable instead of failing on a missing path.
+  const resolvedTarget = (targetDir && (await dirExists(targetDir))) ? targetDir : process.cwd()
+  const parsed = parseArgs([])
+  parsed.targetDir = resolvedTarget
+  const options: RunOptions = { ...(await resolveRunOptions(parsed)), prompt: "" }
+  const workspace = await resumeWorkspace(runID)
+  const metadata = await readRunMetadata(resolve(workspace.dir, "metadata.json"))
+  if (metadata?.pipeline) options.pipeline = metadata.pipeline
+  options.gateway = metadata?.modelRouting?.gateway ?? "configured"
+  try {
+    options.prompt = await readFile(resolve(workspace.dir, "prd.md"), "utf8")
+  } catch {
+    // Legacy/incomplete workspace.
+  }
+  options.plan = buildRunPlan({ ...options, promptSource: "retry" })
+  return options
+}
+
+async function dirExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/src/runs-browser.ts
+++ b/src/runs-browser.ts
@@ -49,6 +49,10 @@ export class RunsBrowser {
   private scroll = 0
   private summary?: { runID: string; lines: string[]; scroll: number }
   private summaryLines?: { source: string[]; doc: MarkdownDoc; width: number; value: StyledText[] }
+  // A pending retry confirmation: keeps the selected run's id/target until the
+  // user answers y/n. Lives in the same modal as the summary (only one modal at
+  // a time), so it's set/cleared together with the overlay visibility.
+  private confirm?: { runID: string; targetDir?: string; title: string }
   // A subshell owns the terminal while the renderer is suspended; ignore keys.
   private inSubshell = false
   private readonly ticker: ReturnType<typeof setInterval>
@@ -82,7 +86,8 @@ export class RunsBrowser {
     if (this.inSubshell) return
     key.preventDefault()
     key.stopPropagation()
-    if (this.summary) this.handleSummaryKey(key)
+    if (this.confirm) this.handleConfirmKey(key)
+    else if (this.summary) this.handleSummaryKey(key)
     else this.handleListKey(key)
   }
 
@@ -281,8 +286,16 @@ export class RunsBrowser {
         break
       }
       case "r": {
+        // `r` retries: a brand-new run from step 0 with the original config,
+        // gated by a confirmation modal. `R` (shift+r) keeps the old resume
+        // behavior, which continues the run from where it stopped.
         const run = this.selectedRun()
-        this.finish({ type: "resume", runID: run.runID, targetDir: run.targetDir })
+        if (key.shift) {
+          this.finish({ type: "resume", runID: run.runID, targetDir: run.targetDir })
+        } else {
+          this.confirm = { runID: run.runID, targetDir: run.targetDir, title: run.title }
+          this.render()
+        }
         break
       }
       case "s":
@@ -335,6 +348,24 @@ export class RunsBrowser {
         break
     }
     this.render()
+  }
+
+  private handleConfirmKey(key: KeyEvent) {
+    const confirm = this.confirm
+    if (!confirm) return
+    switch (key.name) {
+      case "y":
+      case "return":
+      case "linefeed":
+        this.finish({ type: "retry", runID: confirm.runID, targetDir: confirm.targetDir })
+        break
+      case "n":
+      case "escape":
+      case "q":
+        this.confirm = undefined
+        this.render()
+        break
+    }
   }
 
   private moveSelection(delta: number) {
@@ -569,6 +600,13 @@ export class RunsBrowser {
   }
 
   private footerContent(width: number) {
+    if (this.confirm) {
+      const hints: Hint[] = [
+        { keys: "y", label: "retry", priority: 2 },
+        { keys: "n/esc", label: "cancel", priority: 1 },
+      ]
+      return hintsRow(hints, [], width, { style: "spaced", overflow: moreHintsMarker })
+    }
     if (this.summary) {
       const summary = this.summary
       const rendered = this.summaryRows(summary.lines, this.summaryWidth())
@@ -585,9 +623,10 @@ export class RunsBrowser {
     const hints: Hint[] = [
       { keys: "↑/↓", label: "select", priority: 3, tone: "dim" },
       { keys: "enter", label: "open", priority: 2 },
-      { keys: "r", label: "esume", priority: 4, style: "glued" },
-      { keys: "s", label: "ummary", priority: 5, style: "glued" },
-      { keys: "d", label: "ir", priority: 6, style: "glued" },
+      { keys: "r", label: "etry", priority: 4, style: "glued" },
+      { keys: "R", label: "resume", priority: 5 },
+      { keys: "s", label: "ummary", priority: 6, style: "glued" },
+      { keys: "d", label: "ir", priority: 7, style: "glued" },
       { keys: "q", label: "uit", priority: 1, style: "glued" },
     ]
     const right: TextChunk[] = [fg(theme.faint)(`${this.selected + 1}/${this.runs.length}`)]
@@ -600,20 +639,49 @@ export class RunsBrowser {
 
   private renderSummaryModal() {
     const summary = this.summary
-    this.overlay.visible = Boolean(summary)
-    if (!summary) return
+    const confirm = this.confirm
+    this.overlay.visible = Boolean(summary || confirm)
+    if (!summary && !confirm) return
 
     const boxWidth = this.modalWidth()
-    const visible = this.summaryHeight()
-    const rendered = this.summaryRows(summary.lines, this.summaryWidth())
-    summary.scroll = Math.max(0, Math.min(summary.scroll, rendered.length - visible))
+    if (confirm) {
+      this.renderConfirmModal(boxWidth)
+      return
+    }
 
-    const lines = rendered.slice(summary.scroll, summary.scroll + visible)
+    const visible = this.summaryHeight()
+    const rendered = this.summaryRows(summary!.lines, this.summaryWidth())
+    summary!.scroll = Math.max(0, Math.min(summary!.scroll, rendered.length - visible))
+
+    const lines = rendered.slice(summary!.scroll, summary!.scroll + visible)
     while (lines.length < visible) lines.push(plain(""))
 
-    this.modal.title = ` summary · ${summary.runID} `
+    this.modal.title = ` summary · ${summary!.runID} `
     this.modal.width = boxWidth
     this.modal.height = visible + 4
+    this.modalText.content = joinLines(lines)
+  }
+
+  // The retry confirmation reuses the summary modal: it's a small, focused
+  // prompt that spells out what "retry" does (a fresh run from step 0) so the
+  // user doesn't confuse it with resume, which continues the old run.
+  private renderConfirmModal(boxWidth: number) {
+    const confirm = this.confirm!
+    const innerWidth = Math.max(36, boxWidth - 6)
+    const lines: StyledText[] = [
+      t`${bold(fg(theme.text)("Retry this run from the start?"))}`,
+      plain(""),
+      t`${fg(theme.faint)("A new run starts at step 0 using the original")}`,
+      t`${fg(theme.faint)("prompt and pipeline config — a fresh copy, not a resume.")}`,
+      plain(""),
+      new StyledText([fg(theme.faint)("run     "), fg(theme.dim)(confirm.runID)]),
+      new StyledText([fg(theme.faint)("prompt  "), fg(theme.text)(truncate(confirm.title, innerWidth - 9))]),
+      plain(""),
+      t`${fg(theme.accent)("y")} ${fg(theme.text)("retry")}   ${fg(theme.faint)("n / esc")} ${fg(theme.dim)("cancel")}`,
+    ]
+    this.modal.title = " retry "
+    this.modal.width = boxWidth
+    this.modal.height = lines.length + 4
     this.modalText.content = joinLines(lines)
   }
 }

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -42,6 +42,9 @@ export type RunsResolution =
   // Re-enter a run's dashboard: attach to it live if its server is up, else
   // reconstruct the finish screen from metadata + reports.
   | { type: "open"; runID: string; targetDir?: string }
+  // Retry: start a brand-new run from step 0 using the selected run's original
+  // prompt and pipeline config — a fresh copy, not a resume of the old run.
+  | { type: "retry"; runID: string; targetDir?: string }
 
 export async function listRuns(root = runsRoot()): Promise<RunEntry[]> {
   let names: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -236,7 +236,7 @@ export type Pipeline = {
 }
 
 export type RunPlan = {
-  prompt: { source: "inline" | "file" | "resume"; text: string }
+  prompt: { source: "inline" | "file" | "resume" | "retry"; text: string }
   target: {
     directory: string
     baseRef: string

--- a/test/runs-tui.test.ts
+++ b/test/runs-tui.test.ts
@@ -96,10 +96,58 @@ test("o opens the current run", async () => {
   })
 })
 
-test("r resumes the current run", async () => {
+test("r opens a retry confirmation and y confirms a retry", async () => {
   const { renderer, runs, result } = await browser(2)
 
   renderer.keyInput.emit("keypress", keyEvent("r"))
+  // Arrow keys are ignored while the confirmation modal is up.
+  renderer.keyInput.emit("keypress", keyEvent("j"))
+  renderer.keyInput.emit("keypress", keyEvent("y"))
+
+  await expect(result).resolves.toEqual({
+    type: "retry",
+    runID: runs[2]!.runID,
+    targetDir: runs[2]!.targetDir,
+  })
+})
+
+test("return confirms the retry modal", async () => {
+  const { renderer, runs, result } = await browser(0)
+
+  renderer.keyInput.emit("keypress", keyEvent("r"))
+  renderer.keyInput.emit("keypress", keyEvent("return", { raw: "\r" }))
+
+  await expect(result).resolves.toEqual({
+    type: "retry",
+    runID: runs[0]!.runID,
+    targetDir: runs[0]!.targetDir,
+  })
+})
+
+test("n cancels the retry confirmation and returns to the list", async () => {
+  const { renderer, result } = await browser(1)
+
+  renderer.keyInput.emit("keypress", keyEvent("r"))
+  renderer.keyInput.emit("keypress", keyEvent("n"))
+  renderer.keyInput.emit("keypress", keyEvent("q"))
+
+  await expect(result).resolves.toEqual({ type: "exit" })
+})
+
+test("escape cancels the retry confirmation", async () => {
+  const { renderer, result } = await browser(1)
+
+  renderer.keyInput.emit("keypress", keyEvent("r"))
+  renderer.keyInput.emit("keypress", keyEvent("escape"))
+  renderer.keyInput.emit("keypress", keyEvent("q"))
+
+  await expect(result).resolves.toEqual({ type: "exit" })
+})
+
+test("R (shift+r) resumes the current run", async () => {
+  const { renderer, runs, result } = await browser(2)
+
+  renderer.keyInput.emit("keypress", keyEvent("r", { shift: true }))
 
   await expect(result).resolves.toEqual({
     type: "resume",


### PR DESCRIPTION
## What

In the run-history browser (`convoy runs`), pressing `r` on a run now opens a confirmation modal that starts a **brand-new run from step 0** using that run's original prompt and pipeline config — a fresh copy, not a resume of the old run. Resume (re-running only the failed/unfinished phases of the existing run) moves to `R` (shift+r).

## Why

A retry should mean "run it again from the beginning, forgetting everything that already happened," without forcing the operator to retype the prompt or reconfigure the pipeline. Until now `r` only resumed from where the run stopped, so retrying from scratch meant relaunching `convoy` with the original prompt and flags by hand.

## How

- `runs-browser.ts`: `r` opens a confirmation modal (reusing the summary overlay) asking `y/n`. `y`/`Enter` resolves to a new `retry` resolution; `n`/`Esc` cancels. `R` (shift+r) keeps the old resume behavior. Footer hints updated (`r retry · R resume`).
- `runs.ts`: new `{ type: "retry"; runID; targetDir? }` member of `RunsResolution`.
- `types.ts`: `"retry"` added to `RunPlan.prompt.source` so the reviewed plan labels the prompt source correctly.
- `cli.ts`: `openRunsBrowser` handles the `retry` resolution and calls a new `retryOptions(runID, targetDir)`, which reads the original `prd.md`, the frozen pipeline, and the gateway from the run's `metadata.json`. Because `resumeRunID` is left unset, the runner calls `createWorkspace(...)` and executes the full pipeline from step 0 in a new run dir. A `targetDir` that was a worktree since removed falls back to `process.cwd()` instead of failing on a missing path.
- `README.md`: the `convoy runs` section now documents `[r]etry` and `[R]esume`.

## Tests

- `test/runs-tui.test.ts`: replaced the old `r resumes` test with 5 new ones — `y` confirms, `Enter` confirms, `n` cancels back to the list, `Esc` cancels, and `R` resumes.

## Verification

- `bun run typecheck` — clean
- `bun test test/runs-tui.test.ts` — 9 pass
- `bun test` (full suite) — **1840 pass, 0 fail**

## Notes

- Resume is preserved on `R` rather than removed; if you'd rather drop resume entirely (or remap it), that's a one-line change in the `case "r"` block.
- Retry uses the run's recorded `targetDir` when it still exists (to reuse that part of the original config) and only falls back to `cwd` when it's gone. If you'd prefer retry to always run in the current directory, that's a small change too.