### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "convoy",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bumps `package.json` to `0.7.0`. The release workflow verifies the pushed tag matches this version, so this has to land on `main` before `v0.7.0` is tagged.

**Minor rather than patch:** since `v0.6.0` the TUI grew a persistent goal-loop dashboard, pipelines and reports changed shape, and several defaults around prompts, branch naming, and built-in workflows moved.

## What's in it

**Goal loops and quality scoring** — [#60](https://github.com/Inakitajes/convoy/pull/60), [#64](https://github.com/Inakitajes/convoy/pull/64), [#74](https://github.com/Inakitajes/convoy/pull/74). Implementations can iterate against a rubric until they hit a score goal. Goal loops now live in a persistent TUI, and built-in scoring steps receive the branch's historical PRD.

**PRD history** — [#72](https://github.com/Inakitajes/convoy/pull/72), [#71](https://github.com/Inakitajes/convoy/pull/71). Per-project PRDs persist across runs; the launcher can preview the branch's historical PRD before confirming. Worktree branches are named from the PRD, with DeepSeek as the default namer.

**Reports and review** — [#73](https://github.com/Inakitajes/convoy/pull/73), [#70](https://github.com/Inakitajes/convoy/pull/70), [#66](https://github.com/Inakitajes/convoy/pull/66). Phase reports persist through a tool instead of brittle extraction; review steps get reliable scope and bash-policy checks.

**Pipelines** — [#61](https://github.com/Inakitajes/convoy/pull/61), [#69](https://github.com/Inakitajes/convoy/pull/69). Built-ins are consolidated around the real workflow, and each pipeline can ship default and suggested prompts.

**Runner** — [#65](https://github.com/Inakitajes/convoy/pull/65), [#63](https://github.com/Inakitajes/convoy/pull/63), [#62](https://github.com/Inakitajes/convoy/pull/62). Retry a run from step 0 with its original config; abort OpenCode phases that loop the same tool; optional Herdr pane support.

**TUI** — [#75](https://github.com/Inakitajes/convoy/pull/75), [#68](https://github.com/Inakitajes/convoy/pull/68), [#67](https://github.com/Inakitajes/convoy/pull/67). Decluttered run header, launcher sidebar, and runs browser; the launcher stacks on narrow terminals; designed border colors no longer follow the reported background.

**Local builds** now inject a `-local+<short-commit>` version so a `make install` binary never reads as the release that shares its number.

## After merge

Push the tag to publish. `.github/workflows/release.yml` runs on `v*` tags: it verifies, builds the four binaries, smoke-tests Linux and Darwin ARM64, and publishes the GitHub Release with `SHA256SUMS`.

```bash
git checkout main && git pull
git tag v0.7.0
git push origin v0.7.0
```

There is also `bun run scripts/release.ts minor` / `make release BUMP=minor`, but that path expects to bump, commit, tag, and push from a clean `main` in one shot — so it is the wrong tool once this PR exists.

## Verification

Nothing else changed in this commit. CI on the PR is the check; the release workflow builds from the tag.