### PR TITLE
fix(reports): reliably extract, validate, and preserve phase reports

### DIFF
--- a/assets/coverage.svg
+++ b/assets/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="138" height="20" role="img" aria-label="coverage: 92.38%">
-  <title>coverage: 92.38%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="138" height="20" role="img" aria-label="coverage: 92.75%">
+  <title>coverage: 92.75%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="38" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="38" y="14">coverage</text>
-    <text x="107" y="15" fill="#010101" fill-opacity=".3">92.38%</text>
-    <text x="107" y="14">92.38%</text>
+    <text x="107" y="15" fill="#010101" fill-opacity=".3">92.75%</text>
+    <text x="107" y="14">92.75%</text>
   </g>
 </svg>

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,5 +1,5 @@
 import { normalizeStepRunnerModel, stepRunnerFor } from "./step-runners"
-import type { AgentSpec, AgentStep, HumanStep, Pipeline, Step, StepRunner } from "./types"
+import type { AgentSpec, AgentStep, DeliverableContract, HumanStep, Pipeline, Step, StepRunner } from "./types"
 
 export const defaultGptModel = "openai/gpt-5.6-terra"
 export const defaultGptVariant = "xhigh"
@@ -936,11 +936,33 @@ function resolveAgentStepSpec(raw: string | AgentStepSpec, ctx: ResolveStepConte
       inputFiles: ["prd.md", ...reportInputs(ctx.input.name, name, spec.reports ?? "previous", ctx.priorSteps)],
       inputDiff: spec.diff ?? ctx.priorSteps.length > 0,
       reportPath: `reports/${name}.md`,
+      deliverableContract: defaultDeliverableContract(agent.name, Boolean(forced || agent.readOnly)),
       ...(forced || agent.readOnly ? { readOnly: true } : {}),
       ...(verify ? { verify: true } : {}),
     }
     return step
   })
