### PR TITLE
fix(tui): keep designed border colors regardless of reported background

### DIFF
--- a/src/tui-theme.ts
+++ b/src/tui-theme.ts
@@ -104,24 +104,25 @@ export function paletteForMode(mode: "dark" | "light" | null | undefined): Palet
 }
 
 /**
- * Palette tuned to the terminal's own background: borders are subtle
- * elevations of it and modals repaint it exactly, so nothing reads as a
- * foreign skin. Accents still come from the static palettes (picked by the
- * background's brightness, which is the same inference opentui uses for the
- * mode). Without a reported background this falls back to paletteForMode.
+ * Palette tuned to the terminal's own background: only the modal overlay and
+ * chip text follow the reported background, so modals mask what's beneath
+ * them and never read as a foreign skin. Borders stay on the static palette:
+ * deriving them from the reported background turned the designed border colors
+ * into neutral grays under multiplexers that answer the background query with
+ * their own host theme instead of the real terminal. Accents still come from
+ * the static palettes (picked by the background's brightness, which is the
+ * same inference opentui uses for the mode). Without a reported background
+ * this falls back to paletteForMode.
  */
 export function paletteForTerminal(mode: "dark" | "light" | null | undefined, backgroundHex?: string): Palette {
   const rgb = backgroundHex ? parseHex(backgroundHex) : undefined
   if (!rgb) return paletteForMode(mode)
   const isDark = (rgb[0] * 299 + rgb[1] * 587 + rgb[2] * 114) / 1000 <= 128
-  const pole: Rgb = isDark ? [255, 255, 255] : [0, 0, 0]
   return {
     ...(isDark ? darkPalette : lightPalette),
     // The reported color, not transparent: a modal must mask what's beneath
     // it, and repainting the terminal's own background makes that invisible.
     overlay: backgroundHex!,
-    borderDim: mixToward(rgb, pole, 0.16),
-    border: mixToward(rgb, pole, 0.26),
     chipText: backgroundHex!,
   }
 }
@@ -145,14 +146,6 @@ function parseHex(hex: string): Rgb | undefined {
   if (!match) return undefined
   const value = Number.parseInt(match[1]!, 16)
   return [(value >> 16) & 0xff, (value >> 8) & 0xff, value & 0xff]
-}
-
-function mixToward(rgb: Rgb, pole: Rgb, amount: number): string {
-  const hex = (index: number) =>
-    Math.round(rgb[index]! + (pole[index]! - rgb[index]!) * amount)
-      .toString(16)
-      .padStart(2, "0")
-  return `#${hex(0)}${hex(1)}${hex(2)}`
 }
 
 export type PhaseStatus = "pending" | "running" | "completed" | "skipped" | "failed"

--- a/test/tui-theme.test.ts
+++ b/test/tui-theme.test.ts
@@ -17,26 +17,26 @@ describe("palette derivation from the terminal background", () => {
     expect(wrapLines(["éé"], 1)).toEqual(["é", "é"])
   })
 
-  test("dark background: transparent canvas, borders lifted toward white, overlay repaints the terminal", () => {
+  test("dark background: transparent canvas, static borders, overlay repaints the terminal", () => {
     const palette = paletteForTerminal("dark", "#1a1b26")
 
     expect(palette.bg).toBe("transparent")
     expect(palette.overlay).toBe("#1a1b26")
     expect(palette.chipText).toBe("#1a1b26")
-    // 16% / 26% toward white from #1a1b26.
-    expect(palette.borderDim).toBe("#3f3f49")
-    expect(palette.border).toBe("#56565e")
+    // Borders come from the static dark palette, never from the background.
+    expect(palette.borderDim).toBe("#1B2438")
+    expect(palette.border).toBe("#26324B")
     // Accents come from the static dark palette.
     expect(palette.accent).toBe(paletteForMode("dark").accent)
   })
 
-  test("light background: borders sink toward black with light accents", () => {
+  test("light background: transparent canvas, static borders, overlay repaints the terminal", () => {
     const palette = paletteForTerminal("light", "#fafafa")
 
     expect(palette.bg).toBe("transparent")
     expect(palette.overlay).toBe("#fafafa")
-    expect(palette.borderDim).toBe("#d2d2d2")
-    expect(palette.border).toBe("#b9b9b9")
+    expect(palette.borderDim).toBe("#C1C6DD")
+    expect(palette.border).toBe("#A8AECB")
     expect(palette.accent).toBe(paletteForMode("light").accent)
   })
 


### PR DESCRIPTION
## Problem

Inside **Herdr**, Convoy's TUIs don't render with the defined palette: the borders of all panels came out as neutral grays (`#4B4B4B` / `#333333`) instead of the designed ones (`#26324B` / `#1B2438`), and changing Herdr's theme had no effect.

## Cause

`paletteForTerminal()` derived `border` and `borderDim` from the background the terminal reports via OSC 11 (`mixToward(background, white/black, 0.26/0.16)`). Herdr answers that query with its **host terminal theme** (the captured client terminal theme, e.g. Monokai Remastered → `#0C0C0C`), not with Herdr's theme nor the real background. Starting from `#0C0C0C`, the mix produces neutral grays instead of the designed blue-gray borders. In Zellij and standalone, where the reported background is different (or the query never arrives), the borders ended up being the designed ones.

Verified by capturing the real ANSI of the TUI inside a Herdr pane (`herdr pane read --ansi`): exact palette accents, but `#4B4B4B`×6 and `#333333`×72 on the borders; `#26324B`/`#1B2438` at 0 uses. An A/B test with a fake terminal answering the same background confirmed that Herdr doesn't distort colors: the difference lies solely in the reported background.

## Changes

- `src/tui-theme.ts`: `paletteForTerminal` **no longer derives `border`/`borderDim`** from the reported background; it always uses the palette's static colors (dark → `#26324B`/`#1B2438`, light → `#A8AECB`/`#C1C6DD`). `overlay` and `chipText` still follow the reported background so that modals keep masking what's underneath.
- Removed `mixToward()` (it was left unused).
- `test/tui-theme.test.ts`: border expectations updated to the static values.

## Verification

- `bun run typecheck` clean.
- `bun test`: **1880 pass / 0 fail** (a `runner-hosted` test was flaky on the side: it passes in isolation and on `main`).
- E2E: branch-compiled binary running inside Herdr → borders `#26324B`×6 / `#1B2438`×72 in use, derived grays at 0.
