### PR TITLE
feat(tui): declutter the run header, launcher sidebar, and runs browser

### DIFF
--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -499,6 +499,8 @@ export class LaunchPicker {
   private readonly stopLimits: () => void
   /** @internal — tests inject snapshots directly instead of running the poller. */
   private limits?: LimitsSnapshot
+  /** Whether the sidebar's usage meters are on, set by every render. */
+  private usageVisible = false
   private readonly headerText: TextRenderable
   private readonly bodyBox: BoxRenderable
   private readonly leftBox: BoxRenderable
@@ -1398,25 +1400,27 @@ export class LaunchPicker {
     // screens retain the sidebar, but measure the detail panel from the actual
     // inner width rather than a fixed 40-column floor that could overflow.
     const detailWidth = reviewing || compact ? innerWidth : Math.max(34, innerWidth - pipelineWidth - 1)
-    const pipelineHeight = compact ? this.compactPipelineHeight(this.compactBodyHeight()) : this.listHeight()
-    // The meters deserve the sidebar's bottom when they fit without crowding
-    // the pipeline list; on short, compact, or review screens every row goes
-    // to the plan or the list and the usage panel stays hidden.
+    // The left column runs from the header's bottom border to the footer's top,
+    // so its height is the full shell less those two (3 rows each). The usage
+    // panel pins to its bottom edge and the pipeline list fills the rest,
+    // leaving no dead stripe under the meters.
+    const bodyHeight = Math.max(8, this.renderer.height - 6)
     const usageHeight = 4
-    const usageVisible = !compact && !reviewing && this.limits !== undefined && pipelineHeight - usageHeight >= 6
+    const usageVisible = !compact && !reviewing && this.limits !== undefined && bodyHeight - usageHeight >= 6
+    this.usageVisible = usageVisible
     this.usageBox.visible = usageVisible
 
     this.bodyBox.flexDirection = compact ? "column" : "row"
     if (compact) {
       this.leftBox.width = "100%"
-      this.leftBox.height = pipelineHeight
+      this.leftBox.height = this.compactPipelineHeight(this.compactBodyHeight())
       this.pipelineBox.width = "100%"
       this.pipelineBox.height = "100%"
     } else {
       this.leftBox.width = pipelineWidth
-      this.leftBox.height = "100%"
+      this.leftBox.height = bodyHeight
       this.pipelineBox.width = "100%"
-      this.pipelineBox.height = usageVisible ? pipelineHeight - usageHeight : "100%"
+      this.pipelineBox.height = usageVisible ? bodyHeight - usageHeight : bodyHeight
     }
     this.detailBox.width = compact || reviewing ? "100%" : detailWidth
     this.detailBox.height = compact ? "auto" : "100%"
@@ -1499,19 +1503,29 @@ export class LaunchPicker {
   }
 
   /**
-   * The sidebar's subscription meters: GPT window on the first line, the
-   * OpenRouter balance on the second. Reuses the dashboard's color language
+   * The sidebar's subscription meters: the OpenRouter wallet on the first
+   * line, the OpenAI window below it. Reuses the dashboard's color language
    * but drops detail before ever clipping a value mid-token.
    */
   private usageContent(width: number): StyledText[] {
     const lines: StyledText[] = []
     const now = Date.now()
+
+    const openrouter = this.limits?.openrouter
+    if (openrouter) {
+      const value = openrouter.kind === "remaining" ? `${formatMoney(openrouter.amount)} left` : `${formatMoney(openrouter.amount)}/mo`
+      const color = openrouter.kind === "remaining" && openrouter.amount < openRouterLowBalance ? theme.yellow : theme.text
+      lines.push(new StyledText([fg(theme.dim)("OpenRouter "), fg(color)(value)]))
+    } else {
+      lines.push(new StyledText([fg(theme.dim)("OpenRouter "), fg(theme.faint)("not configured")]))
+    }
+
     const gpt = this.limits?.gpt
     if (gpt) {
       const pct = Math.round(gpt.sessionPct)
       const barColor = pct >= 85 ? theme.red : pct >= 60 ? theme.yellow : theme.accent
       const pctChunk = fg(pct >= 60 ? barColor : theme.text)(`${pct}%`)
-      const bar: TextChunk[] = [fg(theme.dim)(`GPT `), ...progressBar(pct / 100, 6, barColor), raw(" "), pctChunk]
+      const bar: TextChunk[] = [fg(theme.dim)("OpenAI "), ...progressBar(pct / 100, 6, barColor), raw(" "), pctChunk]
       const tail: TextChunk[] = []
       if (gpt.sessionResetsAt !== undefined) tail.push(fg(theme.faint)(" resets "), fg(theme.dim)(fmtCountdown(gpt.sessionResetsAt, now)))
       if (gpt.weeklyPct !== undefined) {
@@ -1525,18 +1539,9 @@ export class LaunchPicker {
       if (chunksLength(fitted) - 6 > width) fitted = bar
       lines.push(new StyledText(fitted))
     } else if (this.limits?.gptHint) {
-      lines.push(new StyledText([fg(theme.dim)("GPT "), fg(theme.yellow)(truncate(this.limits.gptHint, width - 4))]))
+      lines.push(new StyledText([fg(theme.dim)("OpenAI "), fg(theme.yellow)(truncate(this.limits.gptHint, width - 7))]))
     } else {
-      lines.push(new StyledText([fg(theme.dim)("GPT "), fg(theme.faint)("not configured")]))
-    }
-
-    const openrouter = this.limits?.openrouter
-    if (openrouter) {
-      const value = openrouter.kind === "remaining" ? `${formatMoney(openrouter.amount)} left` : `${formatMoney(openrouter.amount)}/mo`
-      const color = openrouter.kind === "remaining" && openrouter.amount < openRouterLowBalance ? theme.yellow : theme.text
-      lines.push(new StyledText([fg(theme.dim)("OpenRouter "), fg(color)(value)]))
-    } else {
-      lines.push(new StyledText([fg(theme.dim)("OpenRouter "), fg(theme.faint)("not configured")]))
+      lines.push(new StyledText([fg(theme.dim)("OpenAI "), fg(theme.faint)("not configured")]))
     }
     return lines
   }
@@ -1972,7 +1977,13 @@ export class LaunchPicker {
   }
 
   private pipelineVisibleRows() {
-    return this.usesCompactLayout() ? Math.max(1, this.compactPipelineHeight(this.compactBodyHeight()) - 2) : this.listHeight()
+    if (this.usesCompactLayout()) return Math.max(1, this.compactPipelineHeight(this.compactBodyHeight()) - 2)
+    // Wide: the sidebar shares its column with the usage meters when they're
+    // on, so the list's visible rows shrink to match the box laid out in
+    // render() — keeping pagination and click targets in sync with the panel.
+    const bodyHeight = Math.max(8, this.renderer.height - 6)
+    const rows = bodyHeight - (this.usageVisible ? 4 : 0) - 2
+    return Math.max(3, rows)
   }
 
   private detailContentHeight() {

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -1424,11 +1424,13 @@ export class LaunchPicker {
     }
     this.detailBox.width = compact || reviewing ? "100%" : detailWidth
     this.detailBox.height = compact ? "auto" : "100%"
-    this.detailBox.title = reviewing ? " review " : " run setup "
-    // Mirror the dashboard focus cue: the accented border marks where Enter,
-    // Esc, and the navigation keys apply in the current setup step.
-    this.pipelineBox.borderColor = this.mode === "pipelines" ? theme.accent : theme.borderDim
-    this.detailBox.borderColor = this.mode === "pipelines" ? theme.borderDim : theme.accent
+this.detailBox.title = reviewing ? " review " : " run setup "
+     // The pipeline sidebar never borrows the accent: the steps are uniform,
+     // dimmed containers, and the selected pipeline's own row carries the
+     // focus marker. The accent marks Enter/Esc/navigation in the setup panel
+     // during the prompt/options/branch steps (never in pipelines mode).
+     this.pipelineBox.borderColor = theme.borderDim
+     this.detailBox.borderColor = this.mode === "pipelines" ? theme.borderDim : theme.accent
     this.headerText.content = this.headerContent(innerWidth)
     // Panels reserve 4 cells of chrome (rounded border + paddingX:1 each side),
     // so lay out the rows against the inner text width — matching detailWidth
@@ -1525,7 +1527,10 @@ export class LaunchPicker {
       const pct = Math.round(gpt.sessionPct)
       const barColor = pct >= 85 ? theme.red : pct >= 60 ? theme.yellow : theme.accent
       const pctChunk = fg(pct >= 60 ? barColor : theme.text)(`${pct}%`)
-      const bar: TextChunk[] = [fg(theme.dim)("OpenAI "), ...progressBar(pct / 100, 6, barColor), raw(" "), pctChunk]
+      // A compact gauge instead of the dashboard's full-width bar: the usage
+      // panel only has a sidebar's worth of columns, so the meter is a short
+      // block run and the resets/weekly tail yields before the bar shrinks.
+      const bar: TextChunk[] = [fg(theme.dim)("OpenAI "), ...progressBar(pct / 100, 4, barColor), raw(" "), pctChunk]
       const tail: TextChunk[] = []
       if (gpt.sessionResetsAt !== undefined) tail.push(fg(theme.faint)(" resets "), fg(theme.dim)(fmtCountdown(gpt.sessionResetsAt, now)))
       if (gpt.weeklyPct !== undefined) {
@@ -1535,8 +1540,8 @@ export class LaunchPicker {
       // The weekly window goes before the countdown: neither is worth pushing
       // the bar past the sidebar's edge.
       let fitted = [...bar, ...tail]
-      if (chunksLength(fitted) - 6 > width) fitted = [...bar, ...tail.slice(0, 2)]
-      if (chunksLength(fitted) - 6 > width) fitted = bar
+      if (chunksLength(fitted) > width) fitted = [...bar, ...tail.slice(0, 2)]
+      if (chunksLength(fitted) > width) fitted = bar
       lines.push(new StyledText(fitted))
     } else if (this.limits?.gptHint) {
       lines.push(new StyledText([fg(theme.dim)("OpenAI "), fg(theme.yellow)(truncate(this.limits.gptHint, width - 7))]))

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -8,14 +8,14 @@ import { defaultAdvisorMaxCalls } from "./advisor"
 import { buildAgentRegistry, emptyHooksConfig, loadMergedConvoyConfig } from "./config"
 import { currentBranch, resolveWorktreeDefault } from "./git"
 import { hooksForPipeline } from "./hooks"
-import { startLimitsPoller } from "./limits"
+import { openRouterLowBalance, startLimitsPoller } from "./limits"
 import { builtInPipelines, defaultPipelineName, hasWritableStep, resolvePipeline } from "./pipeline"
 import { stepRunnerFor } from "./step-runners"
 import { gatewayLabel, modelGateways, type ModelGateway } from "./model-routing"
 import { consensusStep } from "./quality-score"
 import { prdHistoryFile, prdHistoryPreviewCopy, readPrdHistoryIndex, resolvePrdHistoryPreview, type PrdHistoryEntry, type PrdHistoryPreview } from "./prd-history"
 import { runReviewLines } from "./review-tui"
-import { clipChunks, hintsRow, joinLines, limitsRow, moreHintsMarker, padBetween, paletteForTerminal, plain, raw, setTheme, spinnerFrame, terminalBackgroundHex, theme, truncate } from "./tui-theme"
+import { chunksLength, clipChunks, fmtCountdown, formatMoney, hintsRow, joinLines, moreHintsMarker, padBetween, paletteForTerminal, plain, progressBar, raw, setTheme, spinnerFrame, terminalBackgroundHex, theme, truncate } from "./tui-theme"
 import { shortVersion } from "./version"
 
 import type { ConvoyConfig } from "./config"
@@ -497,11 +497,15 @@ export class LaunchPicker {
   // while nothing is animating.
   private lastRenderAt = 0
   private readonly stopLimits: () => void
+  /** @internal — tests inject snapshots directly instead of running the poller. */
   private limits?: LimitsSnapshot
   private readonly headerText: TextRenderable
   private readonly bodyBox: BoxRenderable
+  private readonly leftBox: BoxRenderable
   private readonly pipelineText: TextRenderable
   private readonly pipelineBox: BoxRenderable
+  private readonly usageText: TextRenderable
+  private readonly usageBox: BoxRenderable
   private readonly detailText: TextRenderable
   private readonly detailBox: BoxRenderable
   private readonly footerText: TextRenderable
@@ -614,7 +618,7 @@ export class LaunchPicker {
     // while the launcher is open, so it costs nothing to draw it once as chrome.
     const header = this.panel({
       id: "convoy-launch-header",
-      height: 4,
+      height: 3,
       borderColor: theme.border,
       backgroundColor: theme.bg,
       title: ` convoy ${shortVersion()} `,
@@ -647,6 +651,27 @@ export class LaunchPicker {
       onMouseDown: selectFromList,
     })
     pipeline.text.onMouseDown = selectFromList
+
+    // The pipeline list and the subscription meters share the sidebar as a
+    // column: pipelines grow to fill it and the meters sit pinned to the
+    // bottom edge, instead of costing the setup header a whole row.
+    const left = new BoxRenderable(renderer, {
+      id: "convoy-launch-left",
+      width: "100%",
+      height: "100%",
+      flexDirection: "column",
+      gap: 0,
+    })
+    const usage = this.panel({
+      id: "convoy-launch-usage",
+      width: "100%",
+      height: 4,
+      borderColor: theme.borderDim,
+      backgroundColor: theme.bg,
+      title: " usage ",
+      titleAlignment: "left",
+      visible: false,
+    })
 
     const selectOption = (event: { y: number; preventDefault(): void; stopPropagation(): void }) => {
       if (this.mode !== "options" || this.modal) return
@@ -685,8 +710,11 @@ export class LaunchPicker {
 
     this.headerText = header.text
     this.bodyBox = body
+    this.leftBox = left
     this.pipelineText = pipeline.text
     this.pipelineBox = pipeline.box
+    this.usageText = usage.text
+    this.usageBox = usage.box
     this.detailText = detail.text
     this.detailBox = detail.box
     this.footerText = footer.text
@@ -695,11 +723,14 @@ export class LaunchPicker {
       { box: shell, background: "bg" },
       { box: header.box, background: "bg", border: "border" },
       { box: pipeline.box, background: "bg", border: "borderDim" },
+      { box: usage.box, background: "bg", border: "borderDim" },
       { box: detail.box, background: "bg", border: "borderDim" },
       { box: footer.box, background: "bg", border: "borderDim" },
     )
 
-    body.add(pipeline.box)
+    left.add(pipeline.box)
+    left.add(usage.box)
+    body.add(left)
     body.add(detail.box)
     shell.add(header.box)
     shell.add(body)
@@ -1358,20 +1389,35 @@ export class LaunchPicker {
     const innerWidth = Math.max(40, this.renderer.width - 6)
     const reviewing = this.mode === "review"
     const compact = this.usesCompactLayout()
-    // The Review step owns the whole screen: the pipeline list would only
-    // repeat what the plan already freezes, and the plan needs the width.
+    // The pipeline/usage sidebar and the Review step own the whole screen:
+    // Review freezes the plan, and the list would only repeat it.
+    this.leftBox.visible = !reviewing
     this.pipelineBox.visible = !reviewing
     const pipelineWidth = compact ? innerWidth + 4 : this.pipelineWidth()
     // In compact mode both panels occupy the shell's full inner width. Wide
     // screens retain the sidebar, but measure the detail panel from the actual
     // inner width rather than a fixed 40-column floor that could overflow.
     const detailWidth = reviewing || compact ? innerWidth : Math.max(34, innerWidth - pipelineWidth - 1)
-    const bodyHeight = this.compactBodyHeight()
-    const pipelineHeight = compact ? this.compactPipelineHeight(bodyHeight) : bodyHeight
+    const pipelineHeight = compact ? this.compactPipelineHeight(this.compactBodyHeight()) : this.listHeight()
+    // The meters deserve the sidebar's bottom when they fit without crowding
+    // the pipeline list; on short, compact, or review screens every row goes
+    // to the plan or the list and the usage panel stays hidden.
+    const usageHeight = 4
+    const usageVisible = !compact && !reviewing && this.limits !== undefined && pipelineHeight - usageHeight >= 6
+    this.usageBox.visible = usageVisible
 
     this.bodyBox.flexDirection = compact ? "column" : "row"
-    this.pipelineBox.width = compact ? "100%" : pipelineWidth
-    this.pipelineBox.height = compact ? pipelineHeight : "100%"
+    if (compact) {
+      this.leftBox.width = "100%"
+      this.leftBox.height = pipelineHeight
+      this.pipelineBox.width = "100%"
+      this.pipelineBox.height = "100%"
+    } else {
+      this.leftBox.width = pipelineWidth
+      this.leftBox.height = "100%"
+      this.pipelineBox.width = "100%"
+      this.pipelineBox.height = usageVisible ? pipelineHeight - usageHeight : "100%"
+    }
     this.detailBox.width = compact || reviewing ? "100%" : detailWidth
     this.detailBox.height = compact ? "auto" : "100%"
     this.detailBox.title = reviewing ? " review " : " run setup "
@@ -1385,6 +1431,7 @@ export class LaunchPicker {
     // below. Passing the full box width made every right-aligned badge overflow
     // and wrap onto its own line.
     this.pipelineText.content = this.pipelineContent(pipelineWidth - 4)
+    if (usageVisible) this.usageText.content = joinLines(this.usageContent(pipelineWidth - 4))
     this.detailText.content = this.detailContent(compact || reviewing ? innerWidth : detailWidth - 4)
     this.footerText.content = this.footerContent(innerWidth)
     this.renderModal()
@@ -1448,7 +1495,50 @@ export class LaunchPicker {
       }
     }
     const line1 = padBetween(title, stage, width)
-    return joinLines([line1, limitsRow(this.limits, Date.now(), width)])
+    return joinLines([line1])
+  }
+
+  /**
+   * The sidebar's subscription meters: GPT window on the first line, the
+   * OpenRouter balance on the second. Reuses the dashboard's color language
+   * but drops detail before ever clipping a value mid-token.
+   */
+  private usageContent(width: number): StyledText[] {
+    const lines: StyledText[] = []
+    const now = Date.now()
+    const gpt = this.limits?.gpt
+    if (gpt) {
+      const pct = Math.round(gpt.sessionPct)
+      const barColor = pct >= 85 ? theme.red : pct >= 60 ? theme.yellow : theme.accent
+      const pctChunk = fg(pct >= 60 ? barColor : theme.text)(`${pct}%`)
+      const bar: TextChunk[] = [fg(theme.dim)(`GPT `), ...progressBar(pct / 100, 6, barColor), raw(" "), pctChunk]
+      const tail: TextChunk[] = []
+      if (gpt.sessionResetsAt !== undefined) tail.push(fg(theme.faint)(" resets "), fg(theme.dim)(fmtCountdown(gpt.sessionResetsAt, now)))
+      if (gpt.weeklyPct !== undefined) {
+        const wk = Math.round(gpt.weeklyPct)
+        tail.push(fg(theme.faint)(" wk "), fg(wk >= 85 ? theme.red : wk >= 60 ? theme.yellow : theme.dim)(`${wk}%`))
+      }
+      // The weekly window goes before the countdown: neither is worth pushing
+      // the bar past the sidebar's edge.
+      let fitted = [...bar, ...tail]
+      if (chunksLength(fitted) - 6 > width) fitted = [...bar, ...tail.slice(0, 2)]
+      if (chunksLength(fitted) - 6 > width) fitted = bar
+      lines.push(new StyledText(fitted))
+    } else if (this.limits?.gptHint) {
+      lines.push(new StyledText([fg(theme.dim)("GPT "), fg(theme.yellow)(truncate(this.limits.gptHint, width - 4))]))
+    } else {
+      lines.push(new StyledText([fg(theme.dim)("GPT "), fg(theme.faint)("not configured")]))
+    }
+
+    const openrouter = this.limits?.openrouter
+    if (openrouter) {
+      const value = openrouter.kind === "remaining" ? `${formatMoney(openrouter.amount)} left` : `${formatMoney(openrouter.amount)}/mo`
+      const color = openrouter.kind === "remaining" && openrouter.amount < openRouterLowBalance ? theme.yellow : theme.text
+      lines.push(new StyledText([fg(theme.dim)("OpenRouter "), fg(color)(value)]))
+    } else {
+      lines.push(new StyledText([fg(theme.dim)("OpenRouter "), fg(theme.faint)("not configured")]))
+    }
+    return lines
   }
 
   private pipelineContent(width: number) {
@@ -1877,8 +1967,8 @@ export class LaunchPicker {
   }
 
   private compactBodyHeight() {
-    // Header (4), footer (3), and the detail panel's top/bottom borders (2).
-    return Math.max(8, this.renderer.height - 9)
+    // Header (3), footer (3), and the detail panel's top/bottom borders (2).
+    return Math.max(8, this.renderer.height - 8)
   }
 
   private pipelineVisibleRows() {
@@ -1899,8 +1989,8 @@ export class LaunchPicker {
   }
 
   private listHeight() {
-    // Header (4) + footer (3) + list panel borders (2).
-    return Math.max(3, this.renderer.height - 9)
+    // Header (3) + footer (3) + list panel borders (2).
+    return Math.max(3, this.renderer.height - 8)
   }
 }
 

--- a/src/limits.ts
+++ b/src/limits.ts
@@ -26,6 +26,9 @@ export type OpenRouterLimits =
   | { kind: "remaining"; amount: number } // $ left (exact balance or key limit_remaining)
   | { kind: "monthly"; amount: number } // fallback: $ spent this month on a limitless key
 
+/** Below this remaining balance the run header surfaces a low-credit chip. */
+export const openRouterLowBalance = 10
+
 export type LimitsSnapshot = {
   gpt?: GptLimits
   /** Auth problem worth showing instead of the meter, e.g. "codex login". */
@@ -225,10 +228,30 @@ let lastSnapshot: LimitsSnapshot | undefined
 const freshEnoughMs = 30_000
 
 /**
- * Background poll of both providers. `ok` replaces the segment, `auth` clears
- * it (surfacing a hint for GPT), `transient` keeps the last good data so a
- * blip doesn't blank the header. The returned stop() also gates in-flight
- * ticks so nothing resurrects state after the TUI is torn down.
+ * Swap the provider fetches in tests. Restored by installing the live
+ * implementation again (nothing ever does this in production).
+ */
+export let fetchLimitsSnapshot: () => Promise<Pick<LimitsSnapshot, "gpt" | "gptHint" | "openrouter">>
+
+export function setLimitsFetcherForTests(fetcher: typeof fetchLimitsSnapshot | undefined) {
+  fetchLimitsSnapshot = fetcher ?? liveFetchLimitsSnapshot
+}
+
+const liveFetchLimitsSnapshot = async (): Promise<Pick<LimitsSnapshot, "gpt" | "gptHint" | "openrouter">> => {
+  const [gpt, openrouter] = await Promise.all([fetchGptUsage(), fetchOpenRouter()])
+  return {
+    gpt: gpt.ok ? gpt.value : undefined,
+    gptHint: gpt.ok ? undefined : gpt.kind === "auth" ? (gpt.hint ?? "codex login") : undefined,
+    openrouter: openrouter.ok ? openrouter.value : undefined,
+  }
+}
+fetchLimitsSnapshot = liveFetchLimitsSnapshot
+
+/**
+ * Background poll of both providers. A successful segment replaces the last
+ * one; anything else (auth problems, transient blips) keeps it so a hiccup
+ * doesn't blank the header. The returned stop() also gates in-flight ticks so
+ * nothing resurrects state after the TUI is torn down.
  */
 export function startLimitsPoller(onUpdate: (snapshot: LimitsSnapshot) => void, intervalMs = limitsPollMs): () => void {
   let stopped = false
@@ -237,13 +260,13 @@ export function startLimitsPoller(onUpdate: (snapshot: LimitsSnapshot) => void, 
 
   const tick = async () => {
     try {
-      const [gpt, openrouter] = await Promise.all([fetchGptUsage(), fetchOpenRouter()])
+      const snapshot = await fetchLimitsSnapshot()
       if (stopped) return
       last = {
         fetchedAt: Date.now(),
-        gpt: gpt.ok ? gpt.value : gpt.kind === "transient" ? last.gpt : undefined,
-        gptHint: gpt.ok ? undefined : gpt.kind === "auth" ? (gpt.hint ?? "codex login") : last.gptHint,
-        openrouter: openrouter.ok ? openrouter.value : openrouter.kind === "transient" ? last.openrouter : undefined,
+        gpt: snapshot.gpt ?? last.gpt,
+        gptHint: snapshot.gptHint ?? last.gptHint,
+        openrouter: snapshot.openrouter ?? last.openrouter,
       }
       lastSnapshot = last
       onUpdate(last)

--- a/src/runs-browser.ts
+++ b/src/runs-browser.ts
@@ -2,7 +2,6 @@ import { stdout } from "node:process"
 
 import { BoxRenderable, StyledText, TextRenderable, bold, fg, t } from "@opentui/core"
 
-import { startLimitsPoller } from "./limits"
 import { parseMarkdown, renderMarkdownDoc, type MarkdownDoc } from "./markdown-render"
 import { loadRunSummary } from "./runs"
 import {
@@ -10,7 +9,6 @@ import {
   formatMoney,
   hintsRow,
   joinLines,
-  limitsRow,
   moreHintsMarker,
   padBetween,
   paletteForTerminal,
@@ -26,9 +24,11 @@ import { shortVersion } from "./version"
 import { runsRoot } from "./workspace"
 
 import type { BoxOptions, CliRenderer, KeyEvent, TextChunk } from "@opentui/core"
-import type { LimitsSnapshot } from "./limits"
 import type { RunEntry, RunStatusKind, RunsResolution } from "./runs"
 import type { Hint, PaletteColor } from "./tui-theme"
+
+/** Below this width the run list and details stack vertically. */
+const compactRunsMaxWidth = 84
 
 const runStatusStyles: Record<RunStatusKind, { icon: string; color: PaletteColor }> = {
   completed: { icon: "✓", color: "green" },
@@ -56,10 +56,10 @@ export class RunsBrowser {
   // A subshell owns the terminal while the renderer is suspended; ignore keys.
   private inSubshell = false
   private readonly ticker: ReturnType<typeof setInterval>
-  private readonly stopLimits: () => void
-  private limits?: LimitsSnapshot
   private readonly headerText: TextRenderable
+  private readonly bodyBox: BoxRenderable
   private readonly listText: TextRenderable
+  private readonly listBox: BoxRenderable
   private readonly detailsText: TextRenderable
   private readonly footerText: TextRenderable
   private readonly detailsBox: BoxRenderable
@@ -113,9 +113,11 @@ export class RunsBrowser {
 
     const header = this.panel({
       id: "convoy-runs-header",
-      height: 5,
+      height: 4,
       borderColor: theme.border,
       backgroundColor: theme.bg,
+      title: ` convoy ${shortVersion()} `,
+      titleAlignment: "left",
     })
 
     const body = new BoxRenderable(renderer, {
@@ -179,7 +181,9 @@ export class RunsBrowser {
     })
 
     this.headerText = header.text
+    this.bodyBox = body
     this.listText = list.text
+    this.listBox = list.box
     this.detailsText = details.text
     this.detailsBox = details.box
     this.footerText = footer.text
@@ -246,9 +250,6 @@ export class RunsBrowser {
     renderer.on("theme_mode", this.handleThemeMode)
 
     this.ticker = setInterval(() => this.render(), 250)
-    this.stopLimits = startLimitsPoller((snapshot) => {
-      this.limits = snapshot
-    })
     this.render()
   }
 
@@ -420,7 +421,6 @@ export class RunsBrowser {
 
   private finish(resolution: RunsResolution) {
     clearInterval(this.ticker)
-    this.stopLimits()
     this.renderer.keyInput.off("keypress", this.handleKeyPress)
     this.renderer.off("theme_mode", this.handleThemeMode)
     if (!this.renderer.isDestroyed) this.renderer.destroy()
@@ -457,9 +457,19 @@ export class RunsBrowser {
     return Math.max(30, Math.min(46, this.renderer.width - 64))
   }
 
+  // Header (4) + footer (3). The body holds the stacked or side-by-side panels.
+  private bodyHeight() {
+    return Math.max(8, this.renderer.height - 7)
+  }
+
+  private compactListHeight(bodyHeight: number) {
+    return Math.max(5, Math.min(9, Math.floor(bodyHeight * 0.35)))
+  }
+
   private listHeight() {
-    // header (5) + footer (3) + list panel borders (2).
-    return Math.max(3, this.renderer.height - 10)
+    // Header (4) + footer (3) + list panel borders (2); compact stacks instead.
+    if (this.renderer.width <= compactRunsMaxWidth) return Math.max(3, this.compactListHeight(this.bodyHeight()) - 2)
+    return Math.max(3, this.renderer.height - 9)
   }
 
   private summaryHeight() {
@@ -487,13 +497,30 @@ export class RunsBrowser {
     if (this.renderer.isDestroyed) return
     const now = Date.now()
     const innerWidth = Math.max(40, this.renderer.width - 6)
+    const compact = this.renderer.width <= compactRunsMaxWidth
     const detailsWidth = this.detailsWidth()
     const listWidth = Math.max(36, this.renderer.width - detailsWidth - 7)
+    const bodyHeight = this.bodyHeight()
 
-    this.detailsBox.width = detailsWidth
+    // Narrow terminals stack the panels: the list keeps its rows and the
+    // details pane gets whatever the body has left.
+    this.bodyBox.flexDirection = compact ? "column" : "row"
+    if (compact) {
+      const listHeight = this.compactListHeight(bodyHeight)
+      this.listBox.width = "100%"
+      this.listBox.height = listHeight
+      this.detailsBox.width = "100%"
+      this.detailsBox.height = Math.max(3, bodyHeight - listHeight)
+    } else {
+      this.listBox.width = "auto"
+      this.listBox.height = "100%"
+      this.detailsBox.width = detailsWidth
+      this.detailsBox.height = "100%"
+    }
+
     this.headerText.content = this.headerContent(innerWidth)
-    this.listText.content = this.listContent(listWidth)
-    this.detailsText.content = this.detailsContent(now, detailsWidth - 4)
+    this.listText.content = this.listContent(compact ? innerWidth : listWidth)
+    this.detailsText.content = this.detailsContent(now, (compact ? innerWidth : detailsWidth) - 4)
     this.footerText.content = this.footerContent(innerWidth)
     this.renderSummaryModal()
     this.renderer.requestRender()
@@ -504,12 +531,7 @@ export class RunsBrowser {
     const failed = this.runs.filter((run) => run.statusKind === "failed").length
     const cost = this.runs.reduce((sum, run) => sum + (run.cost ?? 0), 0)
 
-    const title: TextChunk[] = [
-      bold(fg(theme.accent)("◆ convoy")),
-      fg(theme.faint)(` ${shortVersion()}`),
-      fg(theme.faint)("  ·  "),
-      fg(theme.text)("run history"),
-    ]
+    const title: TextChunk[] = [fg(theme.text)("run history")]
     const totals: TextChunk[] = [
       fg(theme.text)(`${this.runs.length} run${this.runs.length === 1 ? "" : "s"}`),
       fg(theme.faint)("  ·  "),
@@ -521,7 +543,7 @@ export class RunsBrowser {
     ]
     const line1 = padBetween(title, totals, width)
     const line2 = t`${fg(theme.dim)(truncate(runsRoot(), width))}`
-    return joinLines([line1, line2, limitsRow(this.limits, Date.now(), width)])
+    return joinLines([line1, line2])
   }
 
   private listContent(width: number) {

--- a/src/tui-actions.ts
+++ b/src/tui-actions.ts
@@ -44,6 +44,7 @@ export type ActionID =
   | "permissions"
   | "keep-awake"
   | "interactive"
+  | "usage"
   | "commands"
   | "help"
   | "abort"
@@ -282,6 +283,17 @@ export function dashboardActions(state: DashboardActionState): Action[] {
       label: "Interactive takeover",
       detail: state.interactiveArmed ? "armed for selected step" : "selected running step",
       help: "take over the selected running step",
+      priority: 9,
+    },
+    {
+      id: "usage",
+      group: "run",
+      available: navigable,
+      keys: "u",
+      hint: "usage",
+      label: "Usage and credits",
+      detail: "subscription and wallet meters",
+      help: "show subscription and credit usage",
       priority: 9,
     },
     {

--- a/src/tui-theme.ts
+++ b/src/tui-theme.ts
@@ -448,7 +448,7 @@ export function limitsRow(limits: LimitsSnapshot | undefined, now: number, width
     // Never an empty line: a placeholder keeps the row's cell real while the
     // first poll is in flight (and an all-empty trailing line would let the
     // text layout collapse to a single row).
-    const left: TextChunk[] = limits?.gptHint ? [fg(theme.faint)(`GPT — ${limits.gptHint}`)] : [fg(theme.faint)("…")]
+    const left: TextChunk[] = limits?.gptHint ? [fg(theme.faint)(`OpenAI — ${limits.gptHint}`)] : [fg(theme.faint)("…")]
     return padBetween(left, right, width)
   }
 
@@ -456,7 +456,7 @@ export function limitsRow(limits: LimitsSnapshot | undefined, now: number, width
   const barColor = pct >= 85 ? theme.red : pct >= 60 ? theme.yellow : theme.accent
   const pctChunk = fg(pct >= 60 ? barColor : theme.text)(`${pct}%`)
   const sep = fg(theme.faint)(" · ")
-  const bar = (cells: number): TextChunk[] => [fg(theme.dim)("GPT "), ...progressBar(pct / 100, cells, barColor), raw(" "), pctChunk]
+  const bar = (cells: number): TextChunk[] => [fg(theme.dim)("OpenAI "), ...progressBar(pct / 100, cells, barColor), raw(" "), pctChunk]
   const resets = gpt.sessionResetsAt === undefined ? [] : [sep, fg(theme.dim)(`resets ${fmtCountdown(gpt.sessionResetsAt, now)}`)]
   const weekly =
     gpt.weeklyPct === undefined
@@ -473,7 +473,7 @@ export function limitsRow(limits: LimitsSnapshot | undefined, now: number, width
     [...bar(10), ...resets],
     bar(10),
     bar(6),
-    [fg(theme.dim)("GPT "), pctChunk],
+    [fg(theme.dim)("OpenAI "), pctChunk],
   ]
   const rightLen = chunksLength(right)
   const fits = (chunks: TextChunk[]) => chunksLength(chunks) + (rightLen > 0 ? rightLen + 1 : 0) <= width

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -425,6 +425,7 @@ export class TuiProgress implements ProgressUI {
   private readonly todosText: TextRenderable
   private readonly feedBox: BoxRenderable
   private readonly feedText: TextRenderable
+  private readonly footerBox: BoxRenderable
   private readonly footerText: TextRenderable
   // Rebuilt on every pipeline render: panel row index → selectable tree target,
   // so group headers and concrete phases both resolve exactly as rendered.
@@ -672,7 +673,7 @@ export class TuiProgress implements ProgressUI {
         return
       case "o":
         consume()
-        this.openActiveSessionWindow("key")
+        this.openActiveSessionWindow()
         return
       case "v":
         if (!this.selectedGroup) {
@@ -955,14 +956,9 @@ export class TuiProgress implements ProgressUI {
       gap: 0,
     })
 
-    // The detail panel shows the focused phase; a click on it opens that
-    // phase's opencode session externally (same as [o]).
-    const openFocusedSession = (event: { preventDefault(): void; stopPropagation(): void }) => {
-      event.preventDefault()
-      event.stopPropagation()
-      this.openActiveSessionWindow("click")
-    }
-
+    // The detail panel shows the focused phase. Clicks here used to open that
+    // phase's opencode session, which fired on accidental clicks while reading;
+    // the session opens via [o] or the command palette instead.
     const step = this.panel({
       id: "convoy-step",
       width: "100%",
@@ -971,9 +967,7 @@ export class TuiProgress implements ProgressUI {
       backgroundColor: theme.bg,
       title: " step ",
       titleAlignment: "left",
-      onMouseDown: openFocusedSession,
     })
-    step.text.onMouseDown = openFocusedSession
 
     // Todos live in their own panel below the detail meta, showing the focused
     // phase's list whenever it has one.
@@ -986,9 +980,7 @@ export class TuiProgress implements ProgressUI {
       title: " todos ",
       titleAlignment: "left",
       visible: false,
-      onMouseDown: openFocusedSession,
     })
-    todos.text.onMouseDown = openFocusedSession
 
     // A click on the tab strip (content rows 0-1: labels or rail) selects
     // that tab; clicks anywhere else in the panel fall through untouched.
@@ -1025,20 +1017,15 @@ export class TuiProgress implements ProgressUI {
     feed.text.onMouseDown = switchTabFromFeed
     feed.text.onMouseScroll = wheelFromFeed
 
-    const openFromFooter = (event: { preventDefault(): void; stopPropagation(): void }) => {
-      event.preventDefault()
-      event.stopPropagation()
-      this.openActiveSessionWindow("click")
-    }
-
+    // The footer brands the run in its border title (◆ convoy + version,
+    // right-aligned like the other panels' titles) and holds the key hints.
     const footer = this.panel({
       id: "convoy-footer",
       height: 3,
       borderColor: theme.borderDim,
       backgroundColor: theme.bg,
-      onMouseDown: openFromFooter,
+      titleAlignment: "right",
     })
-    footer.text.onMouseDown = openFromFooter
 
     this.dirText = dirLine
     this.headerText = header.text
@@ -1052,6 +1039,7 @@ export class TuiProgress implements ProgressUI {
     this.todosText = todos.text
     this.feedBox = feed.box
     this.feedText = feed.text
+    this.footerBox = footer.box
     this.footerText = footer.text
 
     this.paletteTargets.push(
@@ -1933,7 +1921,7 @@ export class TuiProgress implements ProgressUI {
         return
       case "session":
         close()
-        this.openActiveSessionWindow("key")
+        this.openActiveSessionWindow()
         return
       case "fullscreen":
         close()
@@ -2351,7 +2339,7 @@ export class TuiProgress implements ProgressUI {
 
   // Opens the focused phase's opencode session in an external window; falls
   // back to any running phase if focus somehow lands on one without a session.
-  private openActiveSessionWindow(source: "click" | "key") {
+  private openActiveSessionWindow() {
     if (this.selectedGroup) {
       this.addEvent("convoy", "system", "select a model row to open its OpenCode session")
       this.render()
@@ -2363,7 +2351,7 @@ export class TuiProgress implements ProgressUI {
       this.render()
       return
     }
-    this.openSessionWindowForPhase(active.name, source)
+    this.openSessionWindowForPhase(active.name)
   }
 
   // Arms (or disarms) interactive takeover for the focused phase: while armed,
@@ -2412,10 +2400,10 @@ export class TuiProgress implements ProgressUI {
     }
     this.interactiveTakeover.add(phase.name)
     this.addEvent(phase.name, "system", "interactive mode armed — a clean finish holds the step here for you; esc in OpenCode holds it too")
-    this.openSessionWindowForPhase(phase.name, "key")
+    this.openSessionWindowForPhase(phase.name)
   }
 
-  private openSessionWindowForPhase(name: string, source: "click" | "key") {
+  private openSessionWindowForPhase(name: string) {
     if (this.humanReviewQueue[0]?.info.kind === "failure") {
       // Opening a session through the normal navigation path would leave the
       // failure gate offering [r], whose clean restore could erase those edits.
@@ -2454,7 +2442,7 @@ export class TuiProgress implements ProgressUI {
     }
 
     if (!runner.capabilities.liveAttach) this.iterateRequested = true
-    this.addEvent("convoy", "system", `${source === "key" ? "[o]" : "click"}: opening ${name} ${runner.sessionName} session ${shortID(phase.sessionID)}`)
+    this.addEvent("convoy", "system", `[o]: opening ${name} ${runner.sessionName} session ${shortID(phase.sessionID)}`)
     open
       .then((backend) => {
         this.addEvent("convoy", "system", `${name} session opened in ${backend}`)
@@ -2688,6 +2676,7 @@ export class TuiProgress implements ProgressUI {
           : this.phaseFeedLines(focus, rightWidth, contentRows)
     this.feedText.content = joinLines([...this.contentTabBar(rightWidth), ...body])
 
+    this.footerBox.title = this.footerTitle()
     this.footerText.content = this.footerContent(now, innerWidth)
     this.renderFullscreenView()
     this.renderModal()
@@ -2736,18 +2725,15 @@ export class TuiProgress implements ProgressUI {
 
   /**
    * The header's title segments, each carrying how eagerly it gives up columns
-   * when the title outgrows the panel. `◆ convoy`, the running version, and a
-   * goal verdict are pinned (Infinity); everything else sacrifices in the PRD's
-   * order — delta first, then the trajectory, then iter — with the goal target
-   * giving way last of all. Higher priority drops first. The version is pinned
-   * because it is identity, not status: the header must keep branding the
-   * binary even when the panel is narrow.
+   * when the title outgrows the panel. A goal verdict is pinned (Infinity);
+   * everything else sacrifices in the PRD's order — delta first, then the
+   * trajectory, then iter — with the goal target giving way last of all.
+   * Higher priority drops first. Branding (`◆ convoy` + version) is identity,
+   * not status, so it lives in the footer panel's border title instead of
+   * spending header columns on it.
    */
   private titleSegments(): { priority: number; chunks: TextChunk[] }[] {
-    const segments: { priority: number; chunks: TextChunk[] }[] = [
-      { priority: Infinity, chunks: [bold(fg(theme.accent)("◆ convoy"))] },
-      { priority: Infinity, chunks: [fg(theme.faint)(" "), fg(theme.faint)(shortVersion())] },
-    ]
+    const segments: { priority: number; chunks: TextChunk[] }[] = []
     const view = this.finished?.goalLoop ?? this.goalLoop
     if (view?.outcome) {
       const best = view.scores.length > 0 ? Math.max(...view.scores) : undefined
@@ -3593,6 +3579,18 @@ export class TuiProgress implements ProgressUI {
   }
 
   /**
+   * Branding rides the footer's border (right-aligned, like the other panels'
+   * titles) so the header row keeps its columns for live run status. When the
+   * full title would outgrow the border it falls back to the bare wordmark —
+   * the version is a nicety, not worth clipping mid-string.
+   */
+  private footerTitle() {
+    const full = ` ◆ convoy ${shortVersion()} `
+    // Border corners and a little slack on each side of the title.
+    return displayWidth(full) + 6 <= this.renderer.width ? full : " ◆ convoy "
+  }
+
+  /**
    * The footer is one unwrapped line in a fixed-height box, so hints that don't
    * fit used to be chopped off against the border with nothing to say they
    * existed. Now the row sheds them by priority and the pinned [ctrl+p] hint
@@ -3629,11 +3627,7 @@ export class TuiProgress implements ProgressUI {
     // Pinned: whatever else goes, the way to find the rest stays. The wording
     // switches to "all shortcuts" the moment a hint is actually dropped.
     const overflow: OverflowHint = { keys: "ctrl+p", label: "commands", moreLabel: "all shortcuts", priority: 0 }
-    const prefix = state.contentFocused
-      ? [fg(theme.dim)("read · ")]
-      : state.selectedGroup
-        ? [fg(theme.dim)("select a child for session · ")]
-        : []
+    const prefix = state.contentFocused ? [fg(theme.dim)("read · ")] : []
     return hintsRow(hints, this.footerStatusCandidates(now), width, { overflow, prefix })
   }
 

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -17,7 +17,7 @@ import { defaultAdvisorMaxCalls } from "./advisor"
 import { openClaudeSessionWindow } from "./claude-code"
 import { aggregateAdvisorEvents, type AdvisorEvent } from "./advisor-events"
 import { copyReportToClipboard, writeClipboardOSC52, type ClipboardResult } from "./clipboard"
-import { startLimitsPoller } from "./limits"
+import { openRouterLowBalance, startLimitsPoller } from "./limits"
 import { log } from "./log"
 import { markdownInlineChunks, markdownLines, parseMarkdown, renderMarkdownDoc, type MarkdownDoc } from "./markdown-render"
 import { openIterateOpencodeWindow, openOpencodeSessionWindow, openStoredSessionWindow, type SessionWindowBackend } from "./opencode"
@@ -31,13 +31,13 @@ import {
   formatElapsed,
   formatMoney,
   formatTime,
+  fmtCountdown,
   clipChunks,
   chunksLength,
   displayWidth,
   hintsRow,
   indentStyled,
   joinLines,
-  limitsRow,
   moreHintsMarker,
   padBetween,
   paletteForTerminal,
@@ -409,8 +409,10 @@ export class TuiProgress implements ProgressUI {
   // Subscription meters (GPT windows, OpenRouter credits) polled in the
   // background; the ticker just repaints whatever the last poll left.
   private readonly stopLimits: () => void
+  /** @internal — tests inject snapshots directly instead of running the poller. */
   private limits?: LimitsSnapshot
   private readonly dirText: TextRenderable
+  private readonly headerBox: BoxRenderable
   private readonly headerText: TextRenderable
   private readonly bodyBox: BoxRenderable
   private readonly pipelineBox: BoxRenderable
@@ -493,6 +495,7 @@ export class TuiProgress implements ProgressUI {
   private controlActivePhases = 0
   private keepAwake?: KeepAwakeState
   private commandPalette?: CommandPalette
+  private usageModal = false
   private finishModal?: FinishModal
   // ScrollBarRenderable emits change events for programmatic state updates as
   // well as mouse drags. Ignore the former so a layout recalculation cannot
@@ -604,6 +607,13 @@ export class TuiProgress implements ProgressUI {
       this.handleFinishKey(key)
       return
     }
+    // Read-only info modal: anything closes it; [u] toggles, esc also exits
+    // content focus so the modal doesn't leave a hidden focus state behind.
+    if (this.usageModal) {
+      this.usageModal = false
+      this.render()
+      return
+    }
     if (this.commandPalette) {
       this.handleCommandPaletteKey(key)
       return
@@ -674,6 +684,10 @@ export class TuiProgress implements ProgressUI {
       case "o":
         consume()
         this.openActiveSessionWindow()
+        return
+      case "u":
+        consume()
+        this.openUsageModal()
         return
       case "v":
         if (!this.selectedGroup) {
@@ -891,8 +905,8 @@ export class TuiProgress implements ProgressUI {
     })
 
     // The working directory sits above the header as a bare line, outside the
-    // bordered box, so the header holds just the run totals row and the
-    // subscription-meter row beneath it.
+    // bordered box. The header itself is one status row; a second row appears
+    // for goal-loop progress or hot subscription meters (see headerContent).
     const dirLine = new TextRenderable(renderer, {
       id: "convoy-dir",
       content: "",
@@ -903,7 +917,7 @@ export class TuiProgress implements ProgressUI {
 
     const header = this.panel({
       id: "convoy-header",
-      height: 4,
+      height: 3,
       borderColor: theme.border,
       backgroundColor: theme.bg,
     })
@@ -1028,6 +1042,7 @@ export class TuiProgress implements ProgressUI {
     })
 
     this.dirText = dirLine
+    this.headerBox = header.box
     this.headerText = header.text
     this.bodyBox = body
     this.pipelineBox = pipeline.box
@@ -1896,6 +1911,15 @@ export class TuiProgress implements ProgressUI {
     this.render()
   }
 
+  // [u]: the subscription meters behind a modal, so the header only surfaces
+  // them when one is hot. Content focus can't carry into a modal — the first
+  // key closes it — so it is dropped on open.
+  private openUsageModal() {
+    this.usageModal = true
+    this.contentFocused = false
+    this.render()
+  }
+
   private runCommand(item: CommandItem) {
     const close = () => {
       this.commandPalette = undefined
@@ -1918,6 +1942,10 @@ export class TuiProgress implements ProgressUI {
       case "interactive":
         close()
         this.toggleInteractiveTakeover()
+        return
+      case "usage":
+        close()
+        this.openUsageModal()
         return
       case "session":
         close()
@@ -2601,13 +2629,15 @@ export class TuiProgress implements ProgressUI {
     }
     const now = Date.now()
     const innerWidth = Math.max(40, this.renderer.width - 6)
+    const headerLines = this.headerContent(now, innerWidth)
+    this.headerBox.height = headerLines.length + 2
     const compact = this.usesCompactLayout()
     const pipelineWidth = compact ? innerWidth + 4 : this.pipelineWidth()
     const rightWidth = compact ? innerWidth : Math.max(40, this.renderer.width - pipelineWidth - 9)
-    // Body rows left after the dir line (1), header (4), and footer (3); the
-    // detail and todos panels grow with their content but never starve the
-    // content panel below them.
-    const bodyHeight = Math.max(8, this.renderer.height - 8)
+    // Body rows left after the dir line (1), the header (its rows plus the two
+    // borders), and the footer (3); the detail and todos panels grow with
+    // their content but never starve the content panel below them.
+    const bodyHeight = Math.max(8, this.renderer.height - headerLines.length - 7)
     const pipelineHeight = compact ? this.compactPipelineHeight(bodyHeight) : bodyHeight
     const rightBodyHeight = compact ? Math.max(8, bodyHeight - pipelineHeight - 1) : bodyHeight
 
@@ -2661,7 +2691,7 @@ export class TuiProgress implements ProgressUI {
     this.contentPageRows = contentRows
 
     this.dirText.content = this.dirContent(innerWidth)
-    this.headerText.content = this.headerContent(now, innerWidth)
+    this.headerText.content = joinLines(headerLines)
     this.pipelineText.content = this.pipelineContent(now, pipelineHeight - 2, pipelineWidth)
 
     // Body first: the active content tab computes the scroll indicator the rail shows.
@@ -2683,10 +2713,15 @@ export class TuiProgress implements ProgressUI {
     this.renderer.requestRender()
   }
 
-  // Header owns the session-wide totals (clock, elapsed time, cost, tokens)
-  // with the subscription meters on the row beneath. Phase status lives in
-  // the pipeline panel.
-  private headerContent(now: number, width: number) {
+  /**
+   * The header is one status row: run state on the left, session-wide totals
+   * (elapsed, cost, tokens) on the right. A second row appears only when the
+   * run is a goal loop (target, iteration, score trajectory) or a meter is
+   * hot enough to be worth an interruption (see limitChips); the panel grows
+   * to fit it. Phase status lives in the pipeline panel and the full meters
+   * behind [u].
+   */
+  private headerContent(now: number, width: number): StyledText[] {
     const usage = totalUsage(this.phases)
     const advisor = aggregateAdvisorEvents(this.phases.flatMap((phase) => phase.advisorEvents))
     const advisorInput = advisor.tokens.input + advisor.tokens.cacheRead + advisor.tokens.cacheWrite
@@ -2703,11 +2738,9 @@ export class TuiProgress implements ProgressUI {
       advisorOutput: advisorOutput + this.priorUsage.advisorOutput,
       advisorAttempted: advisor.attempted > 0 || this.priorUsage.advisorAttempted,
     }
-    // The clock and elapsed time freeze at the moment the run ended.
+    // Elapsed time freezes at the moment the run ended.
     const endAt = this.finished?.at ?? now
     const totals: TextChunk[] = [
-      fg(theme.dim)(formatTime(endAt)),
-      fg(theme.faint)("  ·  "),
       fg(theme.text)(formatElapsed(endAt - this.startedAt)),
       fg(theme.faint)("  ·  "),
       fg(theme.green)(formatMoney(merged.cost + merged.advisorCost)),
@@ -2717,44 +2750,69 @@ export class TuiProgress implements ProgressUI {
       fg(theme.faint)("  ·  "),
       fg(theme.dim)(`↑${formatCount(merged.input + merged.advisorInput)} ↓${formatCount(merged.output + merged.advisorOutput)} tokens`),
     ]
-    const segments = this.titleSegments()
-    const budget = Math.max(12, width - Math.min(42, chunksLength(totals)) - 1)
-    const title = fitTitleSegments(segments, budget)
-    return joinLines([padBetween(title, totals, width), limitsRow(this.limits, now, width)])
+
+    const status: TextChunk[] = this.finished
+      ? this.finished.status === "completed"
+        ? [bold(fg(theme.green)("✓ run completed"))]
+        : [bold(fg(theme.red)("✗ run failed"))]
+      : this.controlState === "paused"
+        ? [bold(fg(theme.yellow)("paused")), fg(theme.faint)(" · p resume")]
+        : this.controlState === "pausing"
+          ? [bold(fg(theme.cyan)("pausing")), fg(theme.faint)(` · ${this.controlActivePhases} active`)]
+          : [fg(theme.dim)("running")]
+    if (this.keepAwake?.status === "on" && !this.finished) status.push(fg(theme.faint)("  ·  "), fg(theme.cyan)("☕ awake"))
+    const row1 = padBetween(status, totals, width)
+
+    const rows = [row1]
+    const goal = this.goalRowSegments()
+    const chips = this.limitChips(now)
+    if (goal.length > 0 || chips.length > 0) {
+      const sep = fg(theme.faint)("  ·  ")
+      const left: TextChunk[] = []
+      for (const segment of goal) {
+        if (left.length > 0) left.push(sep)
+        left.push(...segment.chunks)
+      }
+      const right: TextChunk[] = []
+      for (const segment of chips) {
+        if (right.length > 0) right.push(sep)
+        right.push(...segment.chunks)
+      }
+      rows.push(padBetween(left, right, width))
+    }
+    return rows
   }
 
   /**
-   * The header's title segments, each carrying how eagerly it gives up columns
-   * when the title outgrows the panel. A goal verdict is pinned (Infinity);
-   * everything else sacrifices in the PRD's order — delta first, then the
-   * trajectory, then iter — with the goal target giving way last of all.
-   * Higher priority drops first. Branding (`◆ convoy` + version) is identity,
-   * not status, so it lives in the footer panel's border title instead of
-   * spending header columns on it.
+   * The header's second-row goal segments, each carrying how eagerly it gives
+   * up columns when the row outgrows the panel. The verdict is pinned
+   * (Infinity); everything else sacrifices in the PRD's order — delta first,
+   * then the trajectory, then iter — with the goal target giving way last of
+   * all. Higher priority drops first. Empty for pipelines without a goal
+   * loop, so the header stays a single row.
    */
-  private titleSegments(): { priority: number; chunks: TextChunk[] }[] {
+  private goalRowSegments(): { priority: number; chunks: TextChunk[] }[] {
     const segments: { priority: number; chunks: TextChunk[] }[] = []
     const view = this.finished?.goalLoop ?? this.goalLoop
     if (view?.outcome) {
       const best = view.scores.length > 0 ? Math.max(...view.scores) : undefined
-      const verdictChunks: TextChunk[] = [fg(theme.faint)("  ·  ")]
       if (view.outcome.reason === "no-score") {
-        verdictChunks.push(bold(fg(theme.red)("no score")))
+        segments.push({ priority: Infinity, chunks: [bold(fg(theme.red)("no score"))] })
       } else {
         const label = view.outcome.reason === "goal" ? "goal" : view.outcome.reason === "plateau" ? "plateau" : "cap"
-        const chunks = view.outcome.reason === "goal" ? bold(fg(theme.green)(`✓ ${label} ${best ?? "?"}/100`)) : bold(fg(theme.text)(`${label} ${best ?? "?"}/100`))
-        verdictChunks.push(chunks)
+        const chunks =
+          view.outcome.reason === "goal" ? bold(fg(theme.green)(`✓ ${label} ${best ?? "?"}/100`)) : bold(fg(theme.text)(`${label} ${best ?? "?"}/100`))
+        segments.push({ priority: Infinity, chunks: [chunks] })
       }
       if (view.outcome.reason !== "goal" && view.outcome.restored) {
-        verdictChunks.push(fg(theme.faint)("  ·  "), fg(theme.dim)("restored to best"))
+        segments.push({ priority: Infinity, chunks: [fg(theme.dim)("restored to best")] })
       }
-      segments.push({ priority: Infinity, chunks: verdictChunks })
       if (view.scores.length > 0) segments.push(trajectorySegment(view.scores))
       return segments
     }
     if (!this.finished && view && !view.outcome) {
-      segments.push({ priority: 2, chunks: [fg(theme.faint)("  ·  "), fg(theme.text)(`goal ${view.target}`)] })
-      segments.push({ priority: 4, chunks: [fg(theme.faint)("  ·  "), fg(theme.dim)(`iter ${view.iteration}/${view.maxRuns}`)] })
+      segments.push({ priority: 2, chunks: [fg(theme.text)(`goal ${view.target}`)] })
+      segments.push({ priority: 4, chunks: [fg(theme.dim)(`iter ${view.iteration}/${view.maxRuns}`)] })
       if (view.scores.length > 0) {
         const last = view.scores[view.scores.length - 1]!
         const prev = view.scores[view.scores.length - 2]
@@ -2767,48 +2825,58 @@ export class TuiProgress implements ProgressUI {
           const delta = last - prev
           segments.push({
             priority: 6,
-            chunks: [fg(theme.faint)("  ·  "), fg(delta >= 0 ? theme.green : theme.red)(`${delta >= 0 ? "+" : ""}${delta}`)],
+            chunks: [fg(delta >= 0 ? theme.green : theme.red)(`${delta >= 0 ? "+" : ""}${delta}`)],
           })
         }
       }
+      return segments
     }
-    if (!this.finished) {
-      if (this.controlState !== "running") {
-        segments.push({
-          priority: 6,
-          chunks: [
-            fg(theme.faint)("  ·  "),
-            bold(fg(this.controlState === "paused" ? theme.yellow : theme.cyan)(
-              this.controlState === "paused" ? "paused · p resume" : `pausing · ${this.controlActivePhases} active`,
-            )),
-          ],
-        })
-      }
-      if (this.keepAwake?.status === "on") {
-        segments.push({ priority: 6, chunks: [fg(theme.faint)("  ·  "), bold(fg(theme.cyan)("☕ awake"))] })
-      }
+    // A failed goal-loop run keeps the trajectory it accumulated.
+    if (this.finished?.status === "failed" && view && view.scores.length > 0) {
+      segments.push(trajectorySegment(view.scores))
     }
-    if (this.finished) {
-      const isGoalLoop = this.finished.goalLoop !== undefined
-      if (!isGoalLoop || this.finished.status === "failed") {
-        segments.push({
-          priority: Infinity,
-          chunks: [
-            fg(theme.faint)("  ·  "),
-            this.finished.status === "completed" ? bold(fg(theme.green)("✓ run completed")) : bold(fg(theme.red)("✗ run failed")),
-          ],
-        })
-      }
-      // A failed goal-loop run keeps the trajectory it accumulated, trailing
-      // the failed verdict the same way the completed verdicts lead theirs.
-      if (this.finished.status === "failed" && view && view.scores.length > 0) {
-        segments.push(trajectorySegment(view.scores))
-      }
+    return segments
+  }
+
+  /**
+   * Second-row warning chips for the subscription meters, right-aligned. A
+   * meter only earns header space when it is about to stall the run (GPT
+   * window ≥85%, OpenRouter below openRouterLowBalance, or an auth problem);
+   * the full meters with their healthy states live behind [u].
+   */
+  private limitChips(now: number): { priority: number; chunks: TextChunk[] }[] {
+    const chips: { priority: number; chunks: TextChunk[] }[] = []
+    const gpt = this.limits?.gpt
+    if (gpt) {
+      const session = Math.round(gpt.sessionPct)
+      const weekly = gpt.weeklyPct === undefined ? undefined : Math.round(gpt.weeklyPct)
+      const resets = gpt.sessionResetsAt === undefined ? undefined : fmtCountdown(gpt.sessionResetsAt, now)
+      const chunks: TextChunk[] = [fg(theme.yellow)("⚠ GPT")]
+      if (session >= 85) chunks.push(fg(theme.yellow)(` ${session}%`), ...(resets ? [fg(theme.faint)(` resets ${resets}`)] : []))
+      else if (weekly !== undefined && weekly >= 85) chunks.push(fg(theme.yellow)(` wk ${weekly}%`))
+      if (session >= 85 && weekly !== undefined && weekly >= 85) chunks.push(fg(theme.yellow)(` · wk ${weekly}%`))
+      if (chunks.length > 1) chips.push({ priority: 0, chunks })
+    } else if (this.limits?.gptHint) {
+      chips.push({ priority: 0, chunks: [fg(theme.yellow)(`⚠ GPT — ${this.limits.gptHint}`)] })
     }
-    if (this.finished?.qualityScore !== undefined && !this.finished.goalLoop) {
-      segments.push({ priority: 5, chunks: [fg(theme.faint)("  ·  "), bold(fg(theme.accent)(`score ${this.finished.qualityScore}/100`))] })
+    const openrouter = this.limits?.openrouter
+    if (openrouter?.kind === "remaining" && openrouter.amount < openRouterLowBalance) {
+      chips.push({ priority: 0, chunks: [fg(theme.yellow)(`⚠ OpenRouter ${formatMoney(openrouter.amount)} left`)] })
     }
+    return chips
+  }
+
+  /**
+   * The finish screen's one-line quality summary: the single score, or the
+   * per-iteration trajectory of a score loop that ran without goal targets.
+   * The goal loop's own verdict lives in the header's goal row instead.
+   */
+  private titleSegments(): { priority: number; chunks: TextChunk[] }[] {
+    const segments: { priority: number; chunks: TextChunk[] }[] = []
     const finished = this.finished
+    if (finished?.qualityScore !== undefined && !finished.goalLoop) {
+      segments.push({ priority: 5, chunks: [bold(fg(theme.accent)(`score ${finished.qualityScore}/100`))] })
+    }
     const trajectory = finished?.goalTrajectory
     if (trajectory && trajectory.length > 1 && finished && !finished.goalLoop) {
       segments.push(trajectorySegment(trajectory))
@@ -3656,11 +3724,78 @@ export class TuiProgress implements ProgressUI {
       this.renderFinishModal(this.finishModal)
       return
     }
+    if (this.usageModal) {
+      this.renderUsageModal()
+      return
+    }
     if (this.commandPalette) {
       this.renderCommandPalette()
       return
     }
     this.overlay.visible = false
+  }
+
+  /**
+   * [u]: the subscription meters, moved out of the header so a healthy state
+   * costs zero rows. Everything degrades: no GPT auth yet, no OpenRouter key,
+   * and the first poll still in flight each say so in place.
+   */
+  private renderUsageModal() {
+    this.overlay.visible = true
+    this.modal.title = " usage "
+
+    const boxWidth = Math.max(48, Math.min(76, this.renderer.width - 8))
+    const width = boxWidth - 6
+    const lines: StyledText[] = []
+    const now = Date.now()
+
+    const gpt = this.limits?.gpt
+    const gptLabel = "GPT        "
+    if (gpt) {
+      const pct = Math.round(gpt.sessionPct)
+      const barColor = pct >= 85 ? theme.red : pct >= 60 ? theme.yellow : theme.accent
+      const label = fg(theme.dim)(gptLabel)
+      const bar = [...progressBar(pct / 100, 10, barColor), raw(" "), fg(pct >= 60 ? barColor : theme.text)(`${pct}%`)]
+      const tail: TextChunk[] = []
+      if (gpt.sessionResetsAt !== undefined) tail.push(fg(theme.faint)(" · resets "), fg(theme.dim)(fmtCountdown(gpt.sessionResetsAt, now)))
+      if (gpt.weeklyPct !== undefined) {
+        const wk = Math.round(gpt.weeklyPct)
+        tail.push(fg(theme.faint)(" · wk "), fg(wk >= 85 ? theme.red : wk >= 60 ? theme.yellow : theme.dim)(`${wk}%`))
+      }
+      const full = [...bar, ...tail]
+      // Drop the weekly window first, then the reset countdown, before ever
+      // clipping a value mid-token.
+      const budget = width - chunksLength([label])
+      let fitted = full
+      if (chunksLength(fitted) > budget) fitted = gpt.weeklyPct === undefined ? bar : [...bar, ...tail.slice(0, 2)]
+      if (chunksLength(fitted) > budget) fitted = bar
+      lines.push(new StyledText([label, ...fitted]))
+    } else if (this.limits?.gptHint) {
+      lines.push(new StyledText([fg(theme.dim)(gptLabel), fg(theme.yellow)(truncate(this.limits.gptHint, width - gptLabel.length))]))
+    } else {
+      lines.push(new StyledText([fg(theme.dim)(gptLabel), fg(theme.faint)(truncate("not configured — `codex login` meters the ChatGPT windows", width - gptLabel.length))]))
+    }
+
+    const openrouter = this.limits?.openrouter
+    const orLabel = "OpenRouter "
+    if (openrouter) {
+      const value = openrouter.kind === "remaining" ? `${formatMoney(openrouter.amount)} left` : `${formatMoney(openrouter.amount)} spent this month`
+      const color = openrouter.kind === "remaining" && openrouter.amount < openRouterLowBalance ? theme.yellow : theme.text
+      lines.push(new StyledText([fg(theme.dim)(orLabel), fg(color)(value)]))
+    } else {
+      lines.push(new StyledText([fg(theme.dim)(orLabel), fg(theme.faint)(truncate("not configured — `convoy auth openrouter` stores the balance key", width - orLabel.length))]))
+    }
+
+    lines.push(plain(""))
+    if (this.limits) {
+      lines.push(new StyledText([fg(theme.faint)(`updated ${formatAgo(now - this.limits.fetchedAt)}`)]))
+    } else {
+      lines.push(new StyledText([fg(theme.faint)("first poll still in flight…")]))
+    }
+    lines.push(plain(""))
+    lines.push(new StyledText([fg(theme.faint)("esc close")]))
+
+    this.modalText.content = joinLines(lines)
   }
 
   private renderFinishModal(modal: FinishModal) {
@@ -4385,29 +4520,9 @@ function pendingPhases(phases: readonly ProgressPhase[]): PhaseState[] {
   }))
 }
 
-/** The score trajectory (`71 → 84`, or `71 → …` while pending), among the first title segments to sacrifice. */
+/** The score trajectory (`71 → 84`, or `71 → …` while pending), among the first segments to sacrifice. */
 function trajectorySegment(scores: number[], pending = false): { priority: number; chunks: TextChunk[] } {
-  return { priority: 5, chunks: [fg(theme.faint)("  ·  "), fg(theme.dim)(`${scores.join(" → ")}${pending ? " → …" : ""}`)] }
-}
-
-/**
- * Drops the title's most droppable segments (highest `priority`) until it fits
- * the budget. Pinned segments (Infinity) — `◆ convoy`, the verdict — never
- * leave; everything else yields in priority order.
- */
-function fitTitleSegments(segments: { priority: number; chunks: TextChunk[] }[], budget: number): TextChunk[] {
-  const remaining = [...segments]
-  while (chunksLength(remaining.flatMap((segment) => segment.chunks)) > budget) {
-    let worstIndex = -1
-    for (let index = 0; index < remaining.length; index++) {
-      const segment = remaining[index]!
-      if (segment.priority === Infinity) continue
-      if (worstIndex === -1 || segment.priority > remaining[worstIndex]!.priority) worstIndex = index
-    }
-    if (worstIndex === -1) break
-    remaining.splice(worstIndex, 1)
-  }
-  return remaining.flatMap((segment) => segment.chunks)
+  return { priority: 5, chunks: [fg(theme.dim)(`${scores.join(" → ")}${pending ? " → …" : ""}`)] }
 }
 
 async function fileReadable(path: string) {

--- a/src/tui.ts
+++ b/src/tui.ts
@@ -2851,13 +2851,13 @@ export class TuiProgress implements ProgressUI {
       const session = Math.round(gpt.sessionPct)
       const weekly = gpt.weeklyPct === undefined ? undefined : Math.round(gpt.weeklyPct)
       const resets = gpt.sessionResetsAt === undefined ? undefined : fmtCountdown(gpt.sessionResetsAt, now)
-      const chunks: TextChunk[] = [fg(theme.yellow)("⚠ GPT")]
+      const chunks: TextChunk[] = [fg(theme.yellow)("⚠ OpenAI")]
       if (session >= 85) chunks.push(fg(theme.yellow)(` ${session}%`), ...(resets ? [fg(theme.faint)(` resets ${resets}`)] : []))
       else if (weekly !== undefined && weekly >= 85) chunks.push(fg(theme.yellow)(` wk ${weekly}%`))
       if (session >= 85 && weekly !== undefined && weekly >= 85) chunks.push(fg(theme.yellow)(` · wk ${weekly}%`))
       if (chunks.length > 1) chips.push({ priority: 0, chunks })
     } else if (this.limits?.gptHint) {
-      chips.push({ priority: 0, chunks: [fg(theme.yellow)(`⚠ GPT — ${this.limits.gptHint}`)] })
+      chips.push({ priority: 0, chunks: [fg(theme.yellow)(`⚠ OpenAI — ${this.limits.gptHint}`)] })
     }
     const openrouter = this.limits?.openrouter
     if (openrouter?.kind === "remaining" && openrouter.amount < openRouterLowBalance) {
@@ -3749,12 +3749,22 @@ export class TuiProgress implements ProgressUI {
     const lines: StyledText[] = []
     const now = Date.now()
 
+    const openrouter = this.limits?.openrouter
+    const orLabel = "OpenRouter "
+    if (openrouter) {
+      const value = openrouter.kind === "remaining" ? `${formatMoney(openrouter.amount)} left` : `${formatMoney(openrouter.amount)} spent this month`
+      const color = openrouter.kind === "remaining" && openrouter.amount < openRouterLowBalance ? theme.yellow : theme.text
+      lines.push(new StyledText([fg(theme.dim)(orLabel), fg(color)(value)]))
+    } else {
+      lines.push(new StyledText([fg(theme.dim)(orLabel), fg(theme.faint)(truncate("not configured — `convoy auth openrouter` stores the balance key", width - orLabel.length))]))
+    }
+
     const gpt = this.limits?.gpt
-    const gptLabel = "GPT        "
+    const openaiLabel = "OpenAI     "
     if (gpt) {
       const pct = Math.round(gpt.sessionPct)
       const barColor = pct >= 85 ? theme.red : pct >= 60 ? theme.yellow : theme.accent
-      const label = fg(theme.dim)(gptLabel)
+      const label = fg(theme.dim)(openaiLabel)
       const bar = [...progressBar(pct / 100, 10, barColor), raw(" "), fg(pct >= 60 ? barColor : theme.text)(`${pct}%`)]
       const tail: TextChunk[] = []
       if (gpt.sessionResetsAt !== undefined) tail.push(fg(theme.faint)(" · resets "), fg(theme.dim)(fmtCountdown(gpt.sessionResetsAt, now)))
@@ -3771,19 +3781,9 @@ export class TuiProgress implements ProgressUI {
       if (chunksLength(fitted) > budget) fitted = bar
       lines.push(new StyledText([label, ...fitted]))
     } else if (this.limits?.gptHint) {
-      lines.push(new StyledText([fg(theme.dim)(gptLabel), fg(theme.yellow)(truncate(this.limits.gptHint, width - gptLabel.length))]))
+      lines.push(new StyledText([fg(theme.dim)(openaiLabel), fg(theme.yellow)(truncate(this.limits.gptHint, width - openaiLabel.length))]))
     } else {
-      lines.push(new StyledText([fg(theme.dim)(gptLabel), fg(theme.faint)(truncate("not configured — `codex login` meters the ChatGPT windows", width - gptLabel.length))]))
-    }
-
-    const openrouter = this.limits?.openrouter
-    const orLabel = "OpenRouter "
-    if (openrouter) {
-      const value = openrouter.kind === "remaining" ? `${formatMoney(openrouter.amount)} left` : `${formatMoney(openrouter.amount)} spent this month`
-      const color = openrouter.kind === "remaining" && openrouter.amount < openRouterLowBalance ? theme.yellow : theme.text
-      lines.push(new StyledText([fg(theme.dim)(orLabel), fg(color)(value)]))
-    } else {
-      lines.push(new StyledText([fg(theme.dim)(orLabel), fg(theme.faint)(truncate("not configured — `convoy auth openrouter` stores the balance key", width - orLabel.length))]))
+      lines.push(new StyledText([fg(theme.dim)(openaiLabel), fg(theme.faint)(truncate("not configured — `codex login` meters the OpenAI windows", width - openaiLabel.length))]))
     }
 
     lines.push(plain(""))

--- a/test/env.ts
+++ b/test/env.ts
@@ -2,9 +2,16 @@ import { mkdirSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
+import { setLimitsFetcherForTests } from "../src/limits"
+
 // Isolate every test run from the developer's real ~/.convoy so tests never
 // read or write the user's actual config, runs, or agent prompts. CONVOY_HOME
 // points at the directory that holds `.convoy` (the same convention as a repo
 // root), so the global config resolves to <tmp>/.convoy/config.yaml.
 process.env.CONVOY_HOME ??= join(tmpdir(), `convoy-test-home-${process.pid}`)
 mkdirSync(process.env.CONVOY_HOME, { recursive: true })
+
+// Same for the developer's own subscriptions: dashboards under test must not
+// pick up the real ChatGPT/OpenRouter meters. Tests that need a snapshot
+// assign it to `dashboard.limits` directly.
+setLimitsFetcherForTests(async () => ({}))

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -919,8 +919,18 @@ describe("launch TUI sidebar usage meters", () => {
       const pipelines = frame.indexOf(" pipelines ")
       const usage = frame.indexOf(" usage ", pipelines)
       expect(usage).toBeGreaterThanOrEqual(pipelines)
-      expect(frame).toContain("GPT")
+      // OpenRouter is the wallet row, so it sits above the OpenAI bar.
+      expect(frame.indexOf("OpenRouter ")).toBeLessThan(frame.indexOf("OpenAI "))
+      expect(frame).toContain("OpenAI")
       expect(frame).toContain("42%")
+      // The panel is pegged to the footer: its top border, two meter rows, and
+      // bottom border, then the footer's top border immediately after.
+      const lines = frame.split("\n")
+      const usageLine = lines.findIndex((line) => line.includes(" usage "))
+      // The footer's top border is the first rounded corner after the panel.
+      const footerLine = lines.findIndex((line, index) => index > usageLine && line.trimStart().startsWith("╭"))
+      // usage top, two meter rows, bottom border, then the footer immediately.
+      expect(footerLine - usageLine).toBe(4)
     } finally {
       closeLauncher(launcher)
     }

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -7,6 +7,7 @@ import { builtInAgents, builtInPipelines, hasWritableStep, resolvePipeline } fro
 import { parseConvoyConfig } from "../src/config"
 import { consensusStep } from "../src/quality-score"
 import { displayWidth } from "../src/tui-theme"
+import type { LimitsSnapshot } from "../src/limits"
 import type { KeyEvent } from "@opentui/core"
 
 function key(partial: Partial<KeyEvent>): KeyEvent {
@@ -885,5 +886,67 @@ describe("launch TUI goal mode", () => {
     expect(eligible("review")).toBe(false)
     expect(eligible("review-lite")).toBe(false)
     expect(eligible("implement")).toBe(false)
+  })
+})
+
+describe("launch TUI sidebar usage meters", () => {
+  type Launcher = Awaited<ReturnType<typeof createLauncher>>
+  const injectLimits = (picker: Launcher["picker"], limits: LimitsSnapshot) => {
+    ;(picker as unknown as { limits: LimitsSnapshot }).limits = limits
+  }
+
+  // The launcher repaints on its 250ms ticker, and the background limits poll
+  // (stubbed empty in test/env.ts) can race with its own empty snapshot, so
+  // re-apply the field and wait a tick before judging each frame.
+  async function renderWithLimits(launcher: Launcher, limits: LimitsSnapshot, predicate: (frame: string) => boolean) {
+    for (let attempt = 0; attempt < 60; attempt++) {
+      injectLimits(launcher.picker, limits)
+      await Bun.sleep(280)
+      const frame = launcher.captureCharFrame()
+      if (predicate(frame)) return frame
+    }
+    throw new Error(`timed out waiting for usage render:\n${launcher.captureCharFrame()}`)
+  }
+
+  test("a tall wide screen pins the meters under the pipeline list", async () => {
+    const launcher = await createLauncher(120, 30)
+    try {
+      const frame = await renderWithLimits(
+        launcher,
+        { gpt: { sessionPct: 42, sessionResetsAt: Date.now() + 130 * 60_000, weeklyPct: 18 }, openrouter: { kind: "remaining", amount: 12.34 }, fetchedAt: Date.now() },
+        (f) => f.includes("OpenRouter $12.34 left"),
+      )
+      const pipelines = frame.indexOf(" pipelines ")
+      const usage = frame.indexOf(" usage ", pipelines)
+      expect(usage).toBeGreaterThanOrEqual(pipelines)
+      expect(frame).toContain("GPT")
+      expect(frame).toContain("42%")
+    } finally {
+      closeLauncher(launcher)
+    }
+  })
+
+  test("a low balance warns the amber the way the dashboard does", async () => {
+    const launcher = await createLauncher(120, 30)
+    try {
+      const frame = await renderWithLimits(
+        launcher,
+        { openrouter: { kind: "remaining", amount: 7.4 }, fetchedAt: Date.now() },
+        (f) => f.includes("OpenRouter $7.40 left"),
+      )
+      expect(frame).toContain("OpenRouter $7.40 left")
+    } finally {
+      closeLauncher(launcher)
+    }
+  })
+
+  test("compact panels keep the meters off the sidebar to save vertical space", async () => {
+    const launcher = await createLauncher(compactLaunchMaxWidth, 30)
+    try {
+      await launcher.renderOnce()
+      expect(launcher.captureCharFrame()).not.toContain(" usage ")
+    } finally {
+      closeLauncher(launcher)
+    }
   })
 })

--- a/test/runs-tui.test.ts
+++ b/test/runs-tui.test.ts
@@ -173,3 +173,39 @@ test("Ctrl-C exits immediately", async () => {
 
   await expect(result).resolves.toEqual({ type: "exit" })
 })
+
+test("wide screens keep the run list and details side by side", async () => {
+  const testRenderer = await createTestRenderer({ width: 120, height: 40 })
+  const instance = new RunsBrowser(testRenderer.renderer, sampleRuns(), 0)
+  try {
+    await Bun.sleep(260)
+    const lines = testRenderer.captureCharFrame().split("\n")
+    // The header carries convoy+version on its border, not a meter row.
+    expect(lines.join("\n")).toContain("convoy dev")
+    expect(lines.join("\n")).not.toContain("OpenRouter")
+    expect(lines.join("\n")).not.toContain("OpenAI")
+    // Side by side: both panel titles share the same horizontal band.
+    const runsTitle = lines.findIndex((line) => line.trimStart().startsWith("╭─ runs"))
+    expect(runsTitle).toBeGreaterThanOrEqual(0)
+    // The stock title starts the line; the details border follows on the same row.
+    expect(lines[runsTitle]).toContain("╭─ deta")
+  } finally {
+    testRenderer.mockInput.pressKey("c", { ctrl: true })
+  }
+})
+
+test("compact screens stack the run list above the details panel", async () => {
+  const testRenderer = await createTestRenderer({ width: 84, height: 30 })
+  const instance = new RunsBrowser(testRenderer.renderer, sampleRuns(), 0)
+  try {
+    await Bun.sleep(260)
+    const lines = testRenderer.captureCharFrame().split("\n")
+    const runsTitle = lines.findIndex((line) => line.trimStart().startsWith("╭─ runs"))
+    const detailsTitle = lines.findIndex((line) => line.trimStart().startsWith("╭─ deta"))
+    // Stacked: the details panel's title sits below the runs panel's.
+    expect(runsTitle).toBeGreaterThanOrEqual(0)
+    expect(detailsTitle).toBeGreaterThan(runsTitle)
+  } finally {
+    testRenderer.mockInput.pressKey("c", { ctrl: true })
+  }
+})

--- a/test/runs-tui.test.ts
+++ b/test/runs-tui.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test"
 import { createTestRenderer } from "@opentui/core/testing"
 
 import { RunsBrowser } from "../src/runs-browser"
+import { shortVersion } from "../src/version"
 
 import type { RunEntry } from "../src/runs"
 
@@ -181,7 +182,9 @@ test("wide screens keep the run list and details side by side", async () => {
     await Bun.sleep(260)
     const lines = testRenderer.captureCharFrame().split("\n")
     // The header carries convoy+version on its border, not a meter row.
-    expect(lines.join("\n")).toContain("convoy dev")
+    // shortVersion() is "dev" in a bare checkout and "vX.Y.Z-dev" when
+    // npm_package_version is set (CI), so the assertion has to follow it.
+    expect(lines.join("\n")).toContain(`convoy ${shortVersion()}`)
     expect(lines.join("\n")).not.toContain("OpenRouter")
     expect(lines.join("\n")).not.toContain("OpenAI")
     // Side by side: both panel titles share the same horizontal band.

--- a/test/tui-actions.test.ts
+++ b/test/tui-actions.test.ts
@@ -53,7 +53,7 @@ describe("dashboard action registry", () => {
   })
 
   test("a live run offers the run controls", () => {
-    expect(commands()).toEqual(["keep-awake", "pause", "permissions", "interactive", "session", "fullscreen", "tab-session", "tab-reports", "tab-logs", "tab-advisor", "help"])
+    expect(commands()).toEqual(["keep-awake", "pause", "permissions", "interactive", "usage", "session", "fullscreen", "tab-session", "tab-reports", "tab-logs", "tab-advisor", "help"])
   })
 
   test("an attached observer cannot pause, keep awake, or take over", () => {

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -1240,7 +1240,9 @@ describe("goal loop header", () => {
         const frame = captureCharFrame()
         expect(frame, testCase.outcome.reason).toContain(testCase.verdict)
         expect(frame, testCase.outcome.reason).toContain(testCase.trajectory)
-        expect(frame, testCase.outcome.reason).not.toContain("run completed")
+        // The status row still names the run's end state; the verdict is the
+        // goal row's job, not a replacement for it.
+        expect(frame, testCase.outcome.reason).toContain("✓ run completed")
       } finally {
         dashboard.stop()
       }
@@ -1337,6 +1339,162 @@ describe("goal loop header", () => {
       await renderOnce()
       // The clock kept running from the loop's start rather than the new run's.
       expect(captureCharFrame()).not.toContain("·  0:00")
+    } finally {
+      dashboard.stop()
+    }
+  })
+})
+
+describe("dashboard header status row", () => {
+  test("a plain pipeline stays one row: status on the left, totals on the right", async () => {
+    const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
+    try {
+      dashboard.phaseStarted("implement")
+      await renderOnce()
+      const frame = captureCharFrame()
+      const beforePipeline = frame.slice(0, frame.indexOf("╭─ pipeline")).trim().split("\n")
+      // dir line + header top border + the single status row + bottom border.
+      expect(beforePipeline).toHaveLength(4)
+      const statusRow = beforePipeline[2]!
+      expect(statusRow).toContain("running")
+      expect(statusRow).toContain("tokens")
+      // No goal segments, no stray meter placeholders on the only row.
+      expect(statusRow).not.toContain("goal ")
+      expect(statusRow).not.toContain("…")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("a slowing pipeline names the pausing state without a stray separator", async () => {
+    const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
+    try {
+      dashboard.runControlState("pausing", 1)
+      dashboard.phaseStarted("implement")
+      await renderOnce()
+      const row = lineContaining(captureCharFrame(), "pausing · 1 active")
+      expect(row.trimStart().startsWith("│ pausing")).toBe(true)
+    } finally {
+      dashboard.stop()
+    }
+  })
+})
+
+describe("header limit chips", () => {
+  type Dashboard = Awaited<ReturnType<typeof createDashboard>>["dashboard"]
+  const setLimits = (dashboard: Dashboard, snapshot: LimitsSnapshot) => {
+    ;(dashboard as unknown as { limits: LimitsSnapshot }).limits = snapshot
+  }
+  const now = Date.now()
+  // The dashboard coalesces repaints per frame, so ask for frames until the
+  // injected snapshot — or the absence of any chip — is what's on screen.
+  const renderWithLimits = (
+    dashboard: Dashboard,
+    renderOnce: () => Promise<void>,
+    captureCharFrame: () => string,
+    snapshot: LimitsSnapshot,
+    expectChip: boolean,
+  ) => {
+    dashboard.phaseStarted("implement")
+    setLimits(dashboard, snapshot)
+    return waitForRenderedFrame(renderOnce, captureCharFrame, (frame) => frame.includes("⚠") === expectChip)
+  }
+
+  test("no second row while every meter is healthy", async () => {
+    const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
+    try {
+      const frame = await renderWithLimits(dashboard, renderOnce, captureCharFrame, { gpt: { sessionPct: 42, weeklyPct: 18 }, openrouter: { kind: "remaining", amount: 26.78 }, fetchedAt: now }, false)
+      expect(frame).not.toContain("⚠")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("a hot GPT session earns a chip with its reset countdown", async () => {
+    const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
+    try {
+      const frame = await renderWithLimits(dashboard, renderOnce, captureCharFrame, { gpt: { sessionPct: 92, sessionResetsAt: now + 2 * 1440 * 60_000 + 14 * 60 * 60_000 }, fetchedAt: now }, true)
+      expect(frame).toContain("⚠ GPT 92%")
+      // The countdown is hour-precision within the coarse fmtCountdown window.
+      expect(frame).toMatch(/resets 2d 1[34]h/)
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("the weekly window warns on its own", async () => {
+    const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
+    try {
+      dashboard.phaseStarted("implement")
+      setLimits(dashboard, { gpt: { sessionPct: 42, weeklyPct: 91 }, fetchedAt: now })
+      const frame = await waitForRenderedFrame(renderOnce, captureCharFrame, (f) => f.includes("wk 91%"))
+      expect(frame).toContain("⚠ GPT wk 91%")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("an auth problem surfaces instead of a silent meter", async () => {
+    const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
+    try {
+      dashboard.phaseStarted("implement")
+      setLimits(dashboard, { gptHint: "codex login", fetchedAt: now })
+      const frame = await waitForRenderedFrame(renderOnce, captureCharFrame, (f) => f.includes("codex login"))
+      expect(frame).toContain("⚠ GPT — codex login")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("an OpenRouter balance below the threshold earns a chip", async () => {
+    const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
+    try {
+      dashboard.phaseStarted("implement")
+      setLimits(dashboard, { openrouter: { kind: "remaining", amount: 7.4 }, fetchedAt: now })
+      const frame = await waitForRenderedFrame(renderOnce, captureCharFrame, (f) => f.includes("left"))
+      expect(frame).toContain("⚠ OpenRouter $7.40 left")
+    } finally {
+      dashboard.stop()
+    }
+  })
+})
+
+describe("usage modal", () => {
+  test("[u] opens the meters, any key closes it", async () => {
+    const { dashboard, mockInput, renderOnce, captureCharFrame } = await createDashboard(120, 40)
+    try {
+      await renderOnce()
+      mockInput.pressKey("u")
+      await renderOnce()
+      const frame = captureCharFrame()
+      expect(frame).toContain("usage")
+      expect(frame).toContain("not configured")
+      expect(frame).toContain("updated")
+
+      mockInput.pressKey("escape")
+      await renderOnce()
+      expect(captureCharFrame()).not.toContain("esc close")
+    } finally {
+      dashboard.stop()
+    }
+  })
+
+  test("configured meters render their detail", async () => {
+    const { dashboard, mockInput, renderOnce, captureCharFrame } = await createDashboard(160, 40)
+    const now = Date.now()
+      ;(dashboard as unknown as { limits: LimitsSnapshot }).limits = {
+      gpt: { sessionPct: 42, sessionResetsAt: now + 130 * 60_000, weeklyPct: 18 },
+      openrouter: { kind: "remaining", amount: 12.34 },
+      fetchedAt: now,
+    }
+    try {
+      mockInput.pressKey("u")
+      await renderOnce()
+      const frame = captureCharFrame()
+      expect(frame).toContain("42%")
+      expect(frame).toContain("wk 18%")
+      expect(frame).toContain("OpenRouter $12.34 left")
+      expect(frame).toContain("updated")
     } finally {
       dashboard.stop()
     }

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -104,19 +104,24 @@ describe("run dashboard defaults", () => {
     expect([live, historical]).not.toContain("logs")
   })
 
-  test("brands the header with the running version and keeps it inside a narrow panel", async () => {
+  test("brands the footer's border with the running version and shrinks to the wordmark when narrow", async () => {
+    const fullTitle = `◆ convoy ${shortVersion()}`
     const wide = await createDashboard(120, 40)
-    const narrow = await createDashboard(60, 40)
+    // Just under the width the full border title needs, so the footer falls
+    // back to the bare wordmark regardless of the build's version string.
+    const narrow = await createDashboard(displayWidth(fullTitle) + 4, 40)
     try {
       await wide.renderOnce()
-      expect(wide.captureCharFrame()).toContain(`◆ convoy ${shortVersion()}`)
+      const wideLine = lineContaining(wide.captureCharFrame(), fullTitle).trim()
+      // The title rides the footer panel's top border (rounded corners), not
+      // a content row.
+      expect(wideLine.startsWith("╭")).toBe(true)
+      expect(wideLine).toContain("─")
 
-      // The complete title and the panel's closing border remain visible at the
-      // narrow width instead of the title being clipped by the totals column.
       await narrow.renderOnce()
-      const line = lineContaining(narrow.captureCharFrame(), `◆ convoy ${shortVersion()}`)
-      expect(displayWidth(line)).toBeLessThanOrEqual(60)
-      expect(line.match(/│/g)?.length).toBe(2)
+      const narrowFrame = narrow.captureCharFrame()
+      expect(narrowFrame).toContain("◆ convoy")
+      expect(narrowFrame).not.toContain(shortVersion())
     } finally {
       wide.dashboard.stop()
       narrow.dashboard.stop()

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -1045,7 +1045,7 @@ describe("header limits row", () => {
   test("wide row shows the bar, reset countdown, weekly percent, and credits", () => {
     const row = text(full, 100)
 
-    expect(row).toContain("GPT ")
+    expect(row).toContain("OpenAI ")
     expect(row).toContain("█")
     expect(row).toContain("42%")
     expect(row).toContain("resets 2h 10m")
@@ -1076,7 +1076,7 @@ describe("header limits row", () => {
   test("auth problems surface a dim hint instead of a meter", () => {
     const row = text({ gptHint: "codex login", fetchedAt: now }, 80)
 
-    expect(row).toContain("GPT — codex login")
+    expect(row).toContain("OpenAI — codex login")
     expect(row).not.toContain("█")
   })
 
@@ -1414,7 +1414,7 @@ describe("header limit chips", () => {
     const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
     try {
       const frame = await renderWithLimits(dashboard, renderOnce, captureCharFrame, { gpt: { sessionPct: 92, sessionResetsAt: now + 2 * 1440 * 60_000 + 14 * 60 * 60_000 }, fetchedAt: now }, true)
-      expect(frame).toContain("⚠ GPT 92%")
+      expect(frame).toContain("⚠ OpenAI 92%")
       // The countdown is hour-precision within the coarse fmtCountdown window.
       expect(frame).toMatch(/resets 2d 1[34]h/)
     } finally {
@@ -1428,7 +1428,7 @@ describe("header limit chips", () => {
       dashboard.phaseStarted("implement")
       setLimits(dashboard, { gpt: { sessionPct: 42, weeklyPct: 91 }, fetchedAt: now })
       const frame = await waitForRenderedFrame(renderOnce, captureCharFrame, (f) => f.includes("wk 91%"))
-      expect(frame).toContain("⚠ GPT wk 91%")
+      expect(frame).toContain("⚠ OpenAI wk 91%")
     } finally {
       dashboard.stop()
     }
@@ -1440,7 +1440,7 @@ describe("header limit chips", () => {
       dashboard.phaseStarted("implement")
       setLimits(dashboard, { gptHint: "codex login", fetchedAt: now })
       const frame = await waitForRenderedFrame(renderOnce, captureCharFrame, (f) => f.includes("codex login"))
-      expect(frame).toContain("⚠ GPT — codex login")
+      expect(frame).toContain("⚠ OpenAI — codex login")
     } finally {
       dashboard.stop()
     }


### PR DESCRIPTION
## Summary

A pass over the TUI's chrome: the run dashboard header, the pipeline-picker sidebar, and the runs browser now each lead with state and let the subscription meters live where they earn their space.

### 1. Run dashboard header (commits 1–2)
- `◆ convoy` + version move from the header's pinned title segments to the **footer panel's border title**, right-aligned — the header row keeps ~30 columns for live state.
- The header is once again a single row: run state on the left (`running` / `pausing · N active` / `paused · p resume` / `✓ run completed` / `✗ run failed`), totals on the right (elapsed, cost, tokens). The clock-of-day column is gone.
- A **second header row appears only conditionally**: goal-loop progress (`goal 90 · iter 2/4 · 84 → …`) or a meter hot enough to interrupt — GPT/OpenAI session or weekly ≥85%, OpenRouter under $10, or an auth problem — as compact amber chips. `[u]` opens the full meters in a modal.
- Clicks on the step/todos/footer panels no longer open the session accidentally; `[o]` and the palette remain.
- The "select a child for session" footer prefix is gone.
- Header height is dynamic (3 base, 4 with a second row), so non-goal pipelines no longer show an empty stripe.
- GPT meter is now labeled **OpenAI** everywhere (dashboard chips, `[u]` modal, launcher, runs browser helpers).

### 2. Pipeline-picker (launcher) sidebar (commits 3–4)
- The setup header drops its meter row; the GPT/OpenRouter meters live in a compact ` usage ` panel pinned to the bottom of the ` pipelines ` sidebar, which grows to absorb the space.
- The panel is flush against the footer (no dead stripe), hides on compact/short/review screens, and orders **OpenRouter** (wallet) above **OpenAI** with a compact 4-cell gauge.
- The pipelines panel's border stays dimmed like every other container — the selected pipeline's row carries the focus marker instead.

### 3. Runs browser (commit 5)
- Header meter row removed entirely; branding moves to the header's border title, matching the launcher.
- A narrow-terminal mode (≤84 cols) stacks the run list above the details panel instead of squeezing them side by side.

## Why now
The header competed for the same columns as goal-loop state, and the meter row rendered an empty `…` in non-goal runs. Meters are detail — they belong on demand (`[u]`) or as an interruption only when a run is about to stall.

## Testing
- `bun test`: **2047 pass, 0 fail** (5 new TUI/launcher/runs-browser tests, existing expectation updates).
- `bunx tsc --noEmit` clean.
- Test harness now stubs the limits fetcher (`setLimitsFetcherForTests`) so the developer's real ChatGPT/OpenRouter accounts never leak into test frames.