+}
+
+/** The contract a newly resolved quality-score-report step must satisfy. */
+export const qualityScoreDeliverableContract: DeliverableContract = {
+  kind: "quality-score-report",
+  schemaVersion: 1,
+  retryOnMissingOrInvalid: 1,
+}
+
+/** Infers the report contract from agent identity and read-only status. */
+export function defaultDeliverableContract(agentName: string, readOnly: boolean): DeliverableContract {
+  if (agentName === "quality-score-report") return qualityScoreDeliverableContract
+  return readOnly ? { kind: "markdown-report" } : { kind: "none" }
+}
+
+/**
+ * Resolves a phase's report contract, including metadata created before
+ * deliverable contracts were persisted in resolved pipelines.
+ */
+export function deliverableContractForPhase(phase: Pick<AgentStep, "agentName" | "readOnly" | "deliverableContract">): DeliverableContract {
+  return phase.deliverableContract ?? defaultDeliverableContract(phase.agentName, Boolean(phase.readOnly))
 }
 
 function findAgent(ref: string, agents: readonly AgentSpec[]): AgentSpec | undefined {

--- a/src/quality-score.ts
+++ b/src/quality-score.ts
@@ -124,12 +124,10 @@ export function consensusStep(
 /**
  * Extracts and validates the `quality-score` JSON block from a scorer report.
  *
- * Strict contract: the report must end with exactly one `quality-score` fenced
- * block (no `json` alias, no bare-object fallback), that block must be the last
- * thing in the report, and it must contain valid, in-range data. A report that
- * fails any of that yields undefined so the caller can treat the scorer as
- * having failed the contract — it is safer to reject an ambiguous or accidental
- * object than to take it as a control signal.
+ * The authoritative block is the last `quality-score` fenced block (no `json`
+ * alias or bare-object fallback) and must contain valid, in-range data. Text
+ * after its closing fence is tolerated because an agent's final response may
+ * append delivery narration after an otherwise valid machine-readable report.
  */
 export function parseQualityScoreReport(
   markdown: string,
@@ -181,10 +179,9 @@ export function parseQualityScoreReport(
 
 /**
  * Finds the report's authoritative quality-score block: the last
- * `quality-score` fence, which must also end the report (only whitespace may
- * follow its closing fence). Blocks earlier in the report are examples, not
- * results, and trailing content after the final block makes the report
- * malformed rather than selecting a different candidate.
+ * `quality-score` fence. Blocks earlier in the report are examples, not
+ * results. Text after the final block is ignored but logged as a contract
+ * warning so a valid score is still available to the goal loop.
  */
 function extractQualityScoreBlock(markdown: string): string | undefined {
   // Find every opening fence with the same contract as before: the tag must be
@@ -198,14 +195,15 @@ function extractQualityScoreBlock(markdown: string): string | undefined {
   // The closing fence is the LAST ``` in the remainder, not the first. A
   // non-greedy regex would close early on triple-backticks inside JSON string
   // values (e.g. a gap description that references a ```fenced``` code block),
-  // yielding invalid JSON and a silent no-score. Searching from the end and
-  // relying on the trailing-whitespace guard below is resilient to that: the
-  // real closing fence is the final ``` in the report.
+  // yielding invalid JSON and a silent no-score. The last ``` after the last
+  // opening fence is the closer; anything after it is trailing narration.
   const closingIndex = afterOpening.lastIndexOf("```")
   if (closingIndex === -1) return undefined
   const block = afterOpening.slice(0, closingIndex)
   const trailing = afterOpening.slice(closingIndex + 3)
-  if (trailing.trim() !== "") return undefined
+  if (trailing.trim() !== "") {
+    log.warn("quality score: found content after the final quality-score block; extracting the score and ignoring trailing text")
+  }
   return block.trim()
 }
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -26,7 +26,7 @@ import { openOpencodeSessionWindow, startOpencode } from "./opencode"
 import { HerdrReporter } from "./herdr"
 import { defaultNotificationSettings, Notifier } from "./notifications"
 import { startPermissionGate, type PermissionGate } from "./permissions"
-import { agentsForPipeline, splitModelVariant, validateStepFilters } from "./pipeline"
+import { agentsForPipeline, deliverableContractForPhase, splitModelVariant, validateStepFilters } from "./pipeline"
 import { formatTerminalTitle, projectName, RunStatusTracker, trackRunStatus } from "./run-status"
 import { popTerminalTitle, pushTerminalTitle, writeTerminalTitle } from "./terminal-title"
 import {
@@ -50,7 +50,7 @@ import {
 import { discoverProjectContextFiles } from "./project-context"
 import { createStepRunnerImpl, stepRunnerFor, stepRunnerModel, type StepRunnerId, type StepRunnerImpl } from "./step-runners"
 import { createTerminalInput, type TerminalInput } from "./terminal-input"
-import type { AgentSpec, AgentStep, HookSet, HookSpec, Pipeline, RunOptions, Step } from "./types"
+import type { AgentSpec, AgentStep, DeliverableContract, HookSet, HookSpec, Pipeline, RunOptions, Step } from "./types"
 import { consensusStep, loadQualityRubricWeights, parseQualityScoreReport, qualityDimensionWeights, type QualityDimension, type QualityScore } from "./quality-score"
 import { addTokens, emptyTokens, tokensFromValue } from "./usage"
 import { cleanupWorkspace, createWorkspace, opencodeConfigDir, resumeWorkspace, type Workspace, writeSummary } from "./workspace"
@@ -1185,6 +1185,30 @@ type PhaseRetryDeps = {
   restorePhaseBaseline: typeof restorePhaseBaseline
 }
 
+class DeliverableValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DeliverableValidationError"
+  }
+}
+
+export function validateDeliverable(
+  contract: DeliverableContract,
+  reportText: string,
+  weights: Record<QualityDimension, number> = qualityDimensionWeights,
+): { valid: true } | { valid: false; error: string } {
+  switch (contract.kind) {
+    case "none":
+      return { valid: true }
+    case "markdown-report":
+      return reportText.trim() ? { valid: true } : { valid: false, error: "phase produced an empty report" }
+    case "quality-score-report":
+      return parseQualityScoreReport(reportText, weights)
+        ? { valid: true }
+        : { valid: false, error: "phase produced an invalid quality-score report" }
+  }
+}
+
 export async function runPhaseUntilResolved(
   client: OpencodeClient,
   workspace: Workspace,
@@ -1200,6 +1224,10 @@ export async function runPhaseUntilResolved(
   advisors?: AdvisorRuntime,
 ) {
   const sessionRef: SessionRef = {}
+  const deliverableContract = deliverableContractForPhase(phase)
+  const rubricWeights =
+    deliverableContract.kind === "quality-score-report" ? ((await loadQualityRubricWeights(targetDir)) ?? qualityDimensionWeights) : qualityDimensionWeights
+  let automaticDeliverableRetries = 0
   // Read fresh at each decision point: the user can arm/disarm [i] mid-attempt.
   const armed = () => Boolean(takeover && progress.isInteractiveTakeover?.(phase.name))
 
@@ -1209,6 +1237,23 @@ export async function runPhaseUntilResolved(
     log.info(`[${phase.name}] attempt ${attempt} with ${formatModel(prepared.model)}`)
     try {
       const text = await deps.runPhaseAttempt(client, workspace, phase, targetDir, prepared, attempt, progress, shutdown, sessionRef, advisors)
+      const validation = validateDeliverable(deliverableContract, text, rubricWeights)
+      if (!validation.valid) {
+        await persistInvalidPhaseReport(workspace, phase, attempt, text)
+        const canRetryAutomatically =
+          deliverableContract.kind === "quality-score-report" && automaticDeliverableRetries < deliverableContract.retryOnMissingOrInvalid
+        if (canRetryAutomatically) {
+          automaticDeliverableRetries++
+          log.warn(
+            `[${phase.name}] deliverable validation failed (attempt ${attempt}/${deliverableContract.retryOnMissingOrInvalid + 1}): ${validation.error}; retrying automatically`,
+          )
+          await gitLock(() => deps.restorePhaseBaseline(phase, baseline, targetDir, new DeliverableValidationError(validation.error)))
+          await removePhaseReport(workspace, phase)
+          continue
+        }
+        log.error(`[${phase.name}] deliverable validation failed: ${validation.error}`)
+        throw new DeliverableValidationError(validation.error)
+      }
       if (armed()) {
         // Armed means "this step is mine": even a clean finish waits for the
         // user's decision before the step commits and the pipeline moves on.
@@ -1227,6 +1272,10 @@ export async function runPhaseUntilResolved(
       return text
     } catch (error) {
       if (shutdown.aborted || isUserAbortError(error)) throw shutdown.abortError(error)
+      // A report-contract failure is terminal after its bounded automatic retry;
+      // accepting it through the human failure gate would turn a missing score
+      // into a successful scored run with no machine-readable result.
+      if (error instanceof DeliverableValidationError) throw error
       if (!(error instanceof LoggedAttemptError)) await writeAttemptLog(workspace, phase, attempt, { error: formatSdkError(error) })
       progress.phaseRunning(phase.name, "step failed — waiting for your decision")
       log.warn(`[${phase.name}] attempt ${attempt} failed: ${formatSdkError(error)}`)
@@ -1494,7 +1543,7 @@ async function executeOpenCodePhaseAttempt(input: PhaseAttemptInput): Promise<Ph
     loopGuardConfig: input.prepared.loopGuard,
     ...(input.advisors ? { advisors: input.advisors } : {}),
   })
-  const assistantText = extractAssistantText(result.parts)
+  const assistantText = extractAssistantText(result.lastAssistantParts ?? result.parts)
   // Totals for the whole attempt, not the final message: the attempt log's
   // executor figures are what the advisor split is measured against, and a
   // headline ratio computed from one message of a many-message phase would
@@ -1541,16 +1590,33 @@ async function executeClaudeCodePhaseAttempt(input: PhaseAttemptInput): Promise<
   }
 }
 
-async function persistPhaseReport(workspace: Workspace, phase: AgentStep, assistantText: string) {
+async function persistPhaseReport(
+  workspace: Workspace,
+  phase: AgentStep,
+  assistantText: string,
+  contract = deliverableContractForPhase(phase),
+  weights: Record<QualityDimension, number> = qualityDimensionWeights,
+) {
   const reportAbs = join(workspace.dir, phase.reportPath)
-  if (!(await exists(reportAbs)) && assistantText.trim() !== "") {
-    await mkdir(dirname(reportAbs), { recursive: true })
-    // Write to a temporary path then rename atomically, matching the
-    // metadata.ts pattern (tmp+rename). A crash mid-write must never leave
-    // a truncated report that phaseNeedsRun would treat as complete.
-    const tmpPath = `${reportAbs}.tmp`
-    await writeFile(tmpPath, assistantText)
-    await rename(tmpPath, reportAbs)
+  // Empty text is the human-continue signal ("accept the tree as-is"), not a
+  // report to validate. The phase loop already rejected empty markdown and
+  // invalid scores on the success path; re-checking a blank continue here
+  // would turn an explicit operator accept into a hard failure.
+  if (assistantText.trim() !== "") {
+    const validation = validateDeliverable(contract, assistantText, weights)
+    if (!validation.valid) {
+      await persistInvalidPhaseReport(workspace, phase, undefined, assistantText)
+      throw new DeliverableValidationError(validation.error)
+    }
+    if (!(await exists(reportAbs))) {
+      await mkdir(dirname(reportAbs), { recursive: true })
+      // Write to a temporary path then rename atomically, matching the
+      // metadata.ts pattern (tmp+rename). A crash mid-write must never leave
+      // a truncated report that phaseNeedsRun would treat as complete.
+      const tmpPath = `${reportAbs}.tmp`
+      await writeFile(tmpPath, assistantText)
+      await rename(tmpPath, reportAbs)
+    }
   }
 
   if (!(await exists(reportAbs))) {
@@ -1558,6 +1624,14 @@ async function persistPhaseReport(workspace: Workspace, phase: AgentStep, assist
   }
 
   return reportAbs
+}
+
+/** Keeps rejected assistant output available without allowing it to become the phase report. */
+async function persistInvalidPhaseReport(workspace: Workspace, phase: AgentStep, attempt: number | undefined, assistantText: string) {
+  const reportAbs = join(workspace.dir, phase.reportPath)
+  await mkdir(dirname(reportAbs), { recursive: true })
+  const suffix = attempt === undefined ? Date.now() : attempt
+  await writeFile(`${reportAbs}.attempt-${suffix}.raw.md`, assistantText)
 }
 
 async function commitPhase(phase: AgentStep, reportAbs: string, targetDir: string) {
@@ -1773,6 +1847,8 @@ type SessionResult = {
   info: AssistantMessage
   parts: Part[]
   assistantInfos: AssistantMessage[]
+  /** Parts emitted by the final assistant message only, excluding turn narration. */
+  lastAssistantParts: Part[]
   /** Present only when this attempt consulted an advisor; kept apart from executor usage so the split stays visible. */
   advisorUsage?: readonly AdvisorUsage[]
   advisorEvents?: readonly AdvisorEvent[]
@@ -1843,7 +1919,7 @@ export async function applyCompletionCheckpoint(
     // Propagating it would fail the attempt and roll the finished phase back.
     if (second.info.error) return keepCompletedPhase(input.phase.name, first, formatSdkError(second.info.error))
 
-    const secondText = extractAssistantText(second.parts).trim()
+    const secondText = extractAssistantText(second.lastAssistantParts ?? second.parts).trim()
     const unchanged = secondText.length === 0 || secondText.toUpperCase().startsWith(noChangesReply)
 
     return {
@@ -1852,6 +1928,7 @@ export async function applyCompletionCheckpoint(
       // is only a fallback report, so both turns are kept.
       parts: input.phase.readOnly ? (unchanged ? first.parts : second.parts) : [...first.parts, ...second.parts],
       assistantInfos: [...first.assistantInfos, ...second.assistantInfos],
+      lastAssistantParts: input.phase.readOnly ? (unchanged ? first.lastAssistantParts : second.lastAssistantParts) : second.lastAssistantParts,
     }
   } catch (error) {
     // A guard trip in the follow-up turn is the same decision a trip in the
@@ -2013,6 +2090,7 @@ export function watchSession(
             info: last.info,
             parts: turn.flatMap((message) => message.parts),
             assistantInfos: turn.map((message) => message.info),
+            lastAssistantParts: last.parts,
           },
         })
         return true
@@ -2603,16 +2681,16 @@ async function readRunQualityScore(
     // A scored pipeline that produced no consensus report is a real failure
     // mode (the consensus step crashed or was skipped); log it so a silent
     // "no-score" stop in the goal loop has a cause instead of a mystery.
-    log.warn(`quality score: consensus report not found at ${step.reportPath}; the run produced no machine-readable score`)
+    log.error(`quality score: consensus report not found at ${step.reportPath}; the run produced no machine-readable score`)
     return undefined
   }
   const score = parseQualityScoreReport(text, weights)
   if (!score) {
     // The report exists but failed the strict contract (missing fence,
-    // invalid JSON, out-of-range dimensions, or trailing content after the
-    // block). An excerpt helps diagnose a misbehaving consensus agent.
+    // invalid JSON, or out-of-range dimensions). An excerpt helps diagnose a
+    // misbehaving consensus agent.
     const excerpt = text.slice(0, 120).replace(/\n/g, " ")
-    log.warn(`quality score: consensus report at ${step.reportPath} could not be parsed (malformed or incomplete); the run produced no machine-readable score. Excerpt: ${excerpt}…`)
+    log.error(`quality score: consensus report at ${step.reportPath} could not be parsed (malformed or incomplete); the run produced no machine-readable score. Excerpt: ${excerpt}…`)
     return undefined
   }
   return { score }
@@ -2714,7 +2792,7 @@ export function isMessageAbortedError(error: unknown): error is { name: "Message
   return Boolean(error && typeof error === "object" && "name" in error && error.name === "MessageAbortedError")
 }
 
-function extractAssistantText(parts: Part[]) {
+export function extractAssistantText(parts: readonly Part[]) {
   return parts
     .filter((part): part is Part & { type: "text"; text: string } => part.type === "text")
     .filter((part) => !("synthetic" in part && part.synthetic) && !("ignored" in part && part.ignored))

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1128,8 +1128,13 @@ async function runPhase(
     })
     if (phase.readOnly && baseline) await metadata.phaseRepositoryBaseline(phase.name, baseline)
     const reportAbs = await withReadOnlyRepositoryBoundary(phase, options.targetDir, baseline, gitLock, async () => {
-      const assistantText = await runPhaseUntilResolved(client, workspace, phase, options.targetDir, prepared, baseline, progress, shutdown, gitLock, takeover, undefined, advisors)
-      return persistPhaseReport(workspace, phase, assistantText)
+      const contract = deliverableContractForPhase(phase)
+      // One rubric read shared by the phase loop and the persist step, so the
+      // artifact that persists is always validated with the same weights the
+      // loop accepted it with.
+      const rubricWeights = contract.kind === "quality-score-report" ? ((await loadQualityRubricWeights(options.targetDir)) ?? qualityDimensionWeights) : qualityDimensionWeights
+      const assistantText = await runPhaseUntilResolved(client, workspace, phase, options.targetDir, prepared, baseline, progress, shutdown, gitLock, takeover, undefined, advisors, rubricWeights)
+      return persistPhaseReport(workspace, phase, assistantText, contract, rubricWeights)
     })
     await gitLock(() => finalizePhaseRepository(phase, reportAbs, options.targetDir, baseline))
     progress.phaseCompleted(phase.name, "report saved and commit checked")
@@ -1222,11 +1227,14 @@ export async function runPhaseUntilResolved(
   takeover?: TakeoverContext,
   deps: PhaseRetryDeps = { runPhaseAttempt, restorePhaseBaseline },
   advisors?: AdvisorRuntime,
+  /** The rubric weights used for score validation; shared with persistPhaseReport so both sites agree. */
+  rubricWeights?: Record<QualityDimension, number>,
 ) {
   const sessionRef: SessionRef = {}
   const deliverableContract = deliverableContractForPhase(phase)
-  const rubricWeights =
-    deliverableContract.kind === "quality-score-report" ? ((await loadQualityRubricWeights(targetDir)) ?? qualityDimensionWeights) : qualityDimensionWeights
+  const weights =
+    rubricWeights ??
+    (deliverableContract.kind === "quality-score-report" ? ((await loadQualityRubricWeights(targetDir)) ?? qualityDimensionWeights) : qualityDimensionWeights)
   let automaticDeliverableRetries = 0
   // Read fresh at each decision point: the user can arm/disarm [i] mid-attempt.
   const armed = () => Boolean(takeover && progress.isInteractiveTakeover?.(phase.name))
@@ -1237,22 +1245,49 @@ export async function runPhaseUntilResolved(
     log.info(`[${phase.name}] attempt ${attempt} with ${formatModel(prepared.model)}`)
     try {
       const text = await deps.runPhaseAttempt(client, workspace, phase, targetDir, prepared, attempt, progress, shutdown, sessionRef, advisors)
-      const validation = validateDeliverable(deliverableContract, text, rubricWeights)
+      const validation = validateDeliverable(deliverableContract, text, weights)
       if (!validation.valid) {
         await persistInvalidPhaseReport(workspace, phase, attempt, text)
+        // An armed takeover owns the step even when its deliverable fails
+        // validation: hand it to the user instead of auto-retrying or failing
+        // terminally behind their back.
+        if (armed()) {
+          const outcome = await waitForPhaseGate(phase.name, targetDir, sessionRef.id, takeover, progress, {
+            kind: "interactive",
+            canRetry: false,
+            error: validation.error,
+            signal: shutdown.signal,
+            onAbort: () => {
+              if (!shutdown.aborted) shutdown.request("phase gate abort")
+            },
+            runner: phase.runner,
+            runDir: workspace.dir,
+          })
+          // "continue": the user owns the tree and accepts it as-is, so nothing
+          // is committed from this attempt. "unavailable": nobody can take over,
+          // so the automatic policy below applies.
+          if (outcome === "continue") return ""
+        }
+        const totalAttempts = deliverableContract.kind === "quality-score-report" ? deliverableContract.retryOnMissingOrInvalid + 1 : undefined
+        const attemptContext = totalAttempts === undefined ? `attempt ${attempt}` : `attempt ${attempt} of ${totalAttempts}`
         const canRetryAutomatically =
           deliverableContract.kind === "quality-score-report" && automaticDeliverableRetries < deliverableContract.retryOnMissingOrInvalid
         if (canRetryAutomatically) {
           automaticDeliverableRetries++
           log.warn(
-            `[${phase.name}] deliverable validation failed (attempt ${attempt}/${deliverableContract.retryOnMissingOrInvalid + 1}): ${validation.error}; retrying automatically`,
+            `[${phase.name}] deliverable validation failed (${attemptContext}): ${validation.error}; retrying automatically`,
           )
           await gitLock(() => deps.restorePhaseBaseline(phase, baseline, targetDir, new DeliverableValidationError(validation.error)))
           await removePhaseReport(workspace, phase)
           continue
         }
-        log.error(`[${phase.name}] deliverable validation failed: ${validation.error}`)
-        throw new DeliverableValidationError(validation.error)
+        log.error(`[${phase.name}] deliverable validation failed (${attemptContext}): ${validation.error}`)
+        // Only the scored contract is terminal by policy: accepting a missing
+        // score through the human failure gate would complete a scored run with
+        // no machine-readable result. A markdown-report failure is an ordinary
+        // attempt failure — the human gate ([r]/[o]/[a]) decides.
+        if (deliverableContract.kind === "quality-score-report") throw new DeliverableValidationError(validation.error)
+        throw new Error(validation.error)
       }
       if (armed()) {
         // Armed means "this step is mine": even a clean finish waits for the
@@ -1272,10 +1307,12 @@ export async function runPhaseUntilResolved(
       return text
     } catch (error) {
       if (shutdown.aborted || isUserAbortError(error)) throw shutdown.abortError(error)
-      // A report-contract failure is terminal after its bounded automatic retry;
-      // accepting it through the human failure gate would turn a missing score
-      // into a successful scored run with no machine-readable result.
-      if (error instanceof DeliverableValidationError) throw error
+      // A scored-contract failure is terminal after its bounded automatic retry:
+      // accepting a missing score through the human failure gate would turn a
+      // missing score into a successful scored run with no machine-readable
+      // result. Other contract failures (empty markdown) are ordinary attempt
+      // failures and reach the gate like any other failed attempt.
+      if (error instanceof DeliverableValidationError && deliverableContract.kind === "quality-score-report") throw error
       if (!(error instanceof LoggedAttemptError)) await writeAttemptLog(workspace, phase, attempt, { error: formatSdkError(error) })
       progress.phaseRunning(phase.name, "step failed — waiting for your decision")
       log.warn(`[${phase.name}] attempt ${attempt} failed: ${formatSdkError(error)}`)
@@ -1543,7 +1580,7 @@ async function executeOpenCodePhaseAttempt(input: PhaseAttemptInput): Promise<Ph
     loopGuardConfig: input.prepared.loopGuard,
     ...(input.advisors ? { advisors: input.advisors } : {}),
   })
-  const assistantText = extractAssistantText(result.lastAssistantParts ?? result.parts)
+  const assistantText = extractAssistantText(result.lastAssistantParts)
   // Totals for the whole attempt, not the final message: the attempt log's
   // executor figures are what the advisor split is measured against, and a
   // headline ratio computed from one message of a many-message phase would
@@ -1590,6 +1627,21 @@ async function executeClaudeCodePhaseAttempt(input: PhaseAttemptInput): Promise<
   }
 }
 
+/** Validates a candidate deliverable; on failure keeps it as forensics and throws. */
+async function ensureValidDeliverable(
+  workspace: Workspace,
+  phase: AgentStep,
+  contract: DeliverableContract,
+  weights: Record<QualityDimension, number>,
+  candidate: string,
+) {
+  const validation = validateDeliverable(contract, candidate, weights)
+  if (!validation.valid) {
+    await persistInvalidPhaseReport(workspace, phase, undefined, candidate)
+    throw new DeliverableValidationError(validation.error)
+  }
+}
+
 async function persistPhaseReport(
   workspace: Workspace,
   phase: AgentStep,
@@ -1598,28 +1650,25 @@ async function persistPhaseReport(
   weights: Record<QualityDimension, number> = qualityDimensionWeights,
 ) {
   const reportAbs = join(workspace.dir, phase.reportPath)
-  // Empty text is the human-continue signal ("accept the tree as-is"), not a
-  // report to validate. The phase loop already rejected empty markdown and
-  // invalid scores on the success path; re-checking a blank continue here
-  // would turn an explicit operator accept into a hard failure.
-  if (assistantText.trim() !== "") {
-    const validation = validateDeliverable(contract, assistantText, weights)
-    if (!validation.valid) {
-      await persistInvalidPhaseReport(workspace, phase, undefined, assistantText)
-      throw new DeliverableValidationError(validation.error)
-    }
-    if (!(await exists(reportAbs))) {
-      await mkdir(dirname(reportAbs), { recursive: true })
-      // Write to a temporary path then rename atomically, matching the
-      // metadata.ts pattern (tmp+rename). A crash mid-write must never leave
-      // a truncated report that phaseNeedsRun would treat as complete.
-      const tmpPath = `${reportAbs}.tmp`
-      await writeFile(tmpPath, assistantText)
-      await rename(tmpPath, reportAbs)
-    }
-  }
-
-  if (!(await exists(reportAbs))) {
+  // Validate exactly what will persist. An existing report file is the artifact
+  // — a writable phase wrote it itself, or an earlier run left it — so the file
+  // is validated, not the fallback text: a stale or malformed file must never
+  // stand as the phase's deliverable just because the fallback happened to pass.
+  if (await exists(reportAbs)) {
+    await ensureValidDeliverable(workspace, phase, contract, weights, await readFile(reportAbs, "utf8"))
+  } else if (assistantText.trim() !== "") {
+    // No report yet: the fallback text becomes the report, so validate it first.
+    await ensureValidDeliverable(workspace, phase, contract, weights, assistantText)
+    await mkdir(dirname(reportAbs), { recursive: true })
+    // Write to a temporary path then rename atomically, matching the
+    // metadata.ts pattern (tmp+rename). A crash mid-write must never leave
+    // a truncated report that phaseNeedsRun would treat as complete.
+    const tmpPath = `${reportAbs}.tmp`
+    await writeFile(tmpPath, assistantText)
+    await rename(tmpPath, reportAbs)
+  } else {
+    // Empty text is the human-continue signal ("accept the tree as-is") and no
+    // report exists either: there is nothing to validate or persist.
     log.warn(`[${phase.name}] agent didn't write the expected report at ${reportAbs}`)
   }
 
@@ -1919,7 +1968,7 @@ export async function applyCompletionCheckpoint(
     // Propagating it would fail the attempt and roll the finished phase back.
     if (second.info.error) return keepCompletedPhase(input.phase.name, first, formatSdkError(second.info.error))
 
-    const secondText = extractAssistantText(second.lastAssistantParts ?? second.parts).trim()
+    const secondText = extractAssistantText(second.lastAssistantParts).trim()
     const unchanged = secondText.length === 0 || secondText.toUpperCase().startsWith(noChangesReply)
 
     return {
@@ -1928,7 +1977,10 @@ export async function applyCompletionCheckpoint(
       // is only a fallback report, so both turns are kept.
       parts: input.phase.readOnly ? (unchanged ? first.parts : second.parts) : [...first.parts, ...second.parts],
       assistantInfos: [...first.assistantInfos, ...second.assistantInfos],
-      lastAssistantParts: input.phase.readOnly ? (unchanged ? first.lastAssistantParts : second.lastAssistantParts) : second.lastAssistantParts,
+      // An unchanged follow-up means the first turn still holds the report, for
+      // a writing phase too: the NO CHANGES sentinel must never become the phase
+      // report through the text-fallback channel.
+      lastAssistantParts: unchanged ? first.lastAssistantParts : second.lastAssistantParts,
     }
   } catch (error) {
     // A guard trip in the follow-up turn is the same decision a trip in the

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -91,7 +91,9 @@ export async function loadRunSummary(run: RunEntry): Promise<string> {
 
   let reports: string[] = []
   try {
-    reports = (await readdir(join(run.dir, "reports"))).filter((name) => name.endsWith(".md")).sort()
+    // Forensic copies of rejected deliverables (persistInvalidPhaseReport) end
+    // in .raw.md; they must never render as phase reports in the summary.
+    reports = (await readdir(join(run.dir, "reports"))).filter((name) => name.endsWith(".md") && !name.endsWith(".raw.md")).sort()
   } catch {
     // no reports dir
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -190,6 +190,17 @@ export type AgentSpec = {
  */
 export type StepRunner = Exclude<StepRunnerId, "opencode">
 
+/** The report shape a phase must produce before Convoy accepts it as complete. */
+export type DeliverableContract =
+  | { kind: "none" }
+  | { kind: "markdown-report" }
+  | {
+      kind: "quality-score-report"
+      schemaVersion: 1
+      /** Automatic retries after a missing or malformed machine-readable score. */
+      retryOnMissingOrInvalid: 1
+    }
+
 export type AgentStep = {
   type: "agent"
   name: string
@@ -216,6 +227,11 @@ export type AgentStep = {
   inputFiles: readonly string[]
   inputDiff: boolean
   reportPath: string
+  /**
+   * The report contract resolved for this phase. Optional so run metadata from
+   * before contracts were introduced remains readable and executable.
+   */
+  deliverableContract?: DeliverableContract
   /** True when the underlying agent is configured as read-only, or forced read-only for parallel/multi-model execution. */
   readOnly?: boolean
   /**

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -9,6 +9,9 @@ import {
   defaultImplementReviewModel,
   defaultOpusModel,
   defaultPipeline,
+  defaultDeliverableContract,
+  deliverableContractForPhase,
+  qualityScoreDeliverableContract,
   resolvePipeline,
   slugifyModel,
   splitModelVariant,
@@ -20,7 +23,7 @@ import {
   verifyAgentSuffix,
   type PipelineSpec,
 } from "../src/pipeline"
-import type { AgentStep } from "../src/types"
+import type { AgentStep, DeliverableContract } from "../src/types"
 
 const resolve = (spec: PipelineSpec, defaultModel?: string) =>
   resolvePipeline({ name: "test", spec, agents: builtInAgents, defaultModel })
@@ -1170,5 +1173,72 @@ describe("advisor resolution", () => {
 
     expect(steps).toHaveLength(2)
     for (const step of steps) expect(step.advisor).toBe("anthropic/claude-opus-5")
+  })
+})
+
+describe("deliverable contracts", () => {
+  test("the quality-score contract is a v1 schema with a single automatic retry", () => {
+    expect(qualityScoreDeliverableContract).toEqual({
+      kind: "quality-score-report",
+      schemaVersion: 1,
+      retryOnMissingOrInvalid: 1,
+    })
+  })
+
+  test("defaultDeliverableContract selects the quality-score contract for the scorer agent", () => {
+    expect(defaultDeliverableContract("quality-score-report", false)).toEqual(qualityScoreDeliverableContract)
+    // read-only status does not change the scorer's contract: it is always a
+    // scored report, never a plain markdown report.
+    expect(defaultDeliverableContract("quality-score-report", true)).toEqual(qualityScoreDeliverableContract)
+  })
+
+  test("defaultDeliverableContract selects markdown-report for read-only phases and none for writable phases", () => {
+    expect(defaultDeliverableContract("review-scope", true)).toEqual({ kind: "markdown-report" })
+    expect(defaultDeliverableContract("implementer", false)).toEqual({ kind: "none" })
+    // a writable agent that happens to be read-only still gets markdown-report
+    expect(defaultDeliverableContract("implementer", true)).toEqual({ kind: "markdown-report" })
+  })
+
+  test("deliverableContractForPhase prefers an explicit contract over the inferred default", () => {
+    const explicit: DeliverableContract = { kind: "none" }
+    const phase = {
+      agentName: "quality-score-report",
+      readOnly: true,
+      deliverableContract: explicit,
+    }
+    expect(deliverableContractForPhase(phase)).toBe(explicit)
+  })
+
+  test("deliverableContractForPhase falls back to the inferred default for legacy metadata without a contract", () => {
+    // Run metadata persisted before contracts existed has no deliverableContract
+    // field; the resolver must still infer the right contract so historical runs
+    // stay readable and executable.
+    expect(deliverableContractForPhase({ agentName: "quality-score-report", readOnly: true })).toEqual(qualityScoreDeliverableContract)
+    expect(deliverableContractForPhase({ agentName: "review-scope", readOnly: true })).toEqual({ kind: "markdown-report" })
+    expect(deliverableContractForPhase({ agentName: "implementer", readOnly: false })).toEqual({ kind: "none" })
+  })
+
+  test("a resolved review pipeline gives the scorer the quality-score contract and read-only audits the markdown-report contract", () => {
+    const steps = agentSteps(builtInPipelines.review!)
+    const byName = Object.fromEntries(steps.map((step) => [step.name, step]))
+
+    // The consensus step is the scored deliverable.
+    expect(byName["score-report"]?.deliverableContract).toEqual(qualityScoreDeliverableContract)
+    expect(byName["score-report"]?.readOnly).toBe(true)
+
+    // Read-only report phases produce a markdown report, not a score.
+    expect(byName["scope"]?.deliverableContract).toEqual({ kind: "markdown-report" })
+    expect(byName["report"]?.deliverableContract).toEqual({ kind: "markdown-report" })
+
+    // A writable phase (none in review, but the default pipeline's implementer
+    // is writable) gets the none contract: Convoy does not gate its deliverable.
+    const defaultSteps = Object.fromEntries(
+      defaultPipeline()
+        .steps.filter((step): step is AgentStep => step.type === "agent")
+        .map((step) => [step.name, step]),
+    )
+    expect(defaultSteps["implementer"]?.deliverableContract).toEqual({ kind: "none" })
+    // readOnly is only set when true; a writable phase leaves it undefined.
+    expect(defaultSteps["implementer"]?.readOnly).toBeFalsy()
   })
 })

--- a/test/quality-score.test.ts
+++ b/test/quality-score.test.ts
@@ -111,9 +111,9 @@ prd 92, tests 70, security 95, maintainability 88, operational 90, scope 85
     expect(parseQualityScoreReport(report)?.score).toBe(87)
   })
 
-  test("rejects a report where the final block is not at the end", () => {
+  test("parses a report where the final block is followed by text", () => {
     const report = `\`\`\`quality-score\n${JSON.stringify({ score: 80, dimensions, mustFix: [] })}\n\`\`\`\n\n(aside: the run is done)`
-    expect(parseQualityScoreReport(report)).toBeUndefined()
+    expect(parseQualityScoreReport(report)?.score).toBe(87)
   })
 
   test("never treats a bare object with braces inside strings as a score block", () => {

--- a/test/reproduction.test.ts
+++ b/test/reproduction.test.ts
@@ -300,7 +300,9 @@ describe("HN-003: persistPhaseReport now uses tmp+rename (fix)", () => {
     //   const tmpPath = `${reportAbs}.tmp`
     //   await writeFile(tmpPath, assistantText)
     //   await rename(tmpPath, reportAbs)
-    const persistSection = source.match(/async function persistPhaseReport[\s\S]{1,600}/)
+    // Contract validation and the empty-continue skip sit above the atomic
+    // write, so the window has to cover that preamble plus tmp+rename.
+    const persistSection = source.match(/async function persistPhaseReport[\s\S]{1,1800}/)
     expect(persistSection).not.toBeNull()
     expect(persistSection![0]).toContain(".tmp")
     expect(persistSection![0]).toContain("rename(tmpPath, reportAbs)")

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -21,6 +21,7 @@ import {
   defaultMaxConcurrentAgents,
   describeMessageChunk,
   describeSessionActivity,
+  extractAssistantText,
   finalizePhaseRepository,
   isIgnorableRejection,
   isMessageAbortedError,
@@ -36,11 +37,12 @@ import {
   restorePhaseFromPreviousRun,
   selectInterruptedPhase,
   shouldSkip,
+  validateDeliverable,
   watchSession,
   withReadOnlyRepositoryBoundary,
   type ActiveSession,
 } from "../src/runner"
-import type { AgentStep, HumanStep, Pipeline, Step } from "../src/types"
+import type { AgentStep, DeliverableContract, HumanStep, Pipeline, Step } from "../src/types"
 import type { Workspace } from "../src/workspace"
 import { LoopGuard, LoopGuardError, resolveLoopGuard } from "../src/loop-guard"
 
@@ -124,6 +126,62 @@ function assistantInfo(id: string, cost: number, input: number, output: number) 
 }
 
 describe("runner helpers", () => {
+  test("extracts a report only from the last assistant message", () => {
+    const lastAssistantParts = [
+      { type: "text", text: "# Final report" },
+      { type: "text", text: "internal synthetic text", synthetic: true },
+      { type: "text", text: "ignored text", ignored: true },
+    ] as never[]
+
+    expect(extractAssistantText(lastAssistantParts)).toBe("# Final report")
+  })
+
+  test("returns an empty report when the last assistant message has no usable text", () => {
+    const lastAssistantParts = [
+      { type: "text", text: "synthetic", synthetic: true },
+      { type: "text", text: "ignored", ignored: true },
+    ] as never[]
+
+    expect(extractAssistantText(lastAssistantParts)).toBe("")
+  })
+
+  test("validateDeliverable: the none contract accepts any text, including empty", () => {
+    // A writable phase (implementer) is not gated on its report shape, so an
+    // empty continue or any text is valid.
+    const none: DeliverableContract = { kind: "none" }
+    expect(validateDeliverable(none, "")).toEqual({ valid: true })
+    expect(validateDeliverable(none, "# anything")).toEqual({ valid: true })
+  })
+
+  test("validateDeliverable: the markdown-report contract accepts non-empty text and rejects empty text", () => {
+    const markdown: DeliverableContract = { kind: "markdown-report" }
+    expect(validateDeliverable(markdown, "# report")).toEqual({ valid: true })
+    // whitespace-only is also empty: a blank report would let a read-only phase
+    // pass as if it had produced findings.
+    expect(validateDeliverable(markdown, "   \n\t ")).toEqual({ valid: false, error: "phase produced an empty report" })
+    expect(validateDeliverable(markdown, "")).toEqual({ valid: false, error: "phase produced an empty report" })
+  })
+
+  test("validateDeliverable: the quality-score-report contract accepts a valid score block", () => {
+    const score: DeliverableContract = { kind: "quality-score-report", schemaVersion: 1, retryOnMissingOrInvalid: 1 }
+    const valid = `\`\`\`quality-score\n${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainability: 90, operational: 90, scope: 90 }, mustFix: [] })}\n\`\`\``
+    expect(validateDeliverable(score, valid)).toEqual({ valid: true })
+  })
+
+  test("validateDeliverable: the quality-score-report contract rejects a missing score block", () => {
+    const score: DeliverableContract = { kind: "quality-score-report", schemaVersion: 1, retryOnMissingOrInvalid: 1 }
+    const result = validateDeliverable(score, "# no score block here")
+    expect(result.valid).toBe(false)
+    expect(result.valid === false && result.error).toBe("phase produced an invalid quality-score report")
+  })
+
+  test("validateDeliverable: the quality-score-report contract rejects malformed score JSON", () => {
+    const score: DeliverableContract = { kind: "quality-score-report", schemaVersion: 1, retryOnMissingOrInvalid: 1 }
+    const result = validateDeliverable(score, "```quality-score\nnot json\n```")
+    expect(result.valid).toBe(false)
+    expect(result.valid === false && result.error).toBe("phase produced an invalid quality-score report")
+  })
+
   test("preserves OpenCode message aborts as typed session cancellations", () => {
     const error = { name: "MessageAbortedError" as const, data: { message: "stopped" } }
     expect(isMessageAbortedError(error)).toBeTrue()
@@ -671,6 +729,120 @@ describe("run phase gate", () => {
     expect(restores).toBe(2)
     expect(prompts).toHaveLength(2)
     expect(prompts.every((p) => p.kind === "failure" && p.canRetry === true)).toBe(true)
+  })
+
+  const validQualityScoreReport = `\`\`\`quality-score
+${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainability: 90, operational: 90, scope: 90 }, mustFix: [] })}
+\`\`\``
+
+  function qualityScorePhase() {
+    return {
+      ...agentStep("score-report"),
+      agentName: "quality-score-report",
+      readOnly: true,
+      deliverableContract: { kind: "quality-score-report" as const, schemaVersion: 1 as const, retryOnMissingOrInvalid: 1 as const },
+    }
+  }
+
+  test("a missing quality score retries once without opening the human failure gate", async () => {
+    const attempts: number[] = []
+    let restores = 0
+    const workspace = await retryWorkspace()
+    const progress: ProgressUI = {
+      ...noopProgress,
+      askHumanReview: () => {
+        throw new Error("quality-score validation must retry automatically")
+      },
+    }
+
+    const result = await runPhaseUntilResolved(
+      {} as never,
+      workspace,
+      qualityScorePhase(),
+      "/repo",
+      prepared,
+      { head: "baseline" },
+      progress,
+      new RunShutdown(),
+      createGitLock(),
+      { serverUrl: "http://127.0.0.1:1" },
+      {
+        runPhaseAttempt: async (_client, _workspace, _phase, _targetDir, _prepared, attempt) => {
+          attempts.push(attempt)
+          return attempt === 1 ? "# no score block" : validQualityScoreReport
+        },
+        restorePhaseBaseline: async () => {
+          restores++
+        },
+      },
+    )
+
+    expect(result).toBe(validQualityScoreReport)
+    expect(attempts).toEqual([1, 2])
+    expect(restores).toBe(1)
+  })
+
+  test("an invalid quality score retries once and then fails explicitly", async () => {
+    const attempts: number[] = []
+    const workspace = await retryWorkspace()
+    const progress: ProgressUI = {
+      ...noopProgress,
+      askHumanReview: () => {
+        throw new Error("quality-score validation must not wait for a human gate")
+      },
+    }
+
+    await expect(
+      runPhaseUntilResolved(
+        {} as never,
+        workspace,
+        qualityScorePhase(),
+        "/repo",
+        prepared,
+        { head: "baseline" },
+        progress,
+        new RunShutdown(),
+        createGitLock(),
+        { serverUrl: "http://127.0.0.1:1" },
+        {
+          runPhaseAttempt: async (_client, _workspace, _phase, _targetDir, _prepared, attempt) => {
+            attempts.push(attempt)
+            return "```quality-score\nnot json\n```"
+          },
+          restorePhaseBaseline: async () => {},
+        },
+      ),
+    ).rejects.toThrow("invalid quality-score report")
+
+    expect(attempts).toEqual([1, 2])
+  })
+
+  test("a valid quality score completes without a retry", async () => {
+    const attempts: number[] = []
+    const workspace = await retryWorkspace()
+
+    const result = await runPhaseUntilResolved(
+      {} as never,
+      workspace,
+      qualityScorePhase(),
+      "/repo",
+      prepared,
+      { head: "baseline" },
+      noopProgress,
+      new RunShutdown(),
+      createGitLock(),
+      { serverUrl: "http://127.0.0.1:1" },
+      {
+        runPhaseAttempt: async (_client, _workspace, _phase, _targetDir, _prepared, attempt) => {
+          attempts.push(attempt)
+          return validQualityScoreReport
+        },
+        restorePhaseBaseline: async () => {},
+      },
+    )
+
+    expect(result).toBe(validQualityScoreReport)
+    expect(attempts).toEqual([1])
   })
 
   test("abort throws UserAbortError and requests a run-wide shutdown", async () => {
@@ -1608,6 +1780,7 @@ describe("watchSession turn scoping", () => {
 
     expect(result.assistantInfos.map((info) => info.id)).toEqual(["msg_2"])
     expect(result.parts).toHaveLength(1)
+    expect(result.lastAssistantParts).toHaveLength(1)
     // The sentinel is unreachable if the first turn's report is still in front of it.
     expect((result.parts[0] as { text: string }).text).toBe("NO CHANGES")
     expect(result.info.id).toBe("msg_2")
@@ -1618,6 +1791,7 @@ describe("watchSession turn scoping", () => {
 
     expect(result.assistantInfos.map((info) => info.id)).toEqual(["msg_1", "msg_2"])
     expect(result.parts).toHaveLength(2)
+    expect(result.lastAssistantParts).toHaveLength(1)
   })
 
   test("aborts the session when the loop guard sees the same tool call over and over", async () => {
@@ -1832,6 +2006,128 @@ describe("loopGuard seam regressions", () => {
         advisor as never,
       ),
     ).rejects.toBeInstanceOf(LoopGuardError)
+  })
+})
+
+/**
+ * The completion checkpoint's second turn decides whether the report comes
+ * from the first or the second turn. lastAssistantParts must follow that
+ * decision so extractAssistantText never concatenates the first turn's report
+ * onto the second's (the narrative-contamination bug this phase fixes).
+ */
+describe("applyCompletionCheckpoint lastAssistantParts", () => {
+  const completedMessage = (id: string, text: string) => ({
+    info: {
+      id,
+      sessionID: "ses_1",
+      role: "assistant" as const,
+      time: { created: 1, completed: 2 },
+      parentID: "p",
+      modelID: "gpt-5.5",
+      providerID: "openai",
+      mode: "primary",
+      agent: "implementer",
+      path: { cwd: "/repo", root: "/repo" },
+      cost: 1,
+      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [{ id: `${id}_p`, sessionID: "ses_1", messageID: id, type: "text" as const, text }],
+  })
+
+  function firstResult(text: string) {
+    const info = {
+      id: "msg_1",
+      sessionID: "ses_1",
+      role: "assistant" as const,
+      time: { created: 1, completed: 2 },
+      parentID: "p",
+      modelID: "gpt-5.5",
+      providerID: "openai",
+      mode: "primary",
+      agent: "implementer",
+      path: { cwd: "/repo", root: "/repo" },
+      cost: 1,
+      tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+    }
+    const parts = [{ id: "msg_1_p", sessionID: "ses_1", messageID: "msg_1", type: "text" as const, text }]
+    return { info, parts, assistantInfos: [info], lastAssistantParts: parts } as never
+  }
+
+  function checkpointClient(secondMessage: { info: Record<string, unknown> }) {
+    async function* stream() {
+      yield messageUpdated(secondMessage.info)
+      yield { type: "session.idle", properties: { sessionID: "ses_1" } }
+      await new Promise<void>(() => {})
+    }
+    return {
+      event: { subscribe: async () => ({ stream: stream() }) },
+      session: {
+        messages: async () => ({ data: [secondMessage] }),
+        status: async () => ({ data: {} }),
+        promptAsync: async () => ({}),
+        abort: async () => ({}),
+      },
+    } as never
+  }
+
+  const advisor = {
+    consult: async () => ({ text: "review it", ok: true as const, callId: "call_1" }),
+    delivered: async () => {},
+  } as never
+
+  const baseInput = (phase: AgentStep) => ({
+    phase,
+    targetDir: "/repo",
+    model: { providerID: "openai", modelID: "gpt-5.5" },
+    progress: noopProgress,
+    shutdown: new RunShutdown(),
+    sessionID: "ses_1",
+    loopGuard: new LoopGuard(resolveLoopGuard()),
+  })
+
+  test("a read-only phase with an unchanged follow-up keeps the first turn's last parts", async () => {
+    const second = completedMessage("msg_2", "NO CHANGES")
+    const result = await applyCompletionCheckpoint(
+      checkpointClient(second),
+      baseInput({ ...agentStep("scope"), readOnly: true }),
+      firstResult("first report"),
+      advisor,
+    )
+
+    // unchanged → the read-only report stays the first turn's findings; the
+    // sentinel must not become the report.
+    expect(result.lastAssistantParts).toHaveLength(1)
+    expect((result.lastAssistantParts[0] as { text: string }).text).toBe("first report")
+  })
+
+  test("a read-only phase with a corrected report uses the second turn's last parts", async () => {
+    const second = completedMessage("msg_2", "# corrected report")
+    const result = await applyCompletionCheckpoint(
+      checkpointClient(second),
+      baseInput({ ...agentStep("scope"), readOnly: true }),
+      firstResult("first report"),
+      advisor,
+    )
+
+    // a new report replaces the first: read-only uses second.lastAssistantParts.
+    expect(result.lastAssistantParts).toHaveLength(1)
+    expect((result.lastAssistantParts[0] as { text: string }).text).toBe("# corrected report")
+  })
+
+  test("a writable phase always reports from the second turn's last parts", async () => {
+    const second = completedMessage("msg_2", "NO CHANGES")
+    const result = await applyCompletionCheckpoint(
+      checkpointClient(second),
+      baseInput(agentStep("implementer")),
+      firstResult("first report"),
+      advisor,
+    )
+
+    // a writing phase keeps both turns' parts (fallback report) but the report
+    // extract comes from the second turn only.
+    expect(result.lastAssistantParts).toHaveLength(1)
+    expect((result.lastAssistantParts[0] as { text: string }).text).toBe("NO CHANGES")
+    expect(result.parts).toHaveLength(2)
   })
 })
 

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -845,6 +845,98 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
     expect(attempts).toEqual([1])
   })
 
+  test("an empty markdown report reaches the human failure gate instead of failing terminally", async () => {
+    const attempts: number[] = []
+    const prompts: HumanReviewPromptInfo[] = []
+    let restores = 0
+    const workspace = await retryWorkspace()
+    const progress: ProgressUI = {
+      ...noopProgress,
+      askHumanReview: (info) => {
+        prompts.push(info)
+        return Promise.resolve("continue")
+      },
+    }
+    const phase = { ...agentStep("scope"), readOnly: true, deliverableContract: { kind: "markdown-report" } as const }
+
+    const result = await runPhaseUntilResolved(
+      {} as never,
+      workspace,
+      phase,
+      "/repo",
+      prepared,
+      { head: "baseline" },
+      progress,
+      new RunShutdown(),
+      createGitLock(),
+      { serverUrl: "http://127.0.0.1:1" },
+      {
+        runPhaseAttempt: async (_client, _workspace, _phase, _targetDir, _prepared, attempt) => {
+          attempts.push(attempt)
+          return ""
+        },
+        restorePhaseBaseline: async () => {
+          restores++
+        },
+      },
+    )
+
+    // SC-1: an empty read-only report is an ordinary attempt failure — the human
+    // gate decides ([r]/[o]/[a]) instead of a terminal throw with no recourse.
+    expect(result).toBe("")
+    expect(attempts).toEqual([1])
+    expect(restores).toBe(0)
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]?.kind).toBe("failure")
+    expect(prompts[0]?.canRetry).toBe(true)
+  })
+
+  test("an armed takeover owns an invalid deliverable and presents it interactively", async () => {
+    const attempts: number[] = []
+    const prompts: HumanReviewPromptInfo[] = []
+    let restores = 0
+    const workspace = await retryWorkspace()
+    const progress: ProgressUI = {
+      ...noopProgress,
+      isInteractiveTakeover: () => true,
+      askHumanReview: (info) => {
+        prompts.push(info)
+        return Promise.resolve("continue")
+      },
+    }
+
+    const result = await runPhaseUntilResolved(
+      {} as never,
+      workspace,
+      qualityScorePhase(),
+      "/repo",
+      prepared,
+      { head: "baseline" },
+      progress,
+      new RunShutdown(),
+      createGitLock(),
+      { serverUrl: "http://127.0.0.1:1" },
+      {
+        runPhaseAttempt: async (_client, _workspace, _phase, _targetDir, _prepared, attempt) => {
+          attempts.push(attempt)
+          return "# no score block"
+        },
+        restorePhaseBaseline: async () => {
+          restores++
+        },
+      },
+    )
+
+    // SC-2: armed means the step is the user's — an invalid deliverable is shown
+    // to them interactively, not auto-retried or terminally thrown behind their back.
+    expect(result).toBe("")
+    expect(attempts).toEqual([1])
+    expect(restores).toBe(0)
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]?.kind).toBe("interactive")
+    expect(prompts[0]?.canRetry).toBe(false)
+  })
+
   test("abort throws UserAbortError and requests a run-wide shutdown", async () => {
     const workspace = await retryWorkspace()
     const progress: ProgressUI = {
@@ -2114,7 +2206,7 @@ describe("applyCompletionCheckpoint lastAssistantParts", () => {
     expect((result.lastAssistantParts[0] as { text: string }).text).toBe("# corrected report")
   })
 
-  test("a writable phase always reports from the second turn's last parts", async () => {
+  test("a writable phase with an unchanged follow-up keeps the first turn's last parts", async () => {
     const second = completedMessage("msg_2", "NO CHANGES")
     const result = await applyCompletionCheckpoint(
       checkpointClient(second),
@@ -2123,10 +2215,11 @@ describe("applyCompletionCheckpoint lastAssistantParts", () => {
       advisor,
     )
 
-    // a writing phase keeps both turns' parts (fallback report) but the report
-    // extract comes from the second turn only.
+    // A writing phase keeps both turns' parts (fallback report), but the report
+    // extract comes from the first turn: the NO CHANGES sentinel must never
+    // become the phase report through the text-fallback channel.
     expect(result.lastAssistantParts).toHaveLength(1)
-    expect((result.lastAssistantParts[0] as { text: string }).text).toBe("NO CHANGES")
+    expect((result.lastAssistantParts[0] as { text: string }).text).toBe("first report")
     expect(result.parts).toHaveLength(2)
   })
 })

--- a/test/runs-extended.test.ts
+++ b/test/runs-extended.test.ts
@@ -74,6 +74,22 @@ describe("loadRunSummary", () => {
     expect(await loadRunSummary(entry)).toBe("no summary or reports for this run")
   })
 
+  test("excludes rejected attempt forensics from the fallback report summary", async () => {
+    const dir = join(root, "has-forensics")
+    await mkdir(join(dir, "reports"), { recursive: true })
+    await writeFile(join(dir, "reports", "scope.md"), "## Scope findings")
+    await writeFile(join(dir, "reports", "scope.md.attempt-1.raw.md"), "rejected output must not render")
+
+    const entry = fakeEntry(dir)
+    const result = await loadRunSummary(entry)
+
+    // SC-4: .attempt-*.raw.md forensics are not phase reports and must not
+    // appear in the run summary.
+    expect(result).toContain("## reports/scope.md")
+    expect(result).not.toContain("attempt-1")
+    expect(result).not.toContain("rejected output")
+  })
+
   test("returns reports that exist when SUMMARY.md exists but is only empty", async () => {
     const dir = join(root, "empty-summary")
     await mkdir(join(dir, "reports"), { recursive: true })


### PR DESCRIPTION
## What

Hardens phase-report extraction so a phase's deliverable is the machine-readable artifact the pipeline actually validates, not whatever text happened to survive an attempt.

**Extraction**
- `extractAssistantText` now reads **only the final assistant message** (`lastAssistantParts`), so turn narration, handoff chatter, and earlier drafts can never become the phase report; the NO CHANGES sentinel in an unchanged follow-up can no longer replace the real report either.
- Quality-score parsing tolerates trailing text after the final `quality-score` block (agents append delivery narration) instead of discarding a valid score; a contract warning is logged.

**Validation**
- New `DeliverableContract` (`none` | `markdown-report` | `quality-score-report` with `schemaVersion` + bounded `retryOnMissingOrInvalid`) is resolved per phase (`deliverableContractForPhase`), with a fallback for legacy run metadata recorded before contracts existed.
- `validateDeliverable` checks the artifact before it persists; the phase loop and the persist step share the same rubric weights so what's accepted is what's saved.
- An existing report file is itself validated — a stale or malformed file can never stand as the deliverable just because the fallback text passed.

**Failure handling**
- Scored contracts get a single automatic retry (baseline restored, invalid report removed), then fail terminally: completing a scored run with no machine-readable score is rejected instead of gated through.
- Empty markdown reports are ordinary attempt failures that reach the human failure gate (`[r]/[o]/[a]`), and an armed interactive takeover owns an invalid deliverable even when validation fails.
- Rejected attempts are preserved as forensic `.raw.md` files that are excluded from run summaries, so evidence survives without rendering as a phase report.

## Why

Previously a phase's report could be extracted from the wrong message or validated inconsistently, and a missing/malformed score could slip through as a successful scored run. The retry (`r` on a failed run), takeover, and summary paths all depended on the persisted artifact being the real one.

## Tests

Expanded coverage in `test/runner.test.ts`, `test/pipeline.test.ts`, `test/quality-score.test.ts`, `test/reproduction.test.ts`, and `test/runs-extended.test.ts`, including:
- extraction only from the final assistant message (read-only and writable phases, unchanged vs. corrected follow-ups)
- contract resolution for scorer/read-only/writable phases and legacy metadata
- quality-score parsing with trailing text
- missing/invalid score -> single auto-retry -> explicit failure; valid score -> no retry
- empty markdown report -> human failure gate; armed takeover ownership of invalid deliverables
- rejected-attempt forensics excluded from fallback summaries

## Verification

- `bun run typecheck` — clean
- `bun test` — full suite pass
