### PR TITLE
feat(prd): persist per-project PRD history

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You write the plan, `implement` turns it into something functional, you shape it
 | `ship` | yes | **The close of the cycle.** A `sync` phase merges the advanced base branch in and resolves the conflicts — real and semantic — so what gets graded is the branch as it will actually merge. Then two independent quality-scorers grade it against the rubric and a consensus step reconciles and verifies. `ship` declares `goal: 85` in its own spec, so the fix/re-score loop runs **without you passing `--goal`**: it keeps closing gaps until the score clears 85, plateaus, or hits the iteration cap. See [Quality scoring](#quality-scoring) and [Goal mode](#goal-mode). Two things it expects from your config, because both are machine-local: `permissions.allow` entries for `git merge*`, `git add*` and `git checkout --ours*`/`--theirs*` (without them those commands fall through to "ask" rather than failing), and, optionally, `hooks.pipelines.ship` to fetch the base beforehand and open the PR afterwards — Convoy never runs remote git itself. Post-hooks receive `CONVOY_GOAL_REACHED`, so the PR step can require the bar was actually met. |
 | `fixer` | yes | The follow-up to a report-only run. Give it a set of findings (as the prompt or an attachment) and it proves each one with a focused regression test **before** touching production code, applies minimal fixes only for the findings that actually went red, then independently reruns those proofs and the surrounding checks to report a final per-finding verdict (`fixed`, `already-resolved`, `not-reproducible`, `not-automatable`, `blocked`, `not-fixed`). The validation phase runs the commands itself (see [verifying steps](#project-configuration-convoyconfigyaml)) rather than taking the fix phase's word for it, and never promotes an unproven finding to fixed. |
 | `goal-fix` | yes | The goal loop's fix iteration: applies exactly the gaps the previous scoring round reported, then re-scores. Not run directly — `ship`'s goal, or an explicit `--goal`, drives it. See [Goal mode](#goal-mode). |
-| `review` | **no — report only** | Scope the diff, run the bug / clean-code(+patterns) / security audits **in parallel across two models each**, synthesize one prioritized findings report, then **measure**: two independent quality-scorers grade the same diff against the rubric and a consensus step reconciles and verifies. The deliverables are `reports/report.md` and the machine-readable score in `reports/score-report.md`. Makes no changes. |
+| `review` | **no — report only** | Scope the diff (attaching the branch's original PRD when Convoy has one), run the bug / clean-code(+patterns) / security audits **in parallel across two models each**, synthesize one prioritized findings report, then **measure**: two independent quality-scorers grade the same diff against the rubric and a consensus step reconciles and verifies. The deliverables are `reports/report.md` and the machine-readable score in `reports/score-report.md`. Makes no changes. |
 | `review-lite` | **no — report only** | Same shape as `review`, but nothing runs on Opus: `openrouter/z-ai/glm-5.2` scopes the diff, writes the report and reconciles the score, and the audit and scorer fan-outs pair GLM 5.2 with `openrouter/moonshotai/kimi-k3`. The cheap way to get a full review and a number. |
 | `review-cc` | **no — report only** | `review`'s audits, but each is paired with a second run on the locally installed [`claude` CLI](https://code.claude.com) (`runner: claude-code`) instead of a second API model — cross-vendor diversity billed to a Claude subscription rather than per token. Ends at the findings report rather than a score: its point is a second opinion from a different vendor, not a measurement. Requires `claude` on `PATH`. |
 | `hunter` | **no — report only** | Repo-wide audit across six specialty tracks (correctness, memory, performance, security, reliability, supply chain), each run on GPT 5.6 Terra xhigh plus one specialty model, then reconciled into a single deduplicated, prioritized consensus report. |
@@ -499,6 +499,7 @@ defaults:
   branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731  # proposes worktree branch names (may look up referenced issues); you confirm the name
   commitMessageModel: anthropic/claude-haiku-4-5     # writes the conventional commit `convoy finish` squashes a run into; you edit it before it lands
   worktree: true                   # force a new branch + worktree for every run; false always runs in the current tree. Unset decides per branch (isolate on a trunk, run in place on a branch)
+  prdHistory: true                 # store each new run's git-ignored prompt under .convoy/prd-history; false disables writes and historical attachments
   advisor: anthropic/claude-opus-5   # optional; a stronger model consulted at every step's decision points
   advisorMaxCalls: 1000              # optional; consultations allowed per phase attempt (default 1000 — effectively unlimited; set it lower to cap advisor spend)
   advisorAuditPolicy: summary        # summary (hash-only default), redacted, or full transcript/advice content
@@ -531,6 +532,7 @@ pipelines:
       - implementer
       - agent: api-reviewer
         verify: true               # optional; read-only step gets bash back so it can run tests/checks
+        prdHistory: true           # optional; attach the original PRD recorded for this branch
       - type: human
         name: api-review
       - agent: security
@@ -678,7 +680,7 @@ When a project override exists, it replaces that agent's built-in prompt complet
 
 `--file` is repeatable and accepts files or directories. Relative paths are resolved against the target repo.
 
-Convoy doesn't paste those contents into the prompt. It sends them to the SDK as `FilePartInput` with `file://` URL, just like OpenCode's `--file`. It does the same internally with `prd.md`, previous reports, and phase diffs.
+Convoy doesn't paste those contents into the prompt. It sends them to the SDK as `FilePartInput` with `file://` URL, just like OpenCode's `--file`. It does the same internally with `prd.md`, the original branch PRD for opted-in review scope steps, previous reports, and phase diffs.
 
 ## Anatomy of a Run
 
@@ -711,7 +713,7 @@ Each invocation creates `~/.convoy/runs/<run-id>/`:
 
 The run dir is kept after the run by default (browse it with `convoy runs`); pass `--no-keep-run-dir` to delete it on successful completion. If the run fails, it's always preserved for inspecting reports, diffs, and logs.
 
-The target repo only sees commits with prefix `convoy(<phase>): ...`, made on the run's branch — by default a new one in its own worktree, so your checkout is untouched until you merge. `convoy finish` replaces that stack with one signed commit of your own. Normal runs leave no CLI files in the project; `convoy init` intentionally creates `.convoy/config.yaml` when you want project-local configuration.
+The target repo only sees commits with prefix `convoy(<phase>): ...`, made on the run's branch — by default a new one in its own worktree, so your checkout is untouched until you merge. `convoy finish` replaces that stack with one signed commit of your own. Each new run also stores a git-ignored, private copy of its prompt under `.convoy/prd-history/`; set `defaults.prdHistory: false` to disable it. `convoy init` intentionally creates `.convoy/config.yaml` when you want project-local configuration.
 
 ## Development
 

--- a/prompts/review-scope.md
+++ b/prompts/review-scope.md
@@ -8,6 +8,12 @@ Default scope is the attached diff: this branch or pull request against the base
 
 Do not widen the review to untouched code. The one exception is code the change makes newly reachable or newly wrong; name it explicitly and tie it to the changed line that exposes it. Widen scope only when `prd.md` explicitly asks for a repository-wide review.
 
+## Historical PRD
+
+A historical PRD may be attached alongside this run's `prd.md`. This run's `prd.md` is the request for the current pipeline (often a generic review prompt); the historical PRD, when present, is the original product intent for this branch.
+
+Prefer the historical PRD for what was asked and why. Do not reconstruct a product brief from the diff when it is attached. Under **Scope**, quote its title and the decisions that matter so later auditors and quality scorers can cite the original intent without re-reading the attachment. When no historical PRD is attached, say so under **Scope** and infer intent from the diff as before.
+
 ## Objective
 
 Build the map every later reviewer will use:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,15 +2,16 @@ import { readFile, stat } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import { buildAgentRegistry, ejectAgentPrompt, emptyHooksConfig, globalConfigPath, loadMergedConvoyConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ConvoyDefaults } from "./config"
-import { detectBaseRef, resolveWorktreeDefault } from "./git"
+import { detectBaseRef, currentBranch, resolveWorktreeDefault } from "./git"
 import { openRouterKeySources } from "./limits"
 import { log } from "./log"
 import { builtInAgents, defaultGptModel, defaultGptVariant, defaultPipeline, defaultPipelineName, hasWritableStep, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
 import { consensusStep, defaultGoalMaxIterations, defaultGoalPlateau } from "./quality-score"
 import { runGoalLoop } from "./goal-loop"
 import { defaultMaxConcurrentAgents, parseModel, run } from "./runner"
-import { buildRunPlan } from "./run-plan"
+import { buildRunPlan, type BuildRunPlanInput } from "./run-plan"
 import { confirmRunPlan, renderRunPlan } from "./run-review"
+import { loadPrdHistoryPreview } from "./prd-history"
 import { isModelGateway, type ModelGateway } from "./model-routing"
 import { browseRuns } from "./runs"
 import { deleteKeychainSecret, keychainAvailable, storeKeychainSecret } from "./secrets"
@@ -154,7 +155,7 @@ export async function parseAndRun(argv: string[]) {
     return
   }
 
-  const plan = command.options.plan ?? buildRunPlan(command.options)
+  const plan = command.options.plan ?? (await buildReviewedPlan(command.options))
   if (command.options.planOnly) {
     process.stdout.write(renderRunPlan(plan))
     return
@@ -188,6 +189,27 @@ export async function parseAndRun(argv: string[]) {
     options = await prepareWorktreeForRun(options.targetDir, options)
   }
   await executeRun(options, plan)
+}
+
+/** Builds the operator-reviewed plan, including a checkout-local PRD history preview. */
+async function buildReviewedPlan(input: BuildRunPlanInput): Promise<RunPlan> {
+  // Lookup the launch checkout's current branch, not `input.branch` — that is the
+  // *new* worktree name when isolate is on, and would miss history sitting here.
+  let branch: string | undefined
+  try {
+    branch = await currentBranch(input.targetDir)
+  } catch {
+    branch = undefined
+  }
+  const preview = await loadPrdHistoryPreview({
+    targetDir: input.targetDir,
+    enabled: input.prdHistory,
+    isolateWorktree: Boolean(input.worktree),
+    attachesHistory: input.pipeline.steps.some((step) => step.type === "agent" && step.prdHistory),
+    branch,
+    excludeRunID: input.resumeRunID || undefined,
+  })
+  return buildRunPlan({ ...input, prdHistoryPreview: preview })
 }
 
 /** The result of deciding whether goal mode applies to a resolved run. */
@@ -363,7 +385,7 @@ async function prepareInteractiveRun(targetDir: string, selection: LaunchRunSele
   const options = { ...(await resolveRunOptions(parsed)), prompt: selection.prompt }
   // The branch was named and confirmed in the launcher's branch step, so the
   // plan the user reviews already names the branch the run will create.
-  const plan = buildRunPlan({
+  const plan = await buildReviewedPlan({
     ...options,
     ...(selection.worktreeDir ? { worktreeDir: selection.worktreeDir } : {}),
   })
@@ -398,7 +420,7 @@ async function openRunsBrowser(initialRunID?: string) {
     const resolution = await browseRuns(currentRunID)
     if (resolution.type === "retry") {
       const options = await retryOptions(resolution.runID, resolution.targetDir)
-      const plan = options.plan ?? buildRunPlan({ ...options, promptSource: "retry" })
+      const plan = options.plan ?? (await buildReviewedPlan({ ...options, promptSource: "retry" }))
       if (!(await confirmRunPlan(plan))) return
       await preflightRunPlan(plan)
       await run({ ...options, plan })
@@ -406,7 +428,7 @@ async function openRunsBrowser(initialRunID?: string) {
     }
     if (resolution.type === "resume") {
       const options = await resumeOptions(resolution.runID, resolution.targetDir)
-      const plan = options.plan ?? buildRunPlan({ ...options, promptSource: "resume" })
+      const plan = options.plan ?? (await buildReviewedPlan({ ...options, promptSource: "resume" }))
       if (!(await confirmRunPlan(plan))) return
       await preflightRunPlan(plan)
       await run({ ...options, plan })
@@ -445,7 +467,7 @@ async function resumeOptions(runID: string, targetDir?: string): Promise<RunOpti
   } catch {
     // Legacy/incomplete workspace.
   }
-  options.plan = buildRunPlan({ ...options, promptSource: "resume" })
+  options.plan = await buildReviewedPlan({ ...options, promptSource: "resume" })
   return options
 }
 
@@ -470,7 +492,7 @@ async function retryOptions(runID: string, targetDir?: string): Promise<RunOptio
   } catch {
     // Legacy/incomplete workspace.
   }
-  options.plan = buildRunPlan({ ...options, promptSource: "retry" })
+  options.plan = await buildReviewedPlan({ ...options, promptSource: "retry" })
   return options
 }
 
@@ -630,7 +652,7 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
   // pipeline. Validate them before building a potentially empty review plan.
   validateStepFilters(options.pipeline, options)
   const promptSource: RunPlan["prompt"]["source"] = hasResume ? "resume" : hasPromptFile ? "file" : hasInlinePrompt ? "inline" : "default"
-  options.plan = buildRunPlan({
+  options.plan = await buildReviewedPlan({
     ...options,
     promptSource,
     ...(resumeGateway ? { resumeGateway } : {}),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -279,7 +279,7 @@ async function executeRun(options: RunOptions, plan: RunPlan): Promise<void> {
  * the headless path, where it is either pinned with --branch or proposed by the
  * naming model.
  */
-async function prepareWorktreeForRun(sourceDir: string, options: RunOptions): Promise<RunOptions> {
+export async function prepareWorktreeForRun(sourceDir: string, options: RunOptions): Promise<RunOptions> {
   const { createIsolatedWorktree } = await import("./worktree")
   // A pinned name is sanitized the same way the launcher sanitizes a typed one;
   // an unusable one is a flag error, not something to silently rename around.
@@ -753,6 +753,7 @@ export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOpt
     onlySteps: parsed.onlySteps,
     skipSteps: parsed.skipSteps,
     resumeRunID: parsed.resumeRunID ?? "",
+    prdHistory: defaults.prdHistory ?? true,
     keepRunDir: parsed.keepRunDir ?? true,
     modelOverride: parsed.modelOverride ?? "",
     advisorOverride: parsed.advisorOverride ?? "",
@@ -1101,7 +1102,7 @@ Config files:
                            present once you eject one, and they shadow the built-in
 
 Config keys:
-  defaults:                model, baseRef, pipeline, worktree, autoAcceptJudgeModel,
+  defaults:                model, baseRef, pipeline, worktree, prdHistory, autoAcceptJudgeModel,
                            branchNameModel, commitMessageModel
   modelRouting:            gateway and explicit per-logical-model overrides
   agents:                  project agents or built-in overrides; prompts live at agents/<name>.md

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -129,6 +129,7 @@ const defaultFields: DefaultField[] = [
   { key: "branchNameModel", type: "model" },
   { key: "commitMessageModel", type: "model" },
   { key: "worktree", type: "boolean" },
+  { key: "prdHistory", type: "boolean" },
   { key: "baseRef", type: "string" },
   { key: "pipeline", type: "string" },
 ]
@@ -1996,6 +1997,8 @@ function describeDefault(key: keyof ConvoyDefaults): string {
       return "Model that writes the squashed commit message for finish (default: anthropic/claude-haiku-4-5)."
     case "worktree":
       return "Run each job on a fresh branch in its own worktree. Unset decides per branch: on for a trunk, off once you're on a branch."
+    case "prdHistory":
+      return "Store git-ignored copies of prompts in .convoy/prd-history and attach the original branch PRD to opted-in steps. Unset is on."
     case "baseRef":
       return "Branch/base used to diff between steps (auto-detected when unset)."
     case "pipeline":

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,6 +76,8 @@ export type ConvoyDefaults = {
    * not "on": it decides per branch, isolating only when HEAD sits on a trunk.
    */
   worktree?: boolean
+  /** Persist and attach the git-ignored original PRD history; defaults to true. */
+  prdHistory?: boolean
   /** Advising model for every step that doesn't set its own; unset means no advisor anywhere. */
   advisor?: string
   /** Cap on advisor consultations per phase attempt, for steps that don't set their own. */
@@ -265,6 +267,7 @@ defaults:
   # branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731 # optional: model that names worktree branches
   # commitMessageModel: anthropic/claude-haiku-4-5 # optional: model that writes the squashed commit message for "convoy finish"
   # worktree: true # optional: force a fresh branch + worktree for every run; false always runs in the current tree. Unset decides per branch: isolate on a trunk (main/master/develop/trunk or the detected base), run in place on any other branch
+  # prdHistory: true # optional: store a git-ignored copy of each run's prompt in .convoy/prd-history; false disables history writes and scope attachments
   # advisor: anthropic/claude-opus-5 # optional: reviewing model consulted at phase decision points
   # advisorMaxCalls: 1000 # optional: consultation budget per phase attempt; the default is effectively unlimited, set this to put a real cap on it
   # advisorAuditPolicy: summary # summary (hashes), redacted (lengths), or full content retention
@@ -620,6 +623,7 @@ function validateDefaults(v: Validator, raw: unknown): ConvoyDefaults {
     "branchNameModel",
     "commitMessageModel",
     "worktree",
+    "prdHistory",
     "advisor",
     "advisorMaxCalls",
     "advisorAuditPolicy",
@@ -635,6 +639,7 @@ function validateDefaults(v: Validator, raw: unknown): ConvoyDefaults {
   if (record.branchNameModel !== undefined) defaults.branchNameModel = v.model(record.branchNameModel, "defaults.branchNameModel")
   if (record.commitMessageModel !== undefined) defaults.commitMessageModel = v.model(record.commitMessageModel, "defaults.commitMessageModel")
   if (record.worktree !== undefined) defaults.worktree = v.boolean(record.worktree, "defaults.worktree")
+  if (record.prdHistory !== undefined) defaults.prdHistory = v.boolean(record.prdHistory, "defaults.prdHistory")
   if (record.advisor !== undefined) defaults.advisor = v.model(record.advisor, "defaults.advisor")
   if (record.advisorMaxCalls !== undefined) defaults.advisorMaxCalls = v.positiveInt(record.advisorMaxCalls, "defaults.advisorMaxCalls")
   if (record.advisorAuditPolicy !== undefined) {
@@ -754,7 +759,7 @@ function validateStep(v: Validator, raw: unknown, path: string, context: { insid
     return step
   }
 
-  v.knownKeys(record, path, ["agent", "name", "model", "models", "runner", "advisor", "advisorMaxCalls", "maxAttempts", "reports", "diff", "verify"])
+  v.knownKeys(record, path, ["agent", "name", "model", "models", "runner", "advisor", "advisorMaxCalls", "maxAttempts", "reports", "diff", "verify", "prdHistory"])
 
   const agent = validateStepName(v, record.agent, `${path}.agent`)
   if (context.insideParallel && agent === humanReviewStep) v.fail(path, `"${humanReviewStep}" can't run inside a parallel block`)
@@ -798,6 +803,7 @@ function validateStep(v: Validator, raw: unknown, path: string, context: { insid
     ...(record.reports !== undefined ? { reports: validateReports(v, record.reports, `${path}.reports`) } : {}),
     ...(record.diff !== undefined ? { diff: v.boolean(record.diff, `${path}.diff`) } : {}),
     ...(record.verify !== undefined ? { verify: v.boolean(record.verify, `${path}.verify`) } : {}),
+    ...(record.prdHistory !== undefined ? { prdHistory: v.boolean(record.prdHistory, `${path}.prdHistory`) } : {}),
   }
 }
 

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -1,17 +1,19 @@
 import { homedir } from "node:os"
 import { basename } from "node:path"
+import { existsSync } from "node:fs"
 
 import { BoxRenderable, StyledText, TextRenderable, bg, bold, createCliRenderer, decodePasteBytes, fg, stripAnsiSequences, t } from "@opentui/core"
 
 import { defaultAdvisorMaxCalls } from "./advisor"
 import { buildAgentRegistry, emptyHooksConfig, loadMergedConvoyConfig } from "./config"
-import { resolveWorktreeDefault } from "./git"
+import { currentBranch, resolveWorktreeDefault } from "./git"
 import { hooksForPipeline } from "./hooks"
 import { startLimitsPoller } from "./limits"
 import { builtInPipelines, defaultPipelineName, hasWritableStep, resolvePipeline } from "./pipeline"
 import { stepRunnerFor } from "./step-runners"
 import { gatewayLabel, modelGateways, type ModelGateway } from "./model-routing"
 import { consensusStep } from "./quality-score"
+import { prdHistoryFile, prdHistoryPreviewCopy, readPrdHistoryIndex, resolvePrdHistoryPreview, type PrdHistoryEntry, type PrdHistoryPreview } from "./prd-history"
 import { runReviewLines } from "./review-tui"
 import { clipChunks, hintsRow, joinLines, limitsRow, moreHintsMarker, padBetween, paletteForTerminal, plain, raw, setTheme, spinnerFrame, terminalBackgroundHex, theme, truncate } from "./tui-theme"
 import { shortVersion } from "./version"
@@ -93,6 +95,13 @@ export type LaunchRunTuiOptions = {
   checkBranchName(name: string): Promise<LaunchBranchCheck>
 }
 
+/** Checkout-local history the launcher preloads so the notice can update as toggles change. */
+export type LaunchHistoryContext = {
+  enabled: boolean
+  branch?: string
+  entries: readonly PrdHistoryEntry[]
+}
+
 // One resolved step, flattened for the preview: `groupId` ties concurrent
 // steps together (the runner batches same-groupId steps), and `stepName` is
 // the pre-fan-out logical name shared by every `models:` variant. The tree in
@@ -134,6 +143,8 @@ export type PipelineChoice = {
   defaultPrompt?: string
   /** Alternative prompts Tab can cycle through while the prompt field is clean. */
   suggestedPrompts?: string[]
+  /** True when a resolved agent step will attach the branch's historical PRD. */
+  attachesPrdHistory?: boolean
 }
 
 type ToggleKey = "smart" | "yolo" | "humanReview" | "includeDirty" | "keepRunDir" | "tui" | "worktree"
@@ -313,7 +324,23 @@ export async function launchRunTui(options: LaunchRunTuiOptions): Promise<Launch
     config?.defaults.worktree === undefined
       ? await resolveWorktreeDefault(options.targetDir)
       : { isolate: config.defaults.worktree, reason: "set by defaults.worktree" }
-  return new LaunchPicker(renderer, options.targetDir, choices, config?.modelRouting?.gateway ?? "configured", worktree, options).result
+  const history = await loadLaunchHistory(options.targetDir, config?.defaults.prdHistory ?? true)
+  return new LaunchPicker(renderer, options.targetDir, choices, config?.modelRouting?.gateway ?? "configured", worktree, options, history).result
+}
+
+async function loadLaunchHistory(targetDir: string, enabled: boolean): Promise<LaunchHistoryContext> {
+  try {
+    const entries = (await readPrdHistoryIndex(targetDir)).filter((entry) => {
+      try {
+        return existsSync(prdHistoryFile(targetDir, entry))
+      } catch {
+        return false
+      }
+    })
+    return { enabled, entries, branch: await currentBranch(targetDir) }
+  } catch {
+    return { enabled, entries: [] }
+  }
 }
 
 export function pipelineChoices(config: ConvoyConfig | undefined, agents: readonly AgentSpec[]): PipelineChoice[] {
@@ -351,6 +378,7 @@ export function pipelineChoices(config: ConvoyConfig | undefined, agents: readon
         scored: Boolean(consensusStep(pipeline)) && hasWritableStep(pipeline),
         defaultPrompt: pipeline.defaultPrompt,
         suggestedPrompts: pipeline.suggestedPrompts,
+        attachesPrdHistory: pipeline.steps.some((step) => step.type === "agent" && step.prdHistory),
       }
     } catch (error) {
       return {
@@ -564,6 +592,7 @@ export class LaunchPicker {
     private readonly worktreeDefault: WorktreeDefault,
     // Named `callbacks` rather than `hooks`: this file already uses "hooks" for the pipeline's shell hooks.
     private readonly callbacks: Pick<LaunchRunTuiOptions, "prepareRun" | "proposeBranchName" | "checkBranchName">,
+    private readonly history: LaunchHistoryContext = { enabled: true, entries: [] },
   ) {
     this.toggleState.worktree = worktreeDefault.isolate
     const defaultIndex = choices.findIndex((choice) => choice.isDefault)
@@ -1475,6 +1504,7 @@ export class LaunchPicker {
       const agentSteps = choice.steps.filter((step) => step.kind === "agent").length
       lines.push(plain(""), t`${fg(theme.teal)(`Advisors: ${choice.advisedSteps}/${agentSteps} steps advised`)}`)
     }
+    this.pushHistoryNotice(lines, width, "picker")
     lines.push(plain(""))
     for (const line of hookLines(choice.hooks, width)) lines.push(line)
     if (this.message) {
@@ -1581,6 +1611,7 @@ export class LaunchPicker {
     const lines: StyledText[] = []
     lines.push(new StyledText([fg(theme.faint)("pipeline "), bold(fg(theme.text)(choice.name))]))
     lines.push(new StyledText([fg(theme.faint)("prompt   "), fg(theme.text)(truncate(this.prompt, Math.max(10, width - 9)))]))
+    this.pushHistoryNotice(lines, width, "options")
     lines.push(plain(""))
     lines.push(t`${fg(theme.dim)("Toggle extra run parameters, then press Enter to review.")}`)
     lines.push(new StyledText([fg(theme.faint)("gateway  "), bold(fg(theme.text)(gatewayLabel(this.gateway))), fg(theme.dim)("  (g to change)")]))
@@ -1713,6 +1744,35 @@ export class LaunchPicker {
     const lines = reviewRows.slice(this.reviewScroll, this.reviewScroll + visible)
     while (lines.length < visible) lines.push(plain(""))
     return joinLines(lines)
+  }
+
+  private historyPreview(): PrdHistoryPreview {
+    return resolvePrdHistoryPreview({
+      enabled: this.history.enabled,
+      isolateWorktree: this.toggleState.worktree,
+      attachesHistory: Boolean(this.currentChoice().attachesPrdHistory),
+      branch: this.history.branch,
+      entries: this.history.entries,
+      fileExists: () => true,
+    })
+  }
+
+  /**
+   * Picker stays quiet unless this checkout already has a PRD (browsing should
+   * not nag on every empty review). Options always shows attach-capable outcomes,
+   * including "none — will infer".
+   */
+  private pushHistoryNotice(lines: StyledText[], width: number, surface: "picker" | "options") {
+    const preview = this.historyPreview()
+    if (surface === "picker" && !preview.found) return
+    const copy = prdHistoryPreviewCopy(preview)
+    if (!copy) return
+    const tone = copy.tone === "attach" ? theme.teal : copy.tone === "warn" ? theme.yellow : theme.dim
+    lines.push(plain(""))
+    lines.push(new StyledText([fg(theme.faint)("history  "), fg(tone)(truncate(copy.headline, Math.max(8, width - 9)))]))
+    if (copy.detail) {
+      lines.push(new StyledText([raw("         "), fg(theme.dim)(truncate(copy.detail, Math.max(8, width - 9)))]))
+    }
   }
 
   private enabledFlags() {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -349,6 +349,8 @@ export type AgentStepSpec = {
    * read-only, and dropped for `parallel:` / `models:` fan-outs.
    */
   verify?: boolean
+  /** Attach the original branch PRD from the project's history when available. */
+  prdHistory?: boolean
 }
 
 export type HumanStepSpec = {
@@ -482,7 +484,7 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
     defaultPrompt: "Review the current branch against its base and report prioritized findings with a verified quality score.",
     suggestedPrompts: ["Review the open PR for this branch", "Review only the last commit's diff"],
     steps: [
-      { agent: "review-scope", name: "scope", model: defaultOpusModel, reports: "none", diff: true, verify: true },
+      { agent: "review-scope", name: "scope", model: defaultOpusModel, reports: "none", diff: true, verify: true, prdHistory: true },
       {
         parallel: [
           { agent: "clean-code-auditor", name: "clean-code", models: [fallbackModel, defaultOpusModel], reports: ["scope"] },
@@ -509,7 +511,7 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
     defaultPrompt: "Review the current branch against its base and report prioritized findings with a verified quality score.",
     suggestedPrompts: ["Review the open PR for this branch", "Review only the last commit's diff"],
     steps: [
-      { agent: "review-scope", name: "scope", model: glmModel, reports: "none", diff: true, verify: true },
+      { agent: "review-scope", name: "scope", model: glmModel, reports: "none", diff: true, verify: true, prdHistory: true },
       {
         parallel: [
           { agent: "clean-code-auditor", name: "clean-code", models: [glmModel, kimiModel], reports: ["scope"] },
@@ -581,7 +583,7 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
     defaultPrompt: "Review the current branch against its base and report prioritized findings.",
     suggestedPrompts: ["Review the open PR for this branch", "Review only the last commit's diff"],
     steps: [
-      { agent: "review-scope", name: "scope", model: fallbackModel, reports: "none", diff: true, verify: true },
+      { agent: "review-scope", name: "scope", model: fallbackModel, reports: "none", diff: true, verify: true, prdHistory: true },
       {
         parallel: [
           { agent: "clean-code-auditor", name: "clean-code", model: fallbackModel, reports: ["scope"] },
@@ -939,6 +941,7 @@ function resolveAgentStepSpec(raw: string | AgentStepSpec, ctx: ResolveStepConte
       deliverableContract: defaultDeliverableContract(agent.name, Boolean(forced || agent.readOnly)),
       ...(forced || agent.readOnly ? { readOnly: true } : {}),
       ...(verify ? { verify: true } : {}),
+      ...(spec.prdHistory ? { prdHistory: true } : {}),
     }
     return step
   })

--- a/src/prd-history.ts
+++ b/src/prd-history.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises"
 import { basename, join } from "node:path"
 
@@ -82,6 +83,123 @@ export async function readPrdHistoryIndex(targetDir: string): Promise<PrdHistory
     }
   }
   return entries
+}
+
+/** What the launcher / run-plan review should tell the operator about history. */
+export type PrdHistoryAction = "attach" | "skip-disabled" | "skip-no-scope" | "skip-new-worktree" | "skip-none"
+
+export type PrdHistoryPreview = {
+  /** Branch used for the lookup (current checkout, or detached-HEAD undefined). */
+  branch?: string
+  /** Oldest matching entry in this checkout, if any. Shown even when this run will not attach it. */
+  found?: PrdHistoryEntry
+  action: PrdHistoryAction
+}
+
+export type PrdHistoryPreviewCopy = {
+  headline: string
+  detail?: string
+  tone: "attach" | "warn" | "muted"
+}
+
+/**
+ * Pure preview of "does this checkout have a historical PRD, and will this run attach it?"
+ * Isolate-on means a *new* worktree, which does not inherit gitignored history.
+ */
+export function resolvePrdHistoryPreview(input: {
+  enabled: boolean
+  isolateWorktree: boolean
+  attachesHistory: boolean
+  branch?: string
+  excludeRunID?: string
+  entries: readonly PrdHistoryEntry[]
+  fileExists: (entry: PrdHistoryEntry) => boolean
+}): PrdHistoryPreview {
+  const found = pickPrdHistory(input.entries, {
+    branch: input.branch,
+    excludeRunID: input.excludeRunID,
+    fileExists: input.fileExists,
+  })
+  const preview: PrdHistoryPreview = {
+    ...(input.branch ? { branch: input.branch } : {}),
+    ...(found ? { found } : {}),
+    action: "skip-none",
+  }
+  if (!input.enabled) return { ...preview, action: "skip-disabled" }
+  if (!input.attachesHistory) return { ...preview, action: "skip-no-scope" }
+  if (input.isolateWorktree) return { ...preview, action: "skip-new-worktree" }
+  if (!found) return { ...preview, action: "skip-none" }
+  return { ...preview, action: "attach" }
+}
+
+/** Best-effort I/O wrapper around {@link resolvePrdHistoryPreview}; never throws. */
+export async function loadPrdHistoryPreview(input: {
+  targetDir: string
+  enabled: boolean
+  isolateWorktree: boolean
+  attachesHistory: boolean
+  branch?: string
+  excludeRunID?: string
+}): Promise<PrdHistoryPreview> {
+  let entries: PrdHistoryEntry[] = []
+  try {
+    entries = await readPrdHistoryIndex(input.targetDir)
+  } catch {
+    entries = []
+  }
+  return resolvePrdHistoryPreview({
+    enabled: input.enabled,
+    isolateWorktree: input.isolateWorktree,
+    attachesHistory: input.attachesHistory,
+    branch: input.branch,
+    excludeRunID: input.excludeRunID,
+    entries,
+    fileExists: (entry) => {
+      try {
+        return existsSync(prdHistoryFile(input.targetDir, entry))
+      } catch {
+        return false
+      }
+    },
+  })
+}
+
+export function formatPrdHistoryStamp(timestamp: number): string {
+  return new Date(timestamp).toISOString().slice(0, 10)
+}
+
+/** Operator-facing copy. `undefined` means stay silent (no noise on implement with an empty store). */
+export function prdHistoryPreviewCopy(preview: PrdHistoryPreview): PrdHistoryPreviewCopy | undefined {
+  const found = preview.found
+  const label = found ? `${found.pipeline} PRD · ${formatPrdHistoryStamp(found.timestamp)}` : undefined
+
+  switch (preview.action) {
+    case "attach":
+      if (!found || !label) return undefined
+      return {
+        headline: `will attach ${label}`,
+        ...(found.branch ? { detail: `original intent for ${found.branch}` } : {}),
+        tone: "attach",
+      }
+    case "skip-new-worktree":
+      if (found && label) {
+        return { headline: `this checkout has ${label}`, detail: "a new worktree will not see it", tone: "warn" }
+      }
+      return { headline: "new worktree · no historical PRD will be attached", tone: "muted" }
+    case "skip-no-scope":
+      if (!found || !label) return undefined
+      return { headline: `this checkout has ${label}`, detail: "this pipeline does not attach it", tone: "muted" }
+    case "skip-disabled":
+      if (!found || !label) return undefined
+      return { headline: `${label} found`, detail: "disabled by defaults.prdHistory", tone: "warn" }
+    case "skip-none":
+      return {
+        headline: preview.branch
+          ? `no historical PRD for ${preview.branch} · scope will infer from the diff`
+          : "no historical PRD · scope will infer from the diff",
+        tone: "muted",
+      }
+  }
 }
 
 export function pickPrdHistory(

--- a/src/prd-history.ts
+++ b/src/prd-history.ts
@@ -1,0 +1,137 @@
+import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises"
+import { basename, join } from "node:path"
+
+export type PrdHistoryEntry = {
+  runID: string
+  pipeline: string
+  /** Absent when HEAD was detached when the run started. */
+  branch?: string
+  timestamp: number
+  /** Basename of the verbatim prompt file in the history directory. */
+  file: string
+}
+
+export function prdHistoryDir(targetDir: string): string {
+  return join(targetDir, ".convoy", "prd-history")
+}
+
+export async function ensurePrdHistoryGitignore(dir: string): Promise<void> {
+  const path = join(dir, ".gitignore")
+  try {
+    if ((await readFile(path, "utf8")) === "*\n") return
+  } catch (error) {
+    if (!isErrno(error, "ENOENT")) throw error
+    try {
+      await writeFile(path, "*\n", { flag: "wx" })
+    } catch (writeError) {
+      // A concurrent run may have created it after the read above.
+      if (!isErrno(writeError, "EEXIST")) throw writeError
+    }
+    return
+  }
+
+  // Restore the invariant if a user or a previous version left a stale file.
+  await writeFile(path, "*\n")
+}
+
+export async function writePrdHistory(input: {
+  targetDir: string
+  runID: string
+  prompt: string
+  pipeline: string
+  branch?: string
+}): Promise<void> {
+  const dir = prdHistoryDir(input.targetDir)
+  await mkdir(dir, { recursive: true })
+  await ensurePrdHistoryGitignore(dir)
+
+  const file = `${input.runID}.prd.md`
+  await writeFile(join(dir, file), input.prompt, { mode: 0o600 })
+
+  const entry: PrdHistoryEntry = {
+    runID: input.runID,
+    pipeline: input.pipeline,
+    ...(input.branch ? { branch: input.branch } : {}),
+    timestamp: Date.now(),
+    file,
+  }
+  // appendFile opens in append mode, keeping each small JSONL record one append.
+  // Mode 0o600 on creation matches the prompt files: the index records branch and
+  // pipeline names the user may not want exposed to other local accounts.
+  await appendFile(join(dir, "index.jsonl"), `${JSON.stringify(entry)}\n`, { mode: 0o600 })
+}
+
+/** Returns an empty index when history has not been created yet, and skips corrupt JSONL records. */
+export async function readPrdHistoryIndex(targetDir: string): Promise<PrdHistoryEntry[]> {
+  let body: string
+  try {
+    body = await readFile(join(prdHistoryDir(targetDir), "index.jsonl"), "utf8")
+  } catch (error) {
+    if (isErrno(error, "ENOENT")) return []
+    throw error
+  }
+
+  const entries: PrdHistoryEntry[] = []
+  for (const line of body.split("\n")) {
+    if (!line.trim()) continue
+    try {
+      const entry = parseEntry(JSON.parse(line))
+      if (entry) entries.push(entry)
+    } catch {
+      // One incomplete or manually edited line must not hide the remaining history.
+    }
+  }
+  return entries
+}
+
+export function pickPrdHistory(
+  entries: readonly PrdHistoryEntry[],
+  options: { branch?: string; excludeRunID?: string; fileExists: (entry: PrdHistoryEntry) => boolean },
+): PrdHistoryEntry | undefined {
+  if (!options.branch) return undefined
+
+  let oldest: PrdHistoryEntry | undefined
+  for (const entry of entries) {
+    if (entry.runID === options.excludeRunID || entry.branch !== options.branch || !options.fileExists(entry)) continue
+    if (!oldest || entry.timestamp < oldest.timestamp || (entry.timestamp === oldest.timestamp && entry.runID < oldest.runID)) {
+      oldest = entry
+    }
+  }
+  return oldest
+}
+
+export function prdHistoryFile(targetDir: string, entry: PrdHistoryEntry): string {
+  if (!isHistoryFileName(entry.file)) throw new Error(`invalid PRD history file name: ${entry.file}`)
+  return join(prdHistoryDir(targetDir), entry.file)
+}
+
+function parseEntry(value: unknown): PrdHistoryEntry | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return undefined
+  const record = value as Record<string, unknown>
+  if (
+    typeof record.runID !== "string" ||
+    typeof record.pipeline !== "string" ||
+    typeof record.timestamp !== "number" ||
+    !Number.isFinite(record.timestamp) ||
+    typeof record.file !== "string" ||
+    !isHistoryFileName(record.file) ||
+    (record.branch !== undefined && typeof record.branch !== "string")
+  ) {
+    return undefined
+  }
+  return {
+    runID: record.runID,
+    pipeline: record.pipeline,
+    ...(typeof record.branch === "string" ? { branch: record.branch } : {}),
+    timestamp: record.timestamp,
+    file: record.file,
+  }
+}
+
+function isHistoryFileName(value: string): boolean {
+  return value === basename(value) && value.endsWith(".prd.md") && value.length > ".prd.md".length
+}
+
+function isErrno(error: unknown, code: string): boolean {
+  return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === code
+}

--- a/src/review-tui.ts
+++ b/src/review-tui.ts
@@ -4,6 +4,7 @@ import { StyledText, fg } from "@opentui/core"
 
 import { defaultAdvisorMaxCalls } from "./advisor"
 import { gatewayLabel } from "./model-routing"
+import { prdHistoryPreviewCopy } from "./prd-history"
 import { plannedStepAdvisor, plannedStepModel } from "./run-plan"
 import { sanitizeReviewInline, sanitizeReviewText } from "./run-review"
 import { stepRunnerFor } from "./step-runners"
@@ -53,6 +54,7 @@ export function runReviewLines(plan: RunPlan, width: number, options: RunReviewR
   } else {
     rows.push(continuation([fg(theme.dim)("runs in the current checkout")]))
   }
+  pushHistoryRows(rows, plan, value)
   rows.push(plain(""))
 
   rows.push(labelRow("gateway", [fg(theme.text)(gatewayLabel(plan.modelRouting.gateway))]))
@@ -93,6 +95,17 @@ export function runReviewLines(plan: RunPlan, width: number, options: RunReviewR
   }
 
   return rows
+}
+
+function pushHistoryRows(rows: StyledText[], plan: RunPlan, value: number) {
+  if (!plan.prdHistory) return
+  const copy = prdHistoryPreviewCopy(plan.prdHistory)
+  if (!copy) return
+  const tone = copy.tone === "attach" ? theme.teal : copy.tone === "warn" ? theme.yellow : theme.dim
+  rows.push(labelRow("history", [fg(tone)(truncate(sanitizeReviewInline(copy.headline), value))]))
+  if (copy.detail) {
+    rows.push(continuation([fg(theme.dim)(truncate(sanitizeReviewInline(copy.detail), value))]))
+  }
 }
 
 function pipelineSummary(plan: RunPlan): string {

--- a/src/run-plan.ts
+++ b/src/run-plan.ts
@@ -1,4 +1,5 @@
 import { resolveModel, type ModelGateway, type ModelRoutingOverrides } from "./model-routing"
+import type { PrdHistoryPreview } from "./prd-history"
 import { defaultGoalMaxIterations, defaultGoalPlateau } from "./quality-score"
 import { stepRunnerFor } from "./step-runners"
 import type { AgentStep, Pipeline, RunOptions, RunPlan, Step } from "./types"
@@ -12,6 +13,8 @@ export type BuildRunPlanInput = RunOptions & {
   worktreeDir?: string
   /** The run's frozen gateway when resuming; recorded in the plan when an explicit --gateway replaces it. */
   resumeGateway?: ModelGateway
+  /** Precomputed checkout preview; `buildRunPlan` does not touch the filesystem. */
+  prdHistoryPreview?: PrdHistoryPreview
 }
 
 /** Purely resolves the complete execution shape; it performs no filesystem or process effects. */
@@ -58,6 +61,7 @@ export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
     ...(judge ? { smartJudge: { model: judge } } : {}),
     hooks,
     attachments: [...input.files],
+    ...(input.prdHistoryPreview ? { prdHistory: input.prdHistoryPreview } : {}),
     permissions: input.yolo ? "yolo" : input.smart ? "smart" : "interactive",
     ...(goal ? { goal } : {}),
     ...(input.resumeRunID

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -3,6 +3,7 @@ import { stdin, stdout } from "node:process"
 
 import { defaultAdvisorMaxCalls } from "./advisor"
 import { gatewayLabel } from "./model-routing"
+import { prdHistoryPreviewCopy } from "./prd-history"
 import { plannedStepAdvisor, plannedStepModel } from "./run-plan"
 import { stepRunnerFor } from "./step-runners"
 import type { RunPlan } from "./types"
@@ -25,6 +26,7 @@ export function renderRunPlan(plan: RunPlan, compact = false, options: RunPlanRe
     `Target: ${sanitizeInline(plan.target.directory)}`,
     `  Diff base: ${sanitizeInline(plan.target.baseRef)} · working tree: ${plan.target.dirty ? "include dirty" : "clean required"}`,
     `  Worktree: ${plan.target.worktree ? `yes · branch ${plan.target.branch ? sanitizeInline(plan.target.branch) : "named at start"}` : "no"}`,
+    ...prdHistoryPlanLines(plan),
     `Pipeline: ${sanitizeInline(plan.pipeline.name)} · ${plan.pipeline.steps.length} steps`,
     `Gateway: ${gatewayLabel(plan.modelRouting.gateway)}`,
     `Advisors: ${plan.pipeline.steps.filter((step) => step.type === "agent" && Boolean(plannedStepAdvisor(step))).length}/${plan.pipeline.steps.filter((step) => step.type === "agent").length} steps advised`,
@@ -102,6 +104,15 @@ export async function confirmRunPlan(plan: RunPlan): Promise<boolean> {
   } finally {
     prompt.close()
   }
+}
+
+function prdHistoryPlanLines(plan: RunPlan): string[] {
+  if (!plan.prdHistory) return []
+  const copy = prdHistoryPreviewCopy(plan.prdHistory)
+  if (!copy) return []
+  const headline = sanitizeInline(copy.headline)
+  if (copy.detail) return [`PRD history: ${headline}`, `  ${sanitizeInline(copy.detail)}`]
+  return [`PRD history: ${headline}`]
 }
 
 function sanitize(value: string) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import { link, mkdir, readFile, rename, rm, stat, unlink, writeFile } from "node:fs/promises"
 import { randomUUID } from "node:crypto"
 import { dirname, join } from "node:path"
@@ -27,6 +28,7 @@ import { HerdrReporter } from "./herdr"
 import { defaultNotificationSettings, Notifier } from "./notifications"
 import { startPermissionGate, type PermissionGate } from "./permissions"
 import { agentsForPipeline, deliverableContractForPhase, splitModelVariant, validateStepFilters } from "./pipeline"
+import { pickPrdHistory, prdHistoryFile, readPrdHistoryIndex, writePrdHistory } from "./prd-history"
 import { formatTerminalTitle, projectName, RunStatusTracker, trackRunStatus } from "./run-status"
 import { popTerminalTitle, pushTerminalTitle, writeTerminalTitle } from "./terminal-title"
 import {
@@ -460,6 +462,20 @@ export async function run(options: RunOptions, deps: RunDeps = defaultRunDeps) {
   const workspace = options.resumeRunID
     ? await resumeWorkspace(options.resumeRunID)
     : await createWorkspace(options.prompt)
+
+  if (options.prdHistory && !options.resumeRunID && options.prompt.trim()) {
+    try {
+      await writePrdHistory({
+        targetDir: options.targetDir,
+        runID: workspace.runID,
+        prompt: options.prompt,
+        pipeline: options.pipeline.name,
+        branch: await currentBranch(options.targetDir),
+      })
+    } catch (error) {
+      log.warn(`couldn't write PRD history: ${formatSdkError(error)}`)
+    }
+  }
 
   let runErr: unknown
   let opencode: Awaited<ReturnType<typeof startOpencode>> | undefined
@@ -1152,7 +1168,7 @@ type PreparedPhaseRun = {
   loopGuard: LoopGuardConfig
 }
 
-async function preparePhaseRun(
+export async function preparePhaseRun(
   workspace: Workspace,
   phase: AgentStep,
   options: RunOptions,
@@ -1169,11 +1185,36 @@ async function preparePhaseRun(
 
   const phaseFiles = await fileParts(inputs, workspace.dir, "skip")
   const contextFiles = await projectContextFileParts(projectContextFiles, options.targetDir)
-  const attachments = [...contextFiles, ...phaseFiles, ...extraFiles]
+  const historyFiles = options.prdHistory && phase.prdHistory ? await historicalPrdFileParts(options.targetDir, workspace.runID) : []
+  const attachments = [...contextFiles, ...phaseFiles, ...historyFiles, ...extraFiles]
   const prompt = buildPhasePrompt(workspace, phase)
   const model = selectedModel(phase, options.modelOverride)
 
   return { attachments, prompt, model, loopGuard: resolveLoopGuard(options.loopGuard) }
+}
+
+/** Best-effort dynamic attachment: history stays out of frozen pipeline metadata. */
+async function historicalPrdFileParts(targetDir: string, excludeRunID: string): Promise<FilePartInput[]> {
+  try {
+    const branch = await currentBranch(targetDir)
+    if (!branch) return []
+    const entry = pickPrdHistory(await readPrdHistoryIndex(targetDir), {
+      branch,
+      excludeRunID,
+      fileExists: (candidate) => {
+        try {
+          return existsSync(prdHistoryFile(targetDir, candidate))
+        } catch {
+          return false
+        }
+      },
+    })
+    if (!entry) return []
+    return await fileParts([prdHistoryFile(targetDir, entry)], targetDir, "skip")
+  } catch (error) {
+    log.warn(`couldn't read PRD history: ${formatSdkError(error)}`)
+    return []
+  }
 }
 
 async function projectContextFileParts(paths: string[], targetDir: string) {
@@ -2691,7 +2732,7 @@ function buildPhasePrompt(workspace: Workspace, phase: AgentStep) {
         : "This phase may edit the target repository when the phase-specific instructions call for it.",
     "",
     "## Attachments",
-    "You will receive as file attachments: project context files when present, the original PRD, previous phase reports, the cumulative diff against the base branch, and any `--file` passed by the user. Read them before acting.",
+    "You will receive as file attachments: project context files when present, the original PRD, the project's historical PRD for this branch when present, previous phase reports, the cumulative diff against the base branch, and any `--file` passed by the user. Read them before acting.",
     "",
     "## Project context",
     "Convoy automatically attaches these target-repo files when they exist: `.convoy/rules.md`, `AGENTS.md`, and `CLAUDE.md`.",

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { AdvisorAuditPolicy } from "./advisor-events"
 import type { LoopGuardSettings } from "./loop-guard"
 import type { NotificationSettings } from "./notifications"
+import type { PrdHistoryPreview } from "./prd-history"
 import type { AutoAccept, ProgressUI } from "./progress"
 import type { StepRunnerId } from "./step-runners"
 import type { ModelGateway, ModelRoutingOverrides, ResolvedModel } from "./model-routing"
@@ -309,6 +310,12 @@ export type RunPlan = {
   smartJudge?: { model: ResolvedModel }
   hooks: HookSet
   attachments: string[]
+  /**
+   * Operator-facing preview of the checkout's historical PRD. Computed before
+   * confirmation (never inside `buildRunPlan`) so the launcher and CLI review
+   * can say whether scope will attach it. Absent when the caller did not load one.
+   */
+  prdHistory?: PrdHistoryPreview
   permissions: "interactive" | "smart" | "yolo"
   /**
    * Goal mode, when enabled for this run: the target score, the bounded loop

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import type { ModelGateway, ModelRoutingOverrides, ResolvedModel } from "./model
 
 export type RunOptions = {
   prompt: string
+  /** Whether this run persists and attaches the project's git-ignored PRD history. */
+  prdHistory: boolean
   files: string[]
   onlySteps: string[]
   skipSteps: string[]
@@ -240,6 +242,8 @@ export type AgentStep = {
    * Never set without `readOnly`. Dropped for `parallel:` / `models:` fan-outs.
    */
   verify?: boolean
+  /** Attach the original branch PRD from the project history when available. */
+  prdHistory?: boolean
   /** Shared by every step produced from the same top-level pipeline entry; the runner batches same-groupId steps to run concurrently. */
   groupId: string
   /** Pre-fan-out logical name; equals `name` unless this step was produced by a `models:` fan-out. */

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -75,6 +75,12 @@ describe("config loading", () => {
     expect(config.hooks).toEqual({ pre: [], post: [], pipelines: {} })
   })
 
+  test("parses the optional PRD history default and rejects non-booleans", () => {
+    expect(parse("defaults:\n  prdHistory: true").defaults.prdHistory).toBe(true)
+    expect(parse("defaults:\n  prdHistory: false").defaults.prdHistory).toBe(false)
+    expect(() => parse("defaults:\n  prdHistory: enabled")).toThrow("defaults.prdHistory must be true or false")
+  })
+
   test("parses a full project config", async () => {
     const dir = await projectDir(undefined, ["api-reviewer"])
     const config = parse(
@@ -341,6 +347,15 @@ describe("parallel steps and model fan-out", () => {
       { agent: "review-scope", name: "scope", verify: true },
       { agent: "review-report", name: "report" },
     ])
+  })
+
+  test("parses PRD history on a step and rejects non-booleans", () => {
+    expect(parse("pipelines:\n  p:\n    steps:\n      - agent: review-scope\n        prdHistory: true").pipelines.p?.steps).toEqual([
+      { agent: "review-scope", prdHistory: true },
+    ])
+    expect(() => parse("pipelines:\n  p:\n    steps:\n      - agent: review-scope\n        prdHistory: yes")).toThrow(
+      "prdHistory must be true or false",
+    )
   })
 
   test("rejects an empty parallel block", () => {

--- a/test/goal-loop-owned-tui.test.ts
+++ b/test/goal-loop-owned-tui.test.ts
@@ -66,6 +66,7 @@ const goalFixPipeline = resolvePipeline({ name: "goal-fix", spec: builtInPipelin
 function makeOptions(overrides: Partial<RunOptions> = {}): RunOptions {
   return {
     prompt: "build it",
+    prdHistory: true,
     files: [],
     onlySteps: [],
     skipSteps: [],

--- a/test/goal-loop-regressions.test.ts
+++ b/test/goal-loop-regressions.test.ts
@@ -85,6 +85,7 @@ const goalFixPipeline = resolvePipeline({ name: "goal-fix", spec: builtInPipelin
 function makeOptions(overrides: Partial<RunOptions> = {}): RunOptions {
   return {
     prompt: "build it",
+    prdHistory: true,
     files: [],
     onlySteps: [],
     skipSteps: [],

--- a/test/goal-loop.test.ts
+++ b/test/goal-loop.test.ts
@@ -20,6 +20,7 @@ const goalFixPipeline = resolvePipeline({ name: "goal-fix", spec: builtInPipelin
 function makeOptions(overrides: Partial<RunOptions> = {}): RunOptions {
   return {
     prompt: "build it",
+    prdHistory: true,
     files: [],
     onlySteps: [],
     skipSteps: [],

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -53,9 +53,11 @@ type LaunchPickerView = {
   mode: string
   prompt: string
   optionIndex: number
+  toggleState: { worktree: boolean }
   modalWidth(): number
   promptDetail(width: number): { chunks: Array<{ text: string }> }
   optionsDetail(width: number): { chunks: Array<{ text: string }> }
+  pipelineDetail(width: number): { chunks: Array<{ text: string }> }
 }
 
 function launchView(picker: LaunchPicker): LaunchPickerView {
@@ -594,6 +596,7 @@ describe("launch TUI pipeline choices", () => {
       "Review the current branch against its base and report prioritized findings with a verified quality score.",
     )
     expect(review?.suggestedPrompts).toEqual(["Review the open PR for this branch", "Review only the last commit's diff"])
+    expect(review?.attachesPrdHistory).toBe(true)
   })
 
   test("leaves defaultPrompt and suggestedPrompts unset for pipelines without them", () => {
@@ -601,6 +604,7 @@ describe("launch TUI pipeline choices", () => {
     const implement = choices.find((choice) => choice.name === "implement")
     expect(implement?.defaultPrompt).toBeUndefined()
     expect(implement?.suggestedPrompts).toBeUndefined()
+    expect(implement?.attachesPrdHistory).toBe(false)
   })
 
   test("configured pipelines carry their defaultPrompt and suggestedPrompts", () => {
@@ -623,6 +627,86 @@ describe("launch TUI pipeline choices", () => {
     expect(triage?.source).toBe("configured")
     expect(triage?.defaultPrompt).toBe("Triage the incoming reports.")
     expect(triage?.suggestedPrompts).toEqual(["Triage today's reports"])
+  })
+})
+
+describe("launch TUI historical PRD notice", () => {
+  const historyEntry = {
+    runID: "20260817-103045-x7q2",
+    pipeline: "implement",
+    branch: "feat/history",
+    timestamp: Date.UTC(2026, 7, 17),
+    file: "20260817-103045-x7q2.prd.md",
+  }
+
+  function reviewChoice() {
+    return {
+      name: "review",
+      description: "Review the branch.",
+      source: "built-in" as const,
+      isDefault: true,
+      steps: [],
+      hooks: [],
+      valid: true,
+      advisedSteps: 0,
+      scored: false,
+      attachesPrdHistory: true,
+    }
+  }
+
+  async function createHistoryLauncher(isolate: boolean) {
+    const testRenderer = await createTestRenderer({ width: 100, height: 40 })
+    const picker = new LaunchPicker(
+      testRenderer.renderer,
+      process.cwd(),
+      [reviewChoice()],
+      "configured",
+      { isolate, reason: "test" },
+      {} as never,
+      { enabled: true, branch: "feat/history", entries: [historyEntry] },
+    )
+    return { ...testRenderer, picker }
+  }
+
+  function panelText(content: { chunks: Array<{ text: string }> }) {
+    return content.chunks.map((chunk) => chunk.text).join("")
+  }
+
+  test("shows that this checkout's historical PRD will be attached when running in place", async () => {
+    const launcher = await createHistoryLauncher(false)
+    try {
+      const view = launchView(launcher.picker)
+      const detail = panelText(view.pipelineDetail(80))
+      const options = panelText(view.optionsDetail(80))
+      expect(detail).toContain("will attach implement PRD · 2026-08-17")
+      expect(detail).toContain("original intent for feat/history")
+      expect(options).toContain("will attach implement PRD · 2026-08-17")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("warns that a new worktree will not see this checkout's historical PRD", async () => {
+    const launcher = await createHistoryLauncher(true)
+    try {
+      const view = launchView(launcher.picker)
+      expect(panelText(view.pipelineDetail(80))).toContain("a new worktree will not see it")
+      expect(panelText(view.optionsDetail(80))).toContain("this checkout has implement PRD · 2026-08-17")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("updates the options notice when isolate is toggled", async () => {
+    const launcher = await createHistoryLauncher(false)
+    try {
+      const view = launchView(launcher.picker)
+      expect(panelText(view.optionsDetail(80))).toContain("will attach implement PRD")
+      view.toggleState.worktree = true
+      expect(panelText(view.optionsDetail(80))).toContain("a new worktree will not see it")
+    } finally {
+      await closeLauncher(launcher)
+    }
   })
 })
 

--- a/test/metadata.test.ts
+++ b/test/metadata.test.ts
@@ -607,6 +607,18 @@ describe("openRunMetadata", () => {
     }
   })
 
+  test("assertSafePipelineArtifacts: accepts a frozen PRD history flag", async () => {
+    const { ws, cleanup } = await withDir("history")
+    const step = { ...validAgentStep("scope"), prdHistory: true }
+    const store = await openRunMetadata(ws, "/target", validPipeline([step]))
+    try {
+      expect(store).toBeDefined()
+    } finally {
+      await store.flush()
+      await cleanup()
+    }
+  })
+
   test("assertSafePipelineArtifacts: accepts reports/<step>.md as input", async () => {
     const { ws, cleanup } = await withDir("ok2")
     const step = validAgentStep("design")

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -306,6 +306,7 @@ describe("built-in review pipeline", () => {
       agentName: "review-scope",
       readOnly: true,
       verify: true,
+      prdHistory: true,
     })
     // Not fanned out, so it keeps its own name (no __ro suffix).
     expect(scope?.agentName.endsWith("__ro")).toBe(false)
@@ -357,6 +358,27 @@ describe("built-in review pipeline", () => {
       "reports/score__openai-gpt-5-6-sol-xhigh.md",
       "reports/score__anthropic-claude-opus-5.md",
     ])
+  })
+})
+
+describe("PRD history pipeline plumbing", () => {
+  test("marks only built-in review scope steps for historical PRD attachment", () => {
+    for (const name of ["review", "review-lite", "review-cc"] as const) {
+      const steps = resolvePipeline({ name, spec: builtInPipelines[name]!, agents: builtInAgents }).steps
+      const scope = steps.find((step): step is AgentStep => step.type === "agent" && step.name === "scope")
+      expect(scope?.prdHistory).toBe(true)
+      expect(steps.filter((step): step is AgentStep => step.type === "agent" && step.name !== "scope").every((step) => step.prdHistory === undefined)).toBe(true)
+    }
+
+    for (const name of ["implement", "ship", "hunter"] as const) {
+      const steps = resolvePipeline({ name, spec: builtInPipelines[name]!, agents: builtInAgents }).steps
+      expect(steps.every((step) => step.type !== "agent" || step.prdHistory === undefined)).toBe(true)
+    }
+  })
+
+  test("threads enabled custom step history and omits disabled history", () => {
+    expect(agentSteps({ steps: [{ agent: "review-scope", prdHistory: true }] })[0]?.prdHistory).toBe(true)
+    expect(agentSteps({ steps: [{ agent: "review-scope", prdHistory: false }] })[0]?.prdHistory).toBeUndefined()
   })
 })
 

--- a/test/prd-history.test.ts
+++ b/test/prd-history.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { pickPrdHistory, prdHistoryDir, readPrdHistoryIndex, writePrdHistory, type PrdHistoryEntry } from "../src/prd-history"
+import { formatPrdHistoryStamp, loadPrdHistoryPreview, pickPrdHistory, prdHistoryDir, prdHistoryPreviewCopy, readPrdHistoryIndex, resolvePrdHistoryPreview, writePrdHistory, type PrdHistoryEntry } from "../src/prd-history"
 
 const dirs: string[] = []
 
@@ -125,5 +125,55 @@ describe("PRD history", () => {
         { branch: "feat/history", fileExists: () => true },
       ),
     ).toMatchObject({ runID: "later" })
+  })
+
+  test("resolves whether this run will attach a checkout-local historical PRD", () => {
+    const entry: PrdHistoryEntry = { runID: "old", pipeline: "implement", branch: "feat/history", timestamp: Date.UTC(2026, 7, 17), file: "old.prd.md" }
+    const base = { branch: "feat/history", entries: [entry], fileExists: () => true }
+
+    expect(resolvePrdHistoryPreview({ ...base, enabled: true, isolateWorktree: false, attachesHistory: true })).toEqual({
+      branch: "feat/history",
+      found: entry,
+      action: "attach",
+    })
+    expect(resolvePrdHistoryPreview({ ...base, enabled: true, isolateWorktree: true, attachesHistory: true }).action).toBe("skip-new-worktree")
+    expect(resolvePrdHistoryPreview({ ...base, enabled: true, isolateWorktree: false, attachesHistory: false }).action).toBe("skip-no-scope")
+    expect(resolvePrdHistoryPreview({ ...base, enabled: false, isolateWorktree: false, attachesHistory: true }).action).toBe("skip-disabled")
+    expect(resolvePrdHistoryPreview({ ...base, enabled: true, isolateWorktree: false, attachesHistory: true, entries: [] }).action).toBe("skip-none")
+    expect(resolvePrdHistoryPreview({ ...base, enabled: true, isolateWorktree: false, attachesHistory: true, excludeRunID: "old" }).found).toBeUndefined()
+  })
+
+  test("formats operator-facing copy and stays silent when there is nothing to say", () => {
+    const entry: PrdHistoryEntry = { runID: "old", pipeline: "implement", branch: "feat/history", timestamp: Date.UTC(2026, 7, 17), file: "old.prd.md" }
+    expect(formatPrdHistoryStamp(entry.timestamp)).toBe("2026-08-17")
+
+    expect(prdHistoryPreviewCopy({ action: "attach", found: entry })).toEqual({
+      headline: "will attach implement PRD · 2026-08-17",
+      detail: "original intent for feat/history",
+      tone: "attach",
+    })
+    expect(prdHistoryPreviewCopy({ action: "skip-new-worktree", found: entry })).toMatchObject({
+      headline: "this checkout has implement PRD · 2026-08-17",
+      detail: "a new worktree will not see it",
+      tone: "warn",
+    })
+    expect(prdHistoryPreviewCopy({ action: "skip-new-worktree" })?.headline).toContain("new worktree")
+    expect(prdHistoryPreviewCopy({ action: "skip-no-scope", found: entry })?.detail).toBe("this pipeline does not attach it")
+    expect(prdHistoryPreviewCopy({ action: "skip-no-scope" })).toBeUndefined()
+    expect(prdHistoryPreviewCopy({ action: "skip-disabled", found: entry })?.detail).toBe("disabled by defaults.prdHistory")
+    expect(prdHistoryPreviewCopy({ action: "skip-disabled" })).toBeUndefined()
+    expect(prdHistoryPreviewCopy({ action: "skip-none", branch: "feat/history" })?.headline).toContain("feat/history")
+  })
+
+  test("loads a checkout preview from the on-disk index without throwing on an empty store", async () => {
+    const dir = await repo()
+    expect(await loadPrdHistoryPreview({ targetDir: dir, enabled: true, isolateWorktree: false, attachesHistory: true, branch: "main" })).toMatchObject({
+      action: "skip-none",
+      branch: "main",
+    })
+
+    await writePrdHistory({ targetDir: dir, runID: "run-1", prompt: "# First PRD\n", pipeline: "implement", branch: "main" })
+    const preview = await loadPrdHistoryPreview({ targetDir: dir, enabled: true, isolateWorktree: false, attachesHistory: true, branch: "main" })
+    expect(preview).toMatchObject({ action: "attach", found: { runID: "run-1", pipeline: "implement", branch: "main" } })
   })
 })

--- a/test/prd-history.test.ts
+++ b/test/prd-history.test.ts
@@ -1,0 +1,129 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { pickPrdHistory, prdHistoryDir, readPrdHistoryIndex, writePrdHistory, type PrdHistoryEntry } from "../src/prd-history"
+
+const dirs: string[] = []
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function git(args: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn(["git", "-c", "commit.gpgsign=false", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "convoy-test",
+      GIT_AUTHOR_EMAIL: "convoy-test@example.invalid",
+      GIT_COMMITTER_NAME: "convoy-test",
+      GIT_COMMITTER_EMAIL: "convoy-test@example.invalid",
+    },
+  })
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()])
+  if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")}: ${stderr}`)
+  return stdout.trim()
+}
+
+async function repo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "convoy-prd-history-"))
+  dirs.push(dir)
+  await git(["init", "-q", "-b", "main"], dir)
+  await writeFile(join(dir, "README.md"), "# test\n")
+  await git(["add", "README.md"], dir)
+  await git(["commit", "-qm", "initial"], dir)
+  return dir
+}
+
+describe("PRD history", () => {
+  test("writes private append-only prompt history without dirtying or cleaning the repository", async () => {
+    const dir = await repo()
+
+    await writePrdHistory({ targetDir: dir, runID: "run-1", prompt: "# First PRD\n", pipeline: "implement", branch: "main" })
+    await writeFile(join(prdHistoryDir(dir), ".gitignore"), "not ignored\n")
+    await writePrdHistory({ targetDir: dir, runID: "run-2", prompt: "# Second PRD\n", pipeline: "review", branch: "main" })
+
+    const history = prdHistoryDir(dir)
+    expect(await readFile(join(history, ".gitignore"), "utf8")).toBe("*\n")
+    expect(await readFile(join(history, "run-1.prd.md"), "utf8")).toBe("# First PRD\n")
+    expect(await readFile(join(history, "run-2.prd.md"), "utf8")).toBe("# Second PRD\n")
+    expect((await stat(join(history, "run-1.prd.md"))).mode & 0o777).toBe(0o600)
+    // The index records branch/pipeline names; keep it as private as the prompts.
+    expect((await stat(join(history, "index.jsonl"))).mode & 0o777).toBe(0o600)
+
+    const entries = await readPrdHistoryIndex(dir)
+    expect(entries).toHaveLength(2)
+    expect(entries.map(({ runID, pipeline, branch, file }) => ({ runID, pipeline, branch, file }))).toEqual([
+      { runID: "run-1", pipeline: "implement", branch: "main", file: "run-1.prd.md" },
+      { runID: "run-2", pipeline: "review", branch: "main", file: "run-2.prd.md" },
+    ])
+    expect(await git(["status", "--porcelain=v1", "--untracked-files=all"], dir)).toBe("")
+
+    await git(["clean", "-fd"], dir)
+    expect(await readFile(join(history, "run-1.prd.md"), "utf8")).toBe("# First PRD\n")
+    expect(await readFile(join(history, "index.jsonl"), "utf8")).toContain('"runID":"run-2"')
+  })
+
+  test("skips malformed index records", async () => {
+    const dir = await repo()
+    const history = prdHistoryDir(dir)
+    await mkdir(history, { recursive: true })
+    await Bun.write(join(history, "index.jsonl"), ["not json", JSON.stringify({ runID: "good", pipeline: "implement", branch: "main", timestamp: 1, file: "good.prd.md" }), '{"file":"../escape.prd.md"}'].join("\n"))
+
+    expect(await readPrdHistoryIndex(dir)).toEqual([{ runID: "good", pipeline: "implement", branch: "main", timestamp: 1, file: "good.prd.md" }])
+  })
+
+  test("returns an empty index when no history directory exists yet", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-prd-history-empty-"))
+    dirs.push(dir)
+    expect(await readPrdHistoryIndex(dir)).toEqual([])
+  })
+
+  test("rejects when the history directory cannot be created, leaving no index", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-prd-history-blocked-"))
+    dirs.push(dir)
+    // Put a file where the history dir would descend through, so mkdir -p hits
+    // ENOTDIR regardless of uid (chmod-to-deny is a no-op for root; ENOTDIR is not).
+    await writeFile(join(dir, "blocker"), "not a directory\n")
+    await expect(
+      writePrdHistory({ targetDir: join(dir, "blocker"), runID: "nope", prompt: "p", pipeline: "implement", branch: "main" }),
+    ).rejects.toThrow()
+    // The caller (run()) swallows this; confirm no partial index survived.
+    expect(await readPrdHistoryIndex(dir)).toEqual([])
+  })
+
+  test("picks the oldest existing matching-branch entry, excluding the current run", () => {
+    const entries: PrdHistoryEntry[] = [
+      { runID: "new", pipeline: "review", branch: "feat/history", timestamp: 30, file: "new.prd.md" },
+      { runID: "other-branch", pipeline: "implement", branch: "main", timestamp: 1, file: "other-branch.prd.md" },
+      { runID: "missing", pipeline: "implement", branch: "feat/history", timestamp: 2, file: "missing.prd.md" },
+      { runID: "old", pipeline: "implement", branch: "feat/history", timestamp: 10, file: "old.prd.md" },
+      { runID: "tie-z", pipeline: "implement", branch: "feat/tie", timestamp: 5, file: "tie-z.prd.md" },
+      { runID: "tie-a", pipeline: "implement", branch: "feat/tie", timestamp: 5, file: "tie-a.prd.md" },
+    ]
+
+    expect(pickPrdHistory([], { branch: "feat/history", fileExists: () => true })).toBeUndefined()
+    expect(
+      pickPrdHistory(entries, { branch: "feat/history", excludeRunID: "new", fileExists: (entry) => entry.runID !== "missing" }),
+    ).toMatchObject({ runID: "old" })
+    expect(pickPrdHistory(entries, { branch: "feat/tie", fileExists: () => true })).toMatchObject({ runID: "tie-a" })
+
+    // A detached-HEAD run records no branch and must never be selected: not when
+    // the current branch is undefined, and not as a recorded entry shadowing an
+    // actual branch match even when its timestamp is the smallest.
+    expect(pickPrdHistory(entries, { branch: undefined, fileExists: () => true })).toBeUndefined()
+    expect(
+      pickPrdHistory(
+        [
+          { runID: "detached", pipeline: "implement", timestamp: 0, file: "detached.prd.md" },
+          { runID: "later", pipeline: "implement", branch: "feat/history", timestamp: 100, file: "later.prd.md" },
+        ],
+        { branch: "feat/history", fileExists: () => true },
+      ),
+    ).toMatchObject({ runID: "later" })
+  })
+})

--- a/test/review-tui.test.ts
+++ b/test/review-tui.test.ts
@@ -118,6 +118,37 @@ describe("run review TUI", () => {
     expect(lines.some((line) => line.includes("runtime  smart permissions · 2 attachments · judge openrouter/openai/gpt-5.6-terra#xhigh"))).toBe(true)
   })
 
+  test("renders a historical PRD that this run will attach", () => {
+    const plan = planWith([], {
+      prdHistory: {
+        action: "attach",
+        branch: "feat/history",
+        found: { runID: "old", pipeline: "implement", branch: "feat/history", timestamp: Date.UTC(2026, 7, 17), file: "old.prd.md" },
+      },
+    })
+
+    const lines = plain(runReviewLines(plan, 100))
+
+    expect(lines.some((line) => line.includes("history  will attach implement PRD · 2026-08-17"))).toBe(true)
+    expect(lines.some((line) => line.includes("original intent for feat/history"))).toBe(true)
+  })
+
+  test("warns when isolate will hide a checkout-local historical PRD", () => {
+    const plan = planWith([], {
+      target: { directory: "/repo", baseRef: "main", worktree: true, dirty: false, branch: "feat/new" },
+      prdHistory: {
+        action: "skip-new-worktree",
+        branch: "feat/history",
+        found: { runID: "old", pipeline: "implement", branch: "feat/history", timestamp: Date.UTC(2026, 7, 17), file: "old.prd.md" },
+      },
+    })
+
+    const lines = plain(runReviewLines(plan, 100))
+
+    expect(lines.some((line) => line.includes("this checkout has implement PRD · 2026-08-17"))).toBe(true)
+    expect(lines.some((line) => line.includes("a new worktree will not see it"))).toBe(true)
+  })
+
   test("expands the full prompt with hard wrapping and collapses it back to an excerpt", () => {
     const long = `first ${"requirement ".repeat(30)}\nsecond line`
     const plan = planWith([], { prompt: { source: "inline", text: long } })

--- a/test/run-plan.test.ts
+++ b/test/run-plan.test.ts
@@ -53,6 +53,44 @@ test("the immutable plan filters and freezes exact routed targets", () => {
   expect(Object.isFrozen(options.hooks.pre[0])).toBe(false)
 })
 
+test("freezes a precomputed PRD history preview onto the reviewed plan", () => {
+  const preview = {
+    action: "attach" as const,
+    branch: "feat/history",
+    found: { runID: "old", pipeline: "implement", branch: "feat/history", timestamp: 1, file: "old.prd.md" },
+  }
+  const plan = buildRunPlan({
+    prompt: "review",
+    prdHistory: true,
+    files: [],
+    onlySteps: [],
+    skipSteps: [],
+    resumeRunID: "",
+    keepRunDir: true,
+    modelOverride: "",
+    advisorOverride: "",
+    advisorDisabled: false,
+    tui: false,
+    notify: false,
+    notifications: {},
+    humanReview: false,
+    baseRef: "main",
+    targetDir: "/repo",
+    worktree: false,
+    includeDirty: false,
+    yolo: false,
+    smart: false,
+    smartJudgeModel: "openai/gpt-5.6-sol",
+    pipeline: { name: "review", steps: [] },
+    agents: [],
+    permissions: { allow: [], deny: [] },
+    hooks: { pre: [], post: [], pipelines: {} },
+    prdHistoryPreview: preview,
+  })
+  expect(plan.prdHistory).toEqual(preview)
+  expect(Object.isFrozen(plan.prdHistory)).toBe(true)
+})
+
 test("routing preserves every built-in pipeline's execution structure", () => {
   for (const [name, spec] of Object.entries(builtInPipelines)) {
     const original = resolvePipeline({ name, spec, agents: builtInAgents })

--- a/test/run-plan.test.ts
+++ b/test/run-plan.test.ts
@@ -9,6 +9,7 @@ import type { AgentStep, RunOptions } from "../src/types"
 test("the immutable plan filters and freezes exact routed targets", () => {
   const options: RunOptions = {
     prompt: "ship it",
+    prdHistory: true,
     files: [],
     onlySteps: ["build"],
     skipSteps: ["audit"],
@@ -101,6 +102,7 @@ test("routing preserves every built-in pipeline's execution structure", () => {
 test("the plan routes fan-out and the smart judge while leaving Claude Code untouched", () => {
   const options: RunOptions = {
     prompt: "review the change",
+    prdHistory: true,
     files: ["docs/architecture.md"],
     onlySteps: [],
     skipSteps: [],
@@ -154,6 +156,7 @@ test("the plan routes fan-out and the smart judge while leaving Claude Code unto
 test("the plan freezes the routed branch namer and marks an explicit resume gateway override", () => {
   const options: RunOptions = {
     prompt: "review the change",
+    prdHistory: true,
     files: [],
     onlySteps: [],
     skipSteps: [],

--- a/test/run-review.test.ts
+++ b/test/run-review.test.ts
@@ -221,6 +221,19 @@ describe("renderRunPlan", () => {
     expect(output).not.toMatch(/[\u001b\u0000\u0001\u0007\t]/)
     expect(output).not.toContain("\nforged-")
   })
+
+  test("renders the historical PRD preview when the plan carries one", () => {
+    const plan = samplePlan({
+      prdHistory: {
+        action: "attach",
+        branch: "feat/history",
+        found: { runID: "old", pipeline: "implement", branch: "feat/history", timestamp: Date.UTC(2026, 7, 17), file: "old.prd.md" },
+      },
+    })
+    const output = renderRunPlan(plan, true)
+    expect(output).toContain("PRD history: will attach implement PRD · 2026-08-17")
+    expect(output).toContain("original intent for feat/history")
+  })
 })
 
 describe("sanitizeReviewText", () => {

--- a/test/runner-hosted.test.ts
+++ b/test/runner-hosted.test.ts
@@ -1,14 +1,17 @@
 import { afterAll, describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import type { ProgressUI, RunOutcome } from "../src/progress"
 import type { RunOptions } from "../src/types"
 
-import { run as realRun, hostedTeardownFromError, type RunDeps } from "../src/runner"
+import { preparePhaseRun, run as realRun, hostedTeardownFromError, type RunDeps } from "../src/runner"
 import { noopProgress } from "../src/progress"
 import { builtInAgents } from "../src/pipeline"
+import { prdHistoryDir, readPrdHistoryIndex, writePrdHistory } from "../src/prd-history"
+import { prepareWorktreeForRun } from "../src/cli"
 
 // The runner's run() spawns a real opencode server. Inject the fake through
 // run()'s deps seam rather than `mock.module("../src/opencode", …)`: that mock
@@ -73,6 +76,7 @@ const emptyPipeline = { name: "hosted-test", steps: [] }
 function makeOptions(repo: string, overrides: Partial<RunOptions> = {}): RunOptions {
   return {
     prompt: "build it",
+    prdHistory: true,
     files: [],
     onlySteps: [],
     skipSteps: [],
@@ -208,6 +212,86 @@ describe("run() with a hosted progress", () => {
       const metadata = JSON.parse(await readFile(join(result.dir, "metadata.json"), "utf8"))
       expect(metadata.server).toBeUndefined()
     } finally {
+      await rm(repo, { recursive: true, force: true })
+    }
+  })
+
+  test("records fresh prompts in the target checkout and skips the duplicate on resume", async () => {
+    const repo = await cleanRepo()
+    try {
+      const first = await run(makeOptions(repo, { prompt: "original PRD" }))
+      const history = prdHistoryDir(repo)
+      const entries = await readPrdHistoryIndex(repo)
+      expect(entries).toHaveLength(1)
+      expect(entries[0]).toMatchObject({ runID: first.runID, pipeline: "hosted-test" })
+      expect(await readFile(join(history, `${first.runID}.prd.md`), "utf8")).toBe("original PRD")
+
+      await run(makeOptions(repo, { prompt: "disabled PRD", prdHistory: false }))
+      expect(await readPrdHistoryIndex(repo)).toHaveLength(1)
+
+      await run(makeOptions(repo, { prompt: "", resumeRunID: first.runID }))
+      expect(await readPrdHistoryIndex(repo)).toHaveLength(1)
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+    }
+  })
+
+  test("writes a worktree run's history in the new worktree, not the launch checkout", async () => {
+    const launchRepo = await cleanRepo()
+    let isolated: RunOptions | undefined
+    try {
+      isolated = await prepareWorktreeForRun(
+        launchRepo,
+        makeOptions(launchRepo, { prompt: "worktree PRD", worktree: true, branch: "feat/prd-history-location" }),
+      )
+      expect(isolated.targetDir).not.toBe(launchRepo)
+
+      const result = await run(isolated)
+      expect(await readPrdHistoryIndex(isolated.targetDir)).toEqual([
+        expect.objectContaining({ runID: result.runID, file: `${result.runID}.prd.md`, pipeline: "hosted-test" }),
+      ])
+      expect(existsSync(join(isolated.targetDir, ".convoy", "prd-history", `${result.runID}.prd.md`))).toBe(true)
+      expect(existsSync(join(launchRepo, ".convoy", "prd-history", "index.jsonl"))).toBe(false)
+    } finally {
+      if (isolated) await git(["worktree", "remove", "--", isolated.targetDir], launchRepo)
+      await rm(launchRepo, { recursive: true, force: true })
+    }
+  })
+
+  test("attaches only the oldest historical PRD for an opted-in scope step", async () => {
+    const repo = await cleanRepo()
+    const workspace = await mkdtemp(join(tmpdir(), "convoy-history-phase-"))
+    const phase = {
+      type: "agent" as const,
+      name: "scope",
+      stepName: "scope",
+      groupId: "g1",
+      agentName: "review-scope",
+      description: "scope",
+      model: "openai/gpt-5.6-terra",
+      inputFiles: [],
+      inputDiff: false,
+      reportPath: "reports/scope.md",
+      readOnly: true,
+      prdHistory: true,
+    }
+    try {
+      const branch = (await git(["branch", "--show-current"], repo)).trim()
+      await writePrdHistory({ targetDir: repo, runID: "original", prompt: "original PRD", pipeline: "implement", branch })
+      await writePrdHistory({ targetDir: repo, runID: "current", prompt: "review request", pipeline: "review", branch })
+
+      const prepared = await preparePhaseRun({ dir: workspace, runID: "current" }, phase, makeOptions(repo), [], [])
+      expect(prepared.attachments).toHaveLength(1)
+      expect(prepared.attachments[0]).toMatchObject({ filename: "original.prd.md" })
+      expect(prepared.attachments[0]?.url).toStartWith("file:///")
+      expect(prepared.attachments[0]?.url).toContain(".convoy/prd-history/original.prd.md")
+      expect((await preparePhaseRun({ dir: workspace, runID: "current" }, phase, makeOptions(repo, { prdHistory: false }), [], [])).attachments).toEqual([])
+
+      await rm(join(prdHistoryDir(repo), "index.jsonl"))
+      await mkdir(join(prdHistoryDir(repo), "index.jsonl"))
+      expect((await preparePhaseRun({ dir: workspace, runID: "current" }, phase, makeOptions(repo), [], [])).attachments).toEqual([])
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
       await rm(repo, { recursive: true, force: true })
     }
   })


### PR DESCRIPTION
- Store run prompts and append-only metadata under the executing project checkout
- Attach the oldest matching-branch PRD to built-in scope steps
- Add configuration and pipeline support for PRD history behavior
- Cover persistence, validation, selection, runner, and pipeline integration with tests