### PR TITLE
feat(pipeline): attach the historical PRD to built-in scoring steps

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -459,18 +459,22 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
   "goal-fix": {
     description: "The goal loop's fix iteration: apply exactly the gaps from the previous scoring round, then re-score. Not run directly; ship's goal or --goal drives it.",
     steps: [
-      { agent: "goal-fixer", name: "fix", reports: "none", diff: true },
+      { agent: "goal-fixer", name: "fix", reports: "none", diff: true, prdHistory: true },
       {
         parallel: [
           // The re-scorers must stay blind to the previous score: the fixer's
           // report restates it, so the scorer steps receive no reports at all
-          // (they grade the artifact, not the round's history).
-          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "none" },
+          // (they grade the artifact, not the round's history). They still get
+          // the original PRD via prdHistory: the rubric's `prd` dimension (30%
+          // of the score) cannot be graded without it.
+          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "none", prdHistory: true },
         ],
       },
       // The consensus sees only the fresh scorer reports, never the fixer's,
-      // so its measurement cannot anchor on the number it is reconciling.
-      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: ["score"], verify: true },
+      // so its measurement cannot anchor on the number it is reconciling; the
+      // original PRD is attached so disagreements on the `prd` dimension can be
+      // judged against the actual requirements.
+      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: ["score"], verify: true, prdHistory: true },
     ],
   },
   // Report-only review + the measurement layer: after the parallel audits, two
@@ -495,10 +499,10 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
       { agent: "review-report", name: "report", model: defaultOpusModel, reports: "all" },
       {
         parallel: [
-          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "all" },
+          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "all", prdHistory: true },
         ],
       },
-      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: "all", verify: true },
+      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: "all", verify: true, prdHistory: true },
     ],
   },
   // review's shape with nothing on Opus. The scorer models are pinned rather
@@ -522,10 +526,10 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
       { agent: "review-report", name: "report", model: glmModel, reports: "all" },
       {
         parallel: [
-          { agent: "quality-scorer", name: "score", models: [glmXhighModel, kimiHighModel], reports: "all" },
+          { agent: "quality-scorer", name: "score", models: [glmXhighModel, kimiHighModel], reports: "all", prdHistory: true },
         ],
       },
-      { agent: "quality-score-report", name: "score-report", model: glmXhighModel, reports: "all", verify: true },
+      { agent: "quality-score-report", name: "score-report", model: glmXhighModel, reports: "all", verify: true, prdHistory: true },
     ],
   },
   // The close of the process: the branch is already shaped the way you want it,
@@ -554,10 +558,10 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
       { agent: "sync-with-base", name: "sync", model: fallbackModel, reports: "none" },
       {
         parallel: [
-          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "all" },
+          { agent: "quality-scorer", name: "score", models: [solXhighModel, defaultOpusModel], reports: "all", prdHistory: true },
         ],
       },
