### PR TITLE
fix(worktree): name branches from the PRD, default namer to DeepSeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ defaults:
   baseRef: main                    # optional; auto-detected when unset (origin default branch, else main/master/develop/trunk, else current branch)
   pipeline: quick                  # pipeline used when -p/--pipeline is not given
   autoAcceptJudgeModel: anthropic/claude-haiku-4-5   # model for smart auto-accept (--smart); defaults to the run's model
-  branchNameModel: anthropic/claude-haiku-4-5        # proposes worktree branch names (may look up referenced issues); you confirm the name
+  branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731  # proposes worktree branch names (may look up referenced issues); you confirm the name
   commitMessageModel: anthropic/claude-haiku-4-5     # writes the conventional commit `convoy finish` squashes a run into; you edit it before it lands
   worktree: true                   # force a new branch + worktree for every run; false always runs in the current tree. Unset decides per branch (isolate on a trunk, run in place on a branch)
   advisor: anthropic/claude-opus-5   # optional; a stronger model consulted at every step's decision points
@@ -800,7 +800,7 @@ An isolated run gets a new branch checked out under `~/.convoy/worktrees/<branch
 
 The branch is always agreed with you first, in a **Branch** step between Options and Review:
 
-- `defaults.branchNameModel` (Haiku by default) reads your prompt and proposes a conventional name — `feat/runtime-guard-limits`, `fix/login-redirect` — always in English, even when the prompt is not. Prompts that only reference an issue (`#123`, `DEV-1339`, a URL) are looked up first, so the branch is named after what the issue is about.
+- An `Intended Branch Name` (or `git checkout -b …`) in the prompt is used as-is — the model is not asked to reinvent it. A short prompt that is just a path to a plan file is read first, so pasting `docs/plans/foo.md` still picks up the name inside. Otherwise `defaults.branchNameModel` (DeepSeek V4 Flash 0731 via OpenRouter by default) reads the prompt and proposes a conventional name — `feat/runtime-guard-limits`, `fix/login-redirect` — always in English, even when the prompt is not, keeping the document's own words rather than paraphrasing them. Prompts that only reference an issue (`#123`, `DEV-1339`, a URL) are looked up first, so the branch is named after what the issue is about.
 - The proposed name is shown in an editable field together with the worktree path it would take. Enter accepts it and moves on to Review; nothing is created until you confirm the run there.
 - `tab` moves to the **hint** box: describe how you want it named ("name it after the budget limits") and press Enter or `ctrl+R` to re-name it. This is also what you get when the prompt is too thin to name anything, or when the naming model is unavailable — the step still opens, with a name derived from the prompt, ready to be edited.
 - Names already taken by a branch or an existing worktree are suffixed (`-2`, `-3`) instead of failing `git worktree add` after the run has been confirmed.

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -1991,7 +1991,7 @@ function describeDefault(key: keyof ConvoyDefaults): string {
     case "autoAcceptJudgeModel":
       return "Model the smart auto-accept judge uses (falls back to the run's model)."
     case "branchNameModel":
-      return "Model that names worktree branches (default: anthropic/claude-haiku-4-5)."
+      return "Model that names worktree branches (default: openrouter/deepseek/deepseek-v4-flash-0731)."
     case "commitMessageModel":
       return "Model that writes the squashed commit message for finish (default: anthropic/claude-haiku-4-5)."
     case "worktree":

--- a/src/config.ts
+++ b/src/config.ts
@@ -262,7 +262,7 @@ defaults:
   # maxConcurrentAgents: 30 # optional: cap agents running at once within a parallel group
   # baseRef: main # optional: when unset, convoy auto-detects (origin default branch, else main/master/develop/trunk, else current branch)
   # pipeline: implement
-  # branchNameModel: anthropic/claude-haiku-4-5 # optional: model that names worktree branches
+  # branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731 # optional: model that names worktree branches
   # commitMessageModel: anthropic/claude-haiku-4-5 # optional: model that writes the squashed commit message for "convoy finish"
   # worktree: true # optional: force a fresh branch + worktree for every run; false always runs in the current tree. Unset decides per branch: isolate on a trunk (main/master/develop/trunk or the detected base), run in place on any other branch
   # advisor: anthropic/claude-opus-5 # optional: reviewing model consulted at phase decision points

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -49,8 +49,8 @@ export type LaunchRunSelection = {
 /** A branch name suggested for the run, plus where it came from so the step can say so. */
 export type LaunchBranchProposal = {
   branch: string
-  /** "model" when the namer answered, "prompt" when it was derived locally, "fallback" for the timestamp. */
-  source: "model" | "prompt" | "fallback"
+  /** "declared" when the PRD already named the branch, "model" when the namer answered, "prompt" when it was derived locally, "fallback" for the timestamp. */
+  source: "declared" | "model" | "prompt" | "fallback"
   /** Why the model call didn't produce the name; shown as a hint, never as a blocker. */
   error?: string
   /** The naming model that was asked, for attribution in the UI. */
@@ -1883,11 +1883,13 @@ function textField(value: string, cursor: number, width: number, focused: boolea
 /** Attribution line under the branch field: who proposed the name, and whether it had to move. */
 export function branchProposalNote(proposal: LaunchBranchProposal, check: LaunchBranchCheck): string {
   const origin =
-    proposal.source === "model"
-      ? `proposed by ${proposal.model || "the naming model"}`
-      : proposal.source === "prompt"
-        ? "derived from your prompt (the naming model didn't answer)"
-        : "generic name (nothing to derive it from)"
+    proposal.source === "declared"
+      ? "taken from the document"
+      : proposal.source === "model"
+        ? `proposed by ${proposal.model || "the naming model"}`
+        : proposal.source === "prompt"
+          ? "derived from your prompt (the naming model didn't answer)"
+          : "generic name (nothing to derive it from)"
   return check.suffixed ? `${origin} · renamed, the original was taken` : origin
 }
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,5 +1,6 @@
-import { mkdir, stat } from "node:fs/promises"
-import { join } from "node:path"
+import { mkdir, readFile, stat } from "node:fs/promises"
+import { homedir } from "node:os"
+import { isAbsolute, join, resolve } from "node:path"
 
 import type { AgentConfig, Config, OpencodeClient } from "@opencode-ai/sdk/v2"
 
@@ -36,7 +37,7 @@ export type BranchNameInput = {
 }
 
 /** Where a proposed name came from, so the launcher can say who suggested it. */
-export type BranchNameSource = "model" | "prompt" | "fallback"
+export type BranchNameSource = "declared" | "model" | "prompt" | "fallback"
 
 export type BranchNameProposal = {
   branch: string
@@ -46,7 +47,7 @@ export type BranchNameProposal = {
 }
 
 /** Cheap, fast model used to synthesize a branch name from the prompt. */
-export const defaultBranchNameModel = "anthropic/claude-haiku-4-5"
+export const defaultBranchNameModel = "openrouter/deepseek/deepseek-v4-flash-0731"
 
 /** Registered so the namer replaces opencode's default coding agent instead of merely appending to it. */
 const namerAgentName = "convoy-branch-namer"
@@ -133,13 +134,26 @@ export function worktreeDirFor(branch: string): string {
 
 /**
  * Asks a cheap, read-only model for a short kebab-case branch name derived
- * from the prompt — it may look up referenced issues/tickets first. Any
- * failure (no auth, timeout, unparseable reply) degrades to a name derived
- * from the prompt itself, so the proposal always says something about the work.
+ * from the prompt — it may look up referenced issues/tickets first. A name
+ * the document already declared is used as-is and never sent to the model,
+ * because a paraphraser will "improve" `feat/launcher-compact-mode` into
+ * something the user then has to rewrite. Any model failure degrades to a
+ * name derived from the prompt itself, so the proposal always says something
+ * about the work.
  */
 export async function proposeBranchName(input: BranchNameInput): Promise<BranchNameProposal> {
   const trimmed = input.prompt.trim()
-  if (!trimmed && !input.guidance?.trim()) return { branch: fallbackBranchName(), source: "fallback" }
+  const steer = input.guidance?.trim()
+  if (!trimmed && !steer) return { branch: fallbackBranchName(), source: "fallback" }
+
+  const resolved = trimmed ? await resolveNamingPrompt(trimmed, input.targetDir) : ""
+
+  // Guidance outranks the document, so a declared name is only auto-accepted
+  // when the user didn't ask for something else.
+  if (!steer) {
+    const declared = extractDeclaredBranchName(resolved)
+    if (declared) return { branch: declared, source: "declared" }
+  }
 
   let error: string | undefined
   try {
@@ -147,7 +161,7 @@ export async function proposeBranchName(input: BranchNameInput): Promise<BranchN
     try {
       const reply = await askForBranchName(handle.client, {
         ...input,
-        prompt: trimmed,
+        prompt: resolved,
         model: input.model ?? defaultBranchNameModel,
       })
       const branch = readBranchName(reply)
@@ -163,7 +177,7 @@ export async function proposeBranchName(input: BranchNameInput): Promise<BranchN
   }
 
   log.warn(`worktree: couldn't generate an AI branch name (${error}); deriving one from the prompt`)
-  const heuristic = heuristicBranchName(input.guidance?.trim() || trimmed)
+  const heuristic = heuristicBranchName(steer || resolved || trimmed)
   if (heuristic) return { branch: heuristic, source: "prompt", error }
   return { branch: fallbackBranchName(), source: "fallback", error }
 }
@@ -223,7 +237,21 @@ export function namerMessage(prompt: string, guidance?: string): string {
   const parts: string[] = []
   const steer = guidance?.trim()
   if (steer) parts.push(`How the user wants it named (this outranks everything below):\n${steer}`)
-  if (prompt.trim()) parts.push(`Prompt:\n${excerpt(prompt.trim())}`)
+  const body = prompt.trim()
+  if (body) {
+    const declared = extractDeclaredBranchName(body)
+    if (declared) {
+      parts.push(`The document already names the branch. Use this exact name unless the instruction above conflicts:\n${declared}`)
+    } else {
+      const suggested = heuristicBranchName(body)
+      if (suggested) {
+        parts.push(
+          `Name suggested by the document title (keep this topic; translate to English if needed, do not invent a different subject):\n${suggested}`,
+        )
+      }
+    }
+    parts.push(`Prompt:\n${excerpt(body)}`)
+  }
   return parts.join("\n\n")
 }
 
@@ -238,8 +266,13 @@ const branchNameSystemPrompt = [
   "Rules:",
   "- When the message opens with a \"How the user wants it named\" block, that instruction wins over",
   "  everything else, including the prompt. Build the name around what it asks for.",
+  "- If the message includes a \"The document already names the branch\" block, copy that name",
+  "  exactly. Do not paraphrase it.",
   "- Always name it in ENGLISH, even when the prompt is written in another language.",
-  "- Name what the work DOES. Never transcribe a sentence, heading, or question from the prompt.",
+  "- Prefer the document's own title and Goal. Keep those words. Do not invent synonyms",
+  "  (\"reliable\" must not become \"solid\"; \"compact mode\" must not become \"narrow-screen-support\").",
+  "- A heading or Goal line is the right source for the name. A question is not — never reply",
+  "  with a question or a sentence.",
   "- Never ask the user anything. There is no follow-up turn; a question is a failed answer.",
   "- Never refuse and never explain what you couldn't find. If something the user mentions can't be",
   "  verified from the repo or the tools, name the branch from what they told you anyway — the user",
@@ -248,6 +281,8 @@ const branchNameSystemPrompt = [
   "  the work, look it up first with the tools available to you (issue-tracker tools, webfetch,",
   "  repo files) and name the branch after what the issue is actually about. If the reference",
   "  can't be resolved, use the issue ID itself as the name (e.g. dev-1339).",
+  "- Do not explore the repository unless the prompt is only an issue, ticket, URL, or file path",
+  "  that you must look up. Name from the text you were given.",
   "- You may investigate before answering, but the LAST line of your reply must be the JSON object",
   "  and nothing else.",
 ].join("\n")
@@ -404,23 +439,107 @@ const stopWords = new Set([
 ])
 
 /**
+ * A name the document already chose. Checked before the model is asked, so
+ * a paraphrasing model cannot turn `feat/launcher-compact-mode` into a synonym.
+ * Only explicit declarations count — scanning for any `type/slug` would pick
+ * up code samples.
+ */
+export function extractDeclaredBranchName(prompt: string): string {
+  for (const line of prompt.split("\n")) {
+    if (!declaredBranchLabel.test(line)) continue
+    const afterLabel = line.replace(declaredBranchLabel, "")
+    const value = stripMarkdownDecor(afterLabel).replace(/^[\s:*_\u2013\u2014-]+/, "").trim()
+    const cleaned = cleanBranchName(value)
+    if (cleaned) return cleaned
+  }
+  const checkout = /\bgit\s+checkout\s+-b\s+[`'"]?([^\s`'";\\]+)/i.exec(prompt)
+  if (checkout?.[1]) {
+    const cleaned = cleanBranchName(checkout[1])
+    if (cleaned) return cleaned
+  }
+  return ""
+}
+
+const declaredBranchLabel = /\b(?:intended\s+branch\s+name|(?:proposed|suggested|target)\s+branch(?:\s+name)?)\b/i
+
+function stripMarkdownDecor(value: string): string {
+  return value.replace(/[`'"*_[\]]+/g, " ").replace(/\s+/g, " ").trim()
+}
+
+/**
+ * When the launcher prompt is just a pointer at a plan file, read that file
+ * so naming sees the PRD instead of the path. Long pasted prompts are left
+ * alone — they may mention a path in passing.
+ */
+export async function resolveNamingPrompt(prompt: string, targetDir: string): Promise<string> {
+  const trimmed = prompt.trim()
+  if (!trimmed) return trimmed
+  if (trimmed.length > namingPointerMaxChars || trimmed.split("\n").length > namingPointerMaxLines) return trimmed
+  return (await readReferencedPromptFile(trimmed, targetDir)) ?? trimmed
+}
+
+const namingPointerMaxChars = 400
+const namingPointerMaxLines = 3
+const namingFileMaxBytes = 512_000
+
+async function readReferencedPromptFile(prompt: string, targetDir: string): Promise<string | undefined> {
+  for (const candidate of pathCandidates(prompt)) {
+    const resolved = expandUserPath(candidate, targetDir)
+    try {
+      const info = await stat(resolved)
+      if (!info.isFile() || info.size <= 0 || info.size > namingFileMaxBytes) continue
+      const text = await readFile(resolved, "utf8")
+      if (text.trim()) return text
+    } catch {
+      // not a readable file at this candidate
+    }
+  }
+  return undefined
+}
+
+function pathCandidates(prompt: string): string[] {
+  const found: string[] = []
+  for (const raw of prompt.split(/\s+/)) {
+    const token = raw.replace(/^[`'"]+|[`'":,]+$/g, "")
+    if (token && (token.includes("/") || /\.(md|txt|markdown)$/i.test(token))) found.push(token)
+  }
+  // Last path-like token wins: "implement docs/plans/foo.md".
+  return found.reverse()
+}
+
+function expandUserPath(value: string, targetDir: string): string {
+  if (value.startsWith("~/")) return resolve(homedir(), value.slice(2))
+  if (isAbsolute(value)) return value
+  return resolve(targetDir, value)
+}
+
+/**
  * Last resort before a timestamp: names the branch after the prompt's own
  * opening — its first heading or first line — so a failed model call still
  * produces something recognizable instead of `convoy-20260726-a4f2`.
+ * Only the opening counts: later `# File:` / `# 1.18.18` lines in a plan are
+ * comments, not the title.
  */
 export function heuristicBranchName(prompt: string): string {
-  const lines = prompt
+  const first = prompt
     .split("\n")
     .map((line) => line.trim())
-    .filter(Boolean)
-  const heading = lines.find((line) => line.startsWith("#"))
-  const source = (heading ?? lines[0] ?? "").replace(/^#+\s*/, "")
+    .find(Boolean) ?? ""
+  const source = stripPlanPrefix(first.replace(/^#+\s*/, ""))
   const words = kebab(source)
     .split("-")
-    .filter((word) => word && !stopWords.has(word))
+    .filter((word) => word && !stopWords.has(word) && !/^\d+$/.test(word))
     .slice(0, 4)
   if (words.length === 0) return ""
   return cleanBranchName(words.join("-"))
+}
+
+/** Drops the "Implementation Plan:" / "PRD —" wrapper so the title itself is what gets named. */
+function stripPlanPrefix(value: string): string {
+  return value.replace(
+    /^(?:implementation\s+plan|plan\s+de\s+implementaci[oó]n|plan\s+conjunto|propuesta(?:\s+de\s+implementaci[oó]n)?|prd)\s*[:\u2013\u2014-]\s*/i,
+    "",
+  )
 }
 
 /** Deterministic fallback so worktree creation never depends on a model being available. */
@@ -474,11 +593,36 @@ const excerptTail = 500
 
 /**
  * Long PRDs bury the actual ask in their closing recommendation, so the namer
- * gets both ends of the document rather than only its opening context.
+ * gets both ends of the document rather than only its opening context. Title,
+ * Goal, and any declared branch name are prepended so a mid-document
+ * "Intended Branch Name" cannot fall into the cut.
  */
 export function excerpt(value: string): string {
-  if (value.length <= excerptHead + excerptTail) return value
-  return `${value.slice(0, excerptHead)}\n…\n${value.slice(-excerptTail)}`
+  const highlights = namingHighlights(value)
+  if (value.length <= excerptHead + excerptTail) {
+    return highlights && !value.startsWith(highlights) ? `${highlights}\n\n${value}` : value
+  }
+  const clipped = `${value.slice(0, excerptHead)}\n…\n${value.slice(-excerptTail)}`
+  return highlights ? `${highlights}\n\n${clipped}` : clipped
+}
+
+function namingHighlights(value: string): string {
+  const keep: string[] = []
+  let headings = 0
+  for (const line of value.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+    if (trimmed.startsWith("#") && headings < 2) {
+      keep.push(trimmed)
+      headings += 1
+      continue
+    }
+    if (/(?:intended|proposed|suggested|target)\s+branch|^\*{0,2}goal\*{0,2}\s*:/i.test(trimmed)) {
+      keep.push(trimmed)
+    }
+    if (keep.length >= 6) break
+  }
+  return keep.join("\n")
 }
 
 function truncate(value: string, max: number): string {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -924,7 +924,7 @@ describe("default config init", () => {
     expect(body).toContain("# maxConcurrentAgents: 30")
     expect(body).toContain("# baseRef: main")
     expect(body).toContain("# pipeline: implement")
-    expect(body).toContain("# branchNameModel: anthropic/claude-haiku-4-5")
+    expect(body).toContain("# branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731")
     expect(body).toContain("# hooks:")
     expect(body).toContain("#           command: gh pr create --fill")
     expect(body).toContain("# agents:")

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -460,6 +460,9 @@ describe("launch TUI branch step", () => {
   })
 
   test("attributes the proposal and says when the name had to move", () => {
+    expect(branchProposalNote({ branch: "feat/x", source: "declared" }, { branch: "feat/x", dir: "/w/feat-x" })).toBe(
+      "taken from the document",
+    )
     expect(branchProposalNote({ branch: "feat/x", source: "model", model: "anthropic/claude-haiku-4-5" }, { branch: "feat/x", dir: "/w/feat-x" })).toBe(
       "proposed by anthropic/claude-haiku-4-5",
     )

--- a/test/worktree-extended.test.ts
+++ b/test/worktree-extended.test.ts
@@ -21,7 +21,7 @@ describe("defaultBranchNameModel", () => {
   })
 
   test("is set to the expected default model", () => {
-    expect(defaultBranchNameModel).toBe("anthropic/claude-haiku-4-5")
+    expect(defaultBranchNameModel).toBe("openrouter/deepseek/deepseek-v4-flash-0731")
   })
 })
 
@@ -302,11 +302,12 @@ describe("namerMessage", () => {
     expect(guidanceIdx).toBeLessThan(promptIdx)
   })
 
-  test("without guidance, only the prompt is included", () => {
+  test("without guidance, includes the prompt and a title suggestion", () => {
     const msg = namerMessage("build onboarding")
     expect(msg).not.toContain("How the user wants it named")
     expect(msg).toContain("Prompt:")
     expect(msg).toContain("build onboarding")
+    expect(msg).toContain("feat/build-onboarding")
   })
 
   test("empty prompt with guidance still uses guidance", () => {

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test"
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -11,10 +11,13 @@ import {
   cleanBranchName,
   ensureFreeBranchName,
   excerpt,
+  extractDeclaredBranchName,
   fallbackBranchName,
   heuristicBranchName,
   namerMessage,
+  proposeBranchName,
   readBranchName,
+  resolveNamingPrompt,
   slugifyBranch,
 } from "../src/worktree"
 
@@ -139,6 +142,20 @@ describe("heuristicBranchName", () => {
     expect(heuristicBranchName("# Propuesta de implementación\n\nLa solución debería tener tres capas")).toBe("feat/propuesta-implementacion")
   })
 
+  test("strips the Implementation Plan / PRD wrapper so the title is what gets named", () => {
+    expect(heuristicBranchName("# Implementation Plan: Compact Mode for Pipeline Launcher TUI")).toBe(
+      "feat/compact-mode-pipeline-launcher",
+    )
+    expect(heuristicBranchName("PRD — Auditorías de review fiables: Scope con verify")).toBe("feat/auditorias-review-fiables-scope")
+    expect(heuristicBranchName("Plan conjunto: fix de permisos + OpenCode 1.18.18")).toBe("feat/fix-permisos-opencode")
+  })
+
+  test("ignores later hash comments so a plan's # File: line cannot become the name", () => {
+    expect(
+      heuristicBranchName("Implementation Plan: Reliable Phase Report Delivery\n\n# Create test for last message extraction"),
+    ).toBe("feat/reliable-phase-report-delivery")
+  })
+
   test("uses the first line when there is no heading, dropping stop words", () => {
     expect(heuristicBranchName("Add a budget limit to the execution supervisor")).toBe("feat/budget-limit-execution-supervisor")
   })
@@ -181,7 +198,16 @@ describe("namer payload", () => {
   test("namerMessage puts the user's guidance above the prompt", () => {
     const message = namerMessage("build onboarding", "call it after the budget limits")
     expect(message.indexOf("budget limits")).toBeLessThan(message.indexOf("build onboarding"))
-    expect(namerMessage("build onboarding")).toBe("Prompt:\nbuild onboarding")
+    expect(message).toContain("Prompt:\nbuild onboarding")
+    expect(namerMessage("build onboarding")).toContain("Prompt:\nbuild onboarding")
+    expect(namerMessage("build onboarding")).toContain("feat/build-onboarding")
+  })
+
+  test("namerMessage pins a declared branch name so the model cannot paraphrase it", () => {
+    const message = namerMessage("# Compact Mode\n\n**Intended Branch Name:** `feat/launcher-compact-mode`")
+    expect(message).toContain("The document already names the branch")
+    expect(message).toContain("feat/launcher-compact-mode")
+    expect(message).not.toContain("Name suggested by the document title")
   })
 })
 
@@ -206,7 +232,8 @@ describe("askForBranchName", () => {
     expect(promptInput?.agent).toBe("convoy-branch-namer")
     expect(promptInput?.system).toContain("ENGLISH")
     expect(promptInput?.tools).toEqual({ read: true, list: true, glob: true, grep: true, webfetch: true, write: false, edit: false, bash: false, todoread: false, todowrite: false })
-    expect(promptInput?.parts).toEqual([{ type: "text", text: "Prompt:\nbuild onboarding" }])
+    expect(promptInput?.parts[0]?.text).toContain("Prompt:\nbuild onboarding")
+    expect(promptInput?.parts[0]?.text).toContain("feat/build-onboarding")
   })
 
   test("sends both ends of a long prompt to the naming model", async () => {
@@ -236,6 +263,90 @@ describe("askForBranchName", () => {
 
     await expect(askForBranchName(client, { prompt: "fix login", targetDir: "/repo", model: "openai/gpt-5.5" })).rejects.toThrow("provider unavailable")
     expect(deleted).toEqual({ sessionID: "namer-session", directory: "/repo" })
+  })
+})
+
+describe("extractDeclaredBranchName", () => {
+  test("reads Intended Branch Name from a plan header", () => {
+    expect(extractDeclaredBranchName("# Compact Mode\n\n**Intended Branch Name:** `feat/launcher-compact-mode`\n")).toBe(
+      "feat/launcher-compact-mode",
+    )
+    expect(extractDeclaredBranchName("Intended Branch Name: fix/reliable-score-report-extraction\n")).toBe(
+      "fix/reliable-score-report-extraction",
+    )
+  })
+
+  test("reads a git checkout -b instruction", () => {
+    expect(extractDeclaredBranchName("1. Create branch: git checkout -b fix/reliable-score-report-extraction")).toBe(
+      "fix/reliable-score-report-extraction",
+    )
+  })
+
+  test("ignores documents that never name a branch", () => {
+    expect(extractDeclaredBranchName("# Compact Mode\n\nAdd a stacked layout for narrow terminals.")).toBe("")
+  })
+})
+
+describe("resolveNamingPrompt", () => {
+  const dirs: string[] = []
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  test("reads a short prompt that is just a plan path", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-namer-path-"))
+    dirs.push(dir)
+    await writeFile(join(dir, "plan.md"), "# Compact Mode\n\n**Intended Branch Name:** `feat/launcher-compact-mode`\n")
+    const resolved = await resolveNamingPrompt("docs/plans/ignored.md implement plan.md", dir)
+    expect(resolved).toContain("feat/launcher-compact-mode")
+    expect(await resolveNamingPrompt("plan.md", dir)).toContain("Intended Branch Name")
+  })
+
+  test("leaves a long pasted PRD alone even if it mentions a path", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-namer-long-"))
+    dirs.push(dir)
+    await writeFile(join(dir, "other.md"), "SHOULD NOT BE READ")
+    const prd = `${"context ".repeat(80)}see other.md for notes`
+    expect(await resolveNamingPrompt(prd, dir)).toBe(prd)
+  })
+})
+
+describe("proposeBranchName", () => {
+  const dirs: string[] = []
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+  })
+
+  test("uses the PRD's intended name without calling a model", async () => {
+    const proposal = await proposeBranchName({
+      prompt: "# Compact Mode\n\n**Intended Branch Name:** `feat/launcher-compact-mode`\n",
+      targetDir: "/repo",
+    })
+    expect(proposal).toEqual({ branch: "feat/launcher-compact-mode", source: "declared" })
+  })
+
+  test("reads a referenced plan file and takes its intended name", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-namer-propose-"))
+    dirs.push(dir)
+    await mkdir(join(dir, "docs/plans"), { recursive: true })
+    await writeFile(
+      join(dir, "docs/plans/2026-08-16-launcher-compact-mode.md"),
+      "# Implementation Plan: Compact Mode for Pipeline Launcher TUI\n\n**Intended Branch Name:** `feat/launcher-compact-mode`\n",
+    )
+    const proposal = await proposeBranchName({
+      prompt: "docs/plans/2026-08-16-launcher-compact-mode.md",
+      targetDir: dir,
+    })
+    expect(proposal).toEqual({ branch: "feat/launcher-compact-mode", source: "declared" })
+  })
+})
+
+describe("excerpt highlights", () => {
+  test("keeps an Intended Branch Name that sits past the head window", () => {
+    const prd = `${"a".repeat(1_200)}\n**Intended Branch Name:** \`feat/launcher-compact-mode\`\n${"b".repeat(1_200)}`
+    const sent = excerpt(prd)
+    expect(sent).toContain("feat/launcher-compact-mode")
+    expect(sent).toContain("\n…\n")
   })
 })
 


### PR DESCRIPTION
## What

The worktree namer no longer invents a synonym for the PRD, and the built-in default is no longer Haiku.

**Naming**
- An `Intended Branch Name` / `proposed|suggested|target branch` / `git checkout -b …` in the prompt is used as-is. The model is not asked to reinvent it.
- A short launcher prompt that is just a path (`docs/plans/foo.md`, `implement docs/plans/foo.md`) is read first, so the name inside the plan is what gets proposed.
- The namer prompt now keeps the document's own words instead of forbidding transcription of the heading (that rule is what turned `feat/launcher-compact-mode` into `feat/narrow-screen-support-improvements` and `reliable` into `solid`).
- The heuristic fallback uses the first line (not a later `# File:` / `# 1.18.18` comment), strips the `Implementation Plan:` / `PRD —` wrapper, and ignores numeric-only tokens.
- Long PRDs still send head+tail to the model, but title / Goal / declared-name lines are prepended so they cannot fall into the cut.

**Default model**
- `defaultBranchNameModel` is now `openrouter/deepseek/deepseek-v4-flash-0731` (OpenRouter's DeepSeek V4 Flash 0731).
- The init template, config TUI help, and README follow that default. `commitMessageModel` stays on Haiku.

## Why

Haiku was being asked to name work, then instructed never to transcribe the heading. Combined with a 900+500 excerpt and path-only prompts, proposed branches almost never matched the PRD, so the launcher name had to be typed by hand every time.

## Tests

`bun test test/worktree.test.ts test/worktree-extended.test.ts test/launch-tui.test.ts test/config.test.ts` and `bun run typecheck`.

Coverage includes declared-name extraction (including `**Intended Branch Name:**`), path-only plan resolution, `proposeBranchName` short-circuiting without a model call, heuristic prefix stripping, and the new built-in model id.