-      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: "all", verify: true },
+      { agent: "quality-score-report", name: "score-report", model: solXhighModel, reports: "all", verify: true, prdHistory: true },
     ],
   },
   // The follow-up to a report-only run: feed it the findings (as the prompt or an

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -362,15 +362,47 @@ describe("built-in review pipeline", () => {
 })
 
 describe("PRD history pipeline plumbing", () => {
-  test("marks only built-in review scope steps for historical PRD attachment", () => {
-    for (const name of ["review", "review-lite", "review-cc"] as const) {
+  test("marks the built-in scored pipelines for historical PRD attachment on their scoring steps", () => {
+    // Review-style pipelines attach the PRD on the scope step AND on every
+    // scoring step (the fan-out scorers and the consensus), because the
+    // rubric's `prd` dimension (30% of the score) can only be graded against
+    // the original PRD.
+    for (const name of ["review", "review-lite"] as const) {
       const steps = resolvePipeline({ name, spec: builtInPipelines[name]!, agents: builtInAgents }).steps
+      const scope = steps.find((step): step is AgentStep => step.type === "agent" && step.name === "scope")
+      const scorers = steps.filter((step): step is AgentStep => step.type === "agent" && step.name === "score")
+      const consensus = steps.find((step): step is AgentStep => step.type === "agent" && step.name === "score-report")
+      expect(scope?.prdHistory).toBe(true)
+      expect(scorers.every((step) => step.prdHistory === true)).toBe(true)
+      expect(consensus?.prdHistory).toBe(true)
+    }
+
+    // review-cc ends at the findings report — it has no scoring steps — so it
+    // attaches the PRD only on its scope step.
+    {
+      const steps = resolvePipeline({ name: "review-cc", spec: builtInPipelines["review-cc"]!, agents: builtInAgents }).steps
       const scope = steps.find((step): step is AgentStep => step.type === "agent" && step.name === "scope")
       expect(scope?.prdHistory).toBe(true)
       expect(steps.filter((step): step is AgentStep => step.type === "agent" && step.name !== "scope").every((step) => step.prdHistory === undefined)).toBe(true)
     }
 
-    for (const name of ["implement", "ship", "hunter"] as const) {
+    // ship and goal-fix have no scope step; their scorers and consensus carry
+    // the PRD so the measurement is graded against the original requirements.
+    for (const name of ["ship", "goal-fix"] as const) {
+      const steps = resolvePipeline({ name, spec: builtInPipelines[name]!, agents: builtInAgents }).steps
+      expect(steps.filter((step): step is AgentStep => step.type === "agent" && step.name === "score").every((step) => step.prdHistory === true)).toBe(true)
+      expect(steps.find((step): step is AgentStep => step.type === "agent" && step.name === "score-report")?.prdHistory).toBe(true)
+    }
+
+    // goal-fix also attaches the PRD on the fixer, so it knows the original
+    // requirements while closing exactly the reported gaps.
+    {
+      const steps = resolvePipeline({ name: "goal-fix", spec: builtInPipelines["goal-fix"]!, agents: builtInAgents }).steps
+      expect(steps.find((step): step is AgentStep => step.type === "agent" && step.name === "fix")?.prdHistory).toBe(true)
+    }
+
+    // Non-scored pipelines attach no historical PRD anywhere.
+    for (const name of ["implement", "hunter"] as const) {
       const steps = resolvePipeline({ name, spec: builtInPipelines[name]!, agents: builtInAgents }).steps
       expect(steps.every((step) => step.type !== "agent" || step.prdHistory === undefined)).toBe(true)
     }


### PR DESCRIPTION
## What

Every built-in pipeline that produces a quality score now attaches the branch's **historical PRD** to its scoring steps via `prdHistory: true`. This covers the fan-out `quality-scorer` steps, the `quality-score-report` consensus step, and (in `goal-fix`) the `goal-fixer` step.

Pipelines touched: `review`, `review-lite`, `ship`, `goal-fix`.

## Why

The built-in rubric weights the `prd` dimension at **30%** of the score ("the PRD is implemented: every requirement, including edge cases and non-happy paths"). A scorer cannot grade that dimension without the original PRD.

Every step already receives the current run's `prd.md` by default (line `inputFiles: ["prd.md", ...]`), but in `ship`/`goal-fix` the run prompt is a short ship/fix instruction, not the original implementation PRD. `prdHistory: true` attaches the PRD recorded for the branch (`.convoy/prd-history`) so the measurement is graded against the actual requirements.

This does **not** change the goal-loop's "blind re-scorer" guarantee: the scorer steps still receive `reports: none` (and the consensus only the fresh scorer reports), so they stay blind to the previous score number — they just gain the original PRD needed to grade the `prd` dimension.

## Notes

- `review-cc` is unchanged: it ends at the findings report and has no scoring steps (only its `scope` already carries `prdHistory`).
- `implement`/`hunter` remain un-scored and attach nothing.

## Tests

Updated `test/pipeline.test.ts` to assert the new attachment pattern. Full suite green (2033 tests) and `tsc --noEmit` clean.