### PR TITLE
feat(gateway): add openrouter nitro model routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,11 +771,14 @@ Convoy can change how every OpenCode model is reached without rewriting a pipeli
 ```sh
 convoy "Implement the feature" --gateway direct
 convoy "Implement the feature" --gateway openrouter
+convoy "Implement the feature" --gateway nitro
 convoy "Implement the feature" --gateway vercel
 convoy "Implement the feature" --gateway configured
 ```
 
 `configured` (the default) preserves model IDs literally. `direct` uses the model owner's provider; `openrouter` and `vercel` wrap the logical provider/model. Claude Code steps are never rerouted. A `--model` selects the logical model first, then the gateway is applied.
+
+`nitro` is OpenRouter with the `:nitro` routing suffix appended to every OpenCode model — equivalent to asking OpenRouter to sort providers by **throughput** instead of price. The wrap is identical to `openrouter` (same aliases and safety rules, same credential), so the physical IDs look like `openrouter/z-ai/glm-5.2:nitro`. Nitro often costs more than default OpenRouter routing because it does not load-balance to the cheapest provider; it is meant for long phases where speed matters more than a few cents. The `:nitro` suffix never becomes part of a model's logical identity, so overrides, vercel/direct conversion, and preflight keep working on the unsuffixed ID.
 
 Persist the choice globally in `~/.convoy/config.yaml` or per project in `.convoy/config.yaml` (CLI > project > global > configured):
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import { defaultMaxConcurrentAgents, parseModel, run } from "./runner"
 import { buildRunPlan, type BuildRunPlanInput } from "./run-plan"
 import { confirmRunPlan, renderRunPlan } from "./run-review"
 import { loadPrdHistoryPreview } from "./prd-history"
-import { isModelGateway, modelGatewayChoices, type ModelGateway } from "./model-routing"
+import { isModelGateway, modelGatewayChoices, modelGateways, type ModelGateway } from "./model-routing"
 import { browseRuns } from "./runs"
 import { deleteKeychainSecret, keychainAvailable, storeKeychainSecret } from "./secrets"
 import type { Pipeline, RunOptions, RunPlan } from "./types"
@@ -1089,7 +1089,7 @@ Flags:
                            consulted at decision points (before the first write, before declaring done,
                            and on demand) that reads the step's transcript but never runs tools
   --no-advisor             Run every step without an advisor, whatever the config sets
-  --gateway <configured|direct|openrouter|nitro|vercel> Route all OpenCode models through the selected gateway
+  --gateway <${modelGateways.join("|")}> Route all OpenCode models through the selected gateway
   --plan                   Print the complete resolved plan without creating or running anything
   --no-confirm             Show a compact plan and start without the interactive confirmation
   --tui                    Show visual phase progress (default in interactive terminals)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import { defaultMaxConcurrentAgents, parseModel, run } from "./runner"
 import { buildRunPlan, type BuildRunPlanInput } from "./run-plan"
 import { confirmRunPlan, renderRunPlan } from "./run-review"
 import { loadPrdHistoryPreview } from "./prd-history"
-import { isModelGateway, type ModelGateway } from "./model-routing"
+import { isModelGateway, modelGatewayChoices, type ModelGateway } from "./model-routing"
 import { browseRuns } from "./runs"
 import { deleteKeychainSecret, keychainAvailable, storeKeychainSecret } from "./secrets"
 import type { Pipeline, RunOptions, RunPlan } from "./types"
@@ -932,7 +932,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
         break
       case "--gateway": {
         const gateway = takeValue()
-        if (!isModelGateway(gateway)) throw new Error('--gateway must be "configured", "direct", "openrouter", or "vercel"')
+        if (!isModelGateway(gateway)) throw new Error(`--gateway must be ${modelGatewayChoices()}`)
         parsed.gateway = gateway
         break
       }
@@ -1089,7 +1089,7 @@ Flags:
                            consulted at decision points (before the first write, before declaring done,
                            and on demand) that reads the step's transcript but never runs tools
   --no-advisor             Run every step without an advisor, whatever the config sets
-  --gateway <configured|direct|openrouter|vercel> Route all OpenCode models through the selected gateway
+  --gateway <configured|direct|openrouter|nitro|vercel> Route all OpenCode models through the selected gateway
   --plan                   Print the complete resolved plan without creating or running anything
   --no-confirm             Show a compact plan and start without the interactive confirmation
   --tui                    Show visual phase progress (default in interactive terminals)

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -32,7 +32,7 @@ import {
   type PipelineSpec,
   type StepSpec,
 } from "./pipeline"
-import { gatewayLabel } from "./model-routing"
+import { gatewayLabel, type ModelGateway } from "./model-routing"
 import { claudeCodeModelAliases, normalizeStepRunnerModel, stepRunnerFor } from "./step-runners"
 import {
   displayWidth,
@@ -646,12 +646,13 @@ export class ConfigEditor {
         { value: "configured", label: gatewayLabel("configured"), hint: "preserve pipeline model IDs literally" },
         { value: "direct", label: gatewayLabel("direct"), hint: "use the model owner's provider" },
         { value: "openrouter", label: gatewayLabel("openrouter") },
+        { value: "nitro", label: gatewayLabel("nitro"), hint: "use OpenRouter's highest-throughput providers" },
         { value: "vercel", label: gatewayLabel("vercel") },
       ],
       commit: (value) => {
         config.modelRouting ??= { overrides: {} }
         if (value === "") delete config.modelRouting.gateway
-        else config.modelRouting.gateway = value as "configured" | "direct" | "openrouter" | "vercel"
+        else config.modelRouting.gateway = value as ModelGateway
         this.markDirty()
       },
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,7 @@ import { isStepRunnerId, normalizeStepRunnerModel, stepRunnerFor, type StepRunne
 import type { NotificationSettings } from "./notifications"
 import type { AdvisorAuditPolicy } from "./advisor-events"
 import type { AgentSpec, HookSet, HookSpec, HooksConfig, HookWhen, PermissionAdditions } from "./types"
-import { isModelGateway, logicalModel, type ModelRoutingConfig, type ModelRoutingOverrides } from "./model-routing"
+import { isModelGateway, logicalModel, modelGatewayChoices, modelGateways, type ModelRoutingConfig, type ModelRoutingOverrides } from "./model-routing"
 import { convoyHome, convoyRoot, globalConfigPath } from "./workspace"
 
 /**
@@ -253,10 +253,11 @@ version: 1
 
 # Route OpenCode models without rewriting pipelines. Project config overrides the global choice.
 # modelRouting:
-#   gateway: configured # configured | direct | openrouter | vercel
+#   gateway: configured # configured | direct | openrouter | nitro | vercel
 #   overrides:
 #     zai/glm-5.2:
 #       openrouter: openrouter/z-ai/glm-5.2
+#       nitro: openrouter/z-ai/glm-5.2:nitro # optional; openrouter fallback + :nitro is enough
 #       vercel: vercel/zai/glm-5.2
 
 defaults:
@@ -548,7 +549,7 @@ function validateModelRouting(v: Validator, raw: unknown): ModelRoutingConfig {
   v.knownKeys(record, "modelRouting", ["gateway", "overrides"])
   const routing: ModelRoutingConfig = { overrides: {} }
   if (record.gateway !== undefined) {
-    if (!isModelGateway(record.gateway)) v.fail("modelRouting.gateway", 'must be "configured", "direct", "openrouter", or "vercel"')
+    if (!isModelGateway(record.gateway)) v.fail("modelRouting.gateway", `must be ${modelGatewayChoices()}`)
     routing.gateway = record.gateway
   }
   if (record.overrides !== undefined) {
@@ -566,7 +567,7 @@ function validateModelRouting(v: Validator, raw: unknown): ModelRoutingConfig {
         v.fail(`modelRouting.overrides.${logical}`, error instanceof Error ? error.message : String(error))
       }
       const targets = v.record(rawTargets, `modelRouting.overrides.${logical}`)
-      v.knownKeys(targets, `modelRouting.overrides.${logical}`, ["configured", "direct", "openrouter", "vercel"])
+      v.knownKeys(targets, `modelRouting.overrides.${logical}`, [...modelGateways])
       const parsed: Partial<Record<import("./model-routing").ModelGateway, string>> = {}
       for (const [gateway, target] of Object.entries(targets)) {
         if (!isModelGateway(gateway)) continue

--- a/src/config.ts
+++ b/src/config.ts
@@ -253,7 +253,7 @@ version: 1
 
 # Route OpenCode models without rewriting pipelines. Project config overrides the global choice.
 # modelRouting:
-#   gateway: configured # configured | direct | openrouter | nitro | vercel
+#   gateway: configured # ${modelGateways.join(" | ")}
 #   overrides:
 #     zai/glm-5.2:
 #       openrouter: openrouter/z-ai/glm-5.2
@@ -554,6 +554,7 @@ function validateModelRouting(v: Validator, raw: unknown): ModelRoutingConfig {
   }
   if (record.overrides !== undefined) {
     const overrides = v.record(record.overrides, "modelRouting.overrides")
+    const seenCanonical = new Map<string, string>()
     for (const [logical, rawTargets] of Object.entries(overrides)) {
       if (!isValidModelString(logical)) v.fail(`modelRouting.overrides.${logical}`, "key must be a provider/model")
       // Keys name the canonical logical model, exactly as resolveModel recovers
@@ -566,6 +567,14 @@ function validateModelRouting(v: Validator, raw: unknown): ModelRoutingConfig {
       } catch (error) {
         v.fail(`modelRouting.overrides.${logical}`, error instanceof Error ? error.message : String(error))
       }
+      const previous = seenCanonical.get(canonical)
+      if (previous !== undefined) {
+        v.fail(
+          `modelRouting.overrides.${logical}`,
+          `canonicalizes to "${canonical}", same as "${previous}"; use one override key`,
+        )
+      }
+      seenCanonical.set(canonical, logical)
       const targets = v.record(rawTargets, `modelRouting.overrides.${logical}`)
       v.knownKeys(targets, `modelRouting.overrides.${logical}`, [...modelGateways])
       const parsed: Partial<Record<import("./model-routing").ModelGateway, string>> = {}

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -6,9 +6,10 @@ export type ModelGateway = (typeof modelGateways)[number]
 /** The OpenRouter routing variant Convoy requests as `:nitro` (provider.sort: "throughput"). */
 export const openRouterNitroSuffix = ":nitro"
 
-/** Removes exactly one trailing `:nitro` suffix, when present; otherwise a no-op. */
+/** Removes every trailing `:nitro` suffix; otherwise a no-op. */
 export function stripOpenRouterNitro(value: string): string {
-  return value.endsWith(openRouterNitroSuffix) ? value.slice(0, -openRouterNitroSuffix.length) : value
+  while (value.endsWith(openRouterNitroSuffix)) value = value.slice(0, -openRouterNitroSuffix.length)
+  return value
 }
 
 /** Ensures the value ends with exactly one trailing `:nitro` suffix. */
@@ -87,7 +88,7 @@ function isSafeModelPart(value: string) {
   return value.length > 0 && !/[\s/#\u0000-\u001f\u007f-\u009f]/u.test(value)
 }
 
-type RoutableGateway = "direct" | "openrouter" | "vercel" | "nitro"
+type RoutableGateway = Exclude<ModelGateway, "configured">
 
 export function resolveModel(configured: string, gateway: ModelGateway, overrides: ModelRoutingOverrides = {}): ResolvedModel {
   const configuredParts = splitModelVariant(configured)
@@ -108,14 +109,17 @@ export function resolveModel(configured: string, gateway: ModelGateway, override
     case "openrouter":
     case "vercel":
     case "nitro": {
-      const override = overrides[logical]?.[gateway]
+      const entry = overrides[logical]
+      const override = entry?.[gateway]
       if (override) {
-        physical = overrideFor(logical, gateway, override, logicalVariant)
-        variant ??= splitModelVariant(override).variant
-      } else if (gateway === "nitro" && overrides[logical]?.openrouter) {
+        const applied = overrideFor(logical, gateway, override, logicalVariant)
+        physical = applied.model
+        variant ??= applied.variant
+      } else if (gateway === "nitro" && entry?.openrouter) {
         // Fall back to the plain openrouter override, then apply `:nitro`.
-        physical = applyOpenRouterNitro(overrideFor(logical, "openrouter", overrides[logical]!.openrouter!, logicalVariant))
-        variant ??= splitModelVariant(overrides[logical]!.openrouter!).variant
+        const applied = overrideFor(logical, "openrouter", entry.openrouter, logicalVariant)
+        physical = applyOpenRouterNitro(applied.model)
+        variant ??= applied.variant
       } else {
         physical = autoWrap(gateway, configured, logical)
       }
@@ -144,12 +148,12 @@ export function resolveModel(configured: string, gateway: ModelGateway, override
  * configured logical model is still an error, and an override-only variant is
  * adopted when the configured model names none.
  */
-function overrideFor(logical: string, key: string, target: string, logicalVariant?: string): string {
+function overrideFor(logical: string, key: string, target: string, logicalVariant?: string): { model: string; variant?: string } {
   const parts = splitModelVariant(target)
   if (parts.variant && logicalVariant && parts.variant !== logicalVariant) {
     throw new Error(`modelRouting override for ${logical}.${key} must not replace variant #${logicalVariant}`)
   }
-  return parts.model
+  return parts
 }
 
 /**

--- a/src/model-routing.ts
+++ b/src/model-routing.ts
@@ -1,7 +1,29 @@
 import { splitModelVariant } from "./pipeline"
 
-export const modelGateways = ["configured", "direct", "openrouter", "vercel"] as const
+export const modelGateways = ["configured", "direct", "openrouter", "nitro", "vercel"] as const
 export type ModelGateway = (typeof modelGateways)[number]
+
+/** The OpenRouter routing variant Convoy requests as `:nitro` (provider.sort: "throughput"). */
+export const openRouterNitroSuffix = ":nitro"
+
+/** Removes exactly one trailing `:nitro` suffix, when present; otherwise a no-op. */
+export function stripOpenRouterNitro(value: string): string {
+  return value.endsWith(openRouterNitroSuffix) ? value.slice(0, -openRouterNitroSuffix.length) : value
+}
+
+/** Ensures the value ends with exactly one trailing `:nitro` suffix. */
+export function applyOpenRouterNitro(value: string): string {
+  return value.endsWith(openRouterNitroSuffix) ? value : `${value}${openRouterNitroSuffix}`
+}
+
+/**
+ * The accepted gateway values joined for human error messages, e.g.
+ * `"configured", "direct", "openrouter", "nitro", or "vercel"`. Derived from
+ * the union so a sixth gateway cannot drift into a stale handwritten copy.
+ */
+export function modelGatewayChoices(): string {
+  return modelGateways.map((gateway) => `"${gateway}"`).join(", ").replace(/, "([^"]+)"$/, ', or "$1"')
+}
 
 export type ModelRoutingOverrides = Record<string, Partial<Record<ModelGateway, string>>>
 
@@ -31,15 +53,17 @@ export function isModelGateway(value: unknown): value is ModelGateway {
   return typeof value === "string" && modelGateways.includes(value as ModelGateway)
 }
 
+const gatewayLabels: Record<ModelGateway, string> = {
+  configured: "As configured",
+  direct: "Direct",
+  openrouter: "OpenRouter",
+  nitro: "OpenRouter Nitro",
+  vercel: "Vercel AI Gateway",
+}
+
 /** Single display label shared by the launcher, config editor, review, and errors. */
 export function gatewayLabel(gateway: ModelGateway): string {
-  return gateway === "vercel"
-    ? "Vercel AI Gateway"
-    : gateway === "openrouter"
-      ? "OpenRouter"
-      : gateway === "direct"
-        ? "Direct"
-        : "As configured"
+  return gatewayLabels[gateway]
 }
 
 /** Recover the provider-owned model identity from a direct or gateway-wrapped OpenCode model. */
@@ -53,12 +77,17 @@ export function logicalModel(value: string): { model: string; variant?: string }
     throw new Error(`model must contain non-empty provider, model, and variant segments without whitespace or control characters, got "${value}"`)
   }
   parts[0] = directAliases[parts[0]!] ?? parts[0]!
-  return { model: parts.join("/"), ...(parsed.variant ? { variant: parsed.variant } : {}) }
+  // `:nitro` is an OpenRouter routing alias, not part of the model's identity:
+  // recover the unsuffixed logical model so override keys, vercel/direct
+  // conversion, and preflight all keep working on the plain ID.
+  return { model: stripOpenRouterNitro(parts.join("/")), ...(parsed.variant ? { variant: parsed.variant } : {}) }
 }
 
 function isSafeModelPart(value: string) {
   return value.length > 0 && !/[\s/#\u0000-\u001f\u007f-\u009f]/u.test(value)
 }
+
+type RoutableGateway = "direct" | "openrouter" | "vercel" | "nitro"
 
 export function resolveModel(configured: string, gateway: ModelGateway, overrides: ModelRoutingOverrides = {}): ResolvedModel {
   const configuredParts = splitModelVariant(configured)
@@ -68,27 +97,29 @@ export function resolveModel(configured: string, gateway: ModelGateway, override
   let variant = logicalVariant
 
   let physical: string
-  if (gateway === "configured") {
-    physical = configuredParts.model
-  } else {
-    const override = overrides[logical]?.[gateway]
-    if (override) {
-      const overrideParts = splitModelVariant(override)
-      if (overrideParts.variant && logicalVariant && overrideParts.variant !== logicalVariant) {
-        throw new Error(`modelRouting override for ${logical}.${gateway} must not replace variant #${logicalVariant}`)
+  // Exhaustive on the ModelGateway union: no trailing `else` can silently
+  // misroute a future gateway (the vercel-else trap the PRD forbids).
+  switch (gateway) {
+    case "configured":
+      // Literal: a configured model may already carry `:nitro`; do not add or strip.
+      physical = configuredParts.model
+      break
+    case "direct":
+    case "openrouter":
+    case "vercel":
+    case "nitro": {
+      const override = overrides[logical]?.[gateway]
+      if (override) {
+        physical = overrideFor(logical, gateway, override, logicalVariant)
+        variant ??= splitModelVariant(override).variant
+      } else if (gateway === "nitro" && overrides[logical]?.openrouter) {
+        // Fall back to the plain openrouter override, then apply `:nitro`.
+        physical = applyOpenRouterNitro(overrideFor(logical, "openrouter", overrides[logical]!.openrouter!, logicalVariant))
+        variant ??= splitModelVariant(overrides[logical]!.openrouter!).variant
+      } else {
+        physical = autoWrap(gateway, configured, logical)
       }
-      physical = overrideParts.model
-      // An override can select a provider-specific default variant when the
-      // configured logical model does not name one. A caller-selected variant
-      // still wins (and conflicting values above remain an error).
-      variant ??= overrideParts.variant
-    } else {
-      const [provider, ...model] = logical.split("/")
-      if (!provider || model.length === 0) throw unsafeConversion(configured, gateway)
-      if (!safelyRoutableProviders.has(provider)) throw unsafeConversion(configured, gateway)
-      if (gateway === "direct") physical = `${provider}/${model.join("/")}`
-      else if (gateway === "openrouter") physical = `openrouter/${openRouterAliases[provider] ?? provider}/${model.join("/")}`
-      else physical = `vercel/${provider}/${model.join("/")}`
+      break
     }
   }
 
@@ -104,6 +135,41 @@ export function resolveModel(configured: string, gateway: ModelGateway, override
     modelID,
     ...(variant ? { variant } : {}),
     target,
+  }
+}
+
+/**
+ * Applies an override target as-is (exactly like `openrouter:` / `vercel:`
+ * today): the physical model is literal, but a variant conflict with the
+ * configured logical model is still an error, and an override-only variant is
+ * adopted when the configured model names none.
+ */
+function overrideFor(logical: string, key: string, target: string, logicalVariant?: string): string {
+  const parts = splitModelVariant(target)
+  if (parts.variant && logicalVariant && parts.variant !== logicalVariant) {
+    throw new Error(`modelRouting override for ${logical}.${key} must not replace variant #${logicalVariant}`)
+  }
+  return parts.model
+}
+
+/**
+ * The no-override physical for a routable gateway. `logical` is already the
+ * unsuffixed logical model, so direct/vercel/openrouter never leak `:nitro`;
+ * only nitro re-appends the suffix.
+ */
+function autoWrap(gateway: RoutableGateway, configured: string, logical: string): string {
+  const [provider, ...model] = logical.split("/")
+  if (!provider || model.length === 0) throw unsafeConversion(configured, gateway)
+  if (!safelyRoutableProviders.has(provider)) throw unsafeConversion(configured, gateway)
+  switch (gateway) {
+    case "direct":
+      return `${provider}/${model.join("/")}`
+    case "openrouter":
+      return `openrouter/${openRouterAliases[provider] ?? provider}/${model.join("/")}`
+    case "nitro":
+      return applyOpenRouterNitro(`openrouter/${openRouterAliases[provider] ?? provider}/${model.join("/")}`)
+    case "vercel":
+      return `vercel/${provider}/${model.join("/")}`
   }
 }
 

--- a/src/preflight-validation.ts
+++ b/src/preflight-validation.ts
@@ -1,4 +1,4 @@
-import { gatewayLabel, type ResolvedModel } from "./model-routing"
+import { gatewayLabel, stripOpenRouterNitro, type ResolvedModel } from "./model-routing"
 import type { RunPlan } from "./types"
 
 type DiscoveredModel = { variants?: unknown }
@@ -49,8 +49,12 @@ export function validatePreflightTargets(
     }
 
     const models = isRecord(provider.models) ? provider.models : {}
-    if (!Object.hasOwn(models, target.modelID)) throw modelUnavailable(target)
-    const model = models[target.modelID] as DiscoveredModel | undefined
+    // `:nitro` is an OpenRouter routing alias, not a models.dev model: the
+    // catalog carries the unsuffixed ID. Strip for lookup only — the error and
+    // the frozen plan keep showing the full physical target.
+    const catalogID = stripOpenRouterNitro(target.modelID)
+    if (!Object.hasOwn(models, catalogID)) throw modelUnavailable(target)
+    const model = models[catalogID] as DiscoveredModel | undefined
     if (!model) throw modelUnavailable(target)
 
     if (target.variant) {

--- a/test/cli-regression.test.ts
+++ b/test/cli-regression.test.ts
@@ -8,6 +8,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:tes
 import { parseAndRun, parseArgs, parseCommand, resolveRunOptions } from "../src/cli"
 import { addWorktree } from "../src/git"
 import { stepNames } from "../src/pipeline"
+import type { AgentStep } from "../src/types"
 
 const dirs: string[] = []
 let savedHome: string | undefined
@@ -200,6 +201,25 @@ describe("CLI semantic regression coverage", () => {
     expect(cli.options.gateway).toBe("vercel")
     expect(cli.options.gatewayExplicit).toBe(true)
     expect(cli.options.plan?.modelRouting.gateway).toBe("vercel")
+  })
+
+  test("--gateway nitro routes the resolved plan through OpenRouter Nitro", async () => {
+    const dir = await projectWithQuickPipeline()
+
+    const nitro = await parseCommand(["--dir", dir, "--gateway", "nitro", "prompt"])
+    expect(nitro.type).toBe("run")
+    if (nitro.type !== "run") return
+    expect(nitro.options.gateway).toBe("nitro")
+    expect(nitro.options.plan?.modelRouting.gateway).toBe("nitro")
+
+    const routed = (nitro.options.plan?.pipeline.steps ?? []).filter(
+      (step): step is AgentStep => step.type === "agent" && Boolean(step.resolvedModel),
+    )
+    expect(routed.length).toBeGreaterThan(0)
+    for (const step of routed) {
+      expect(step.resolvedModel?.providerID).toBe("openrouter")
+      expect(step.resolvedModel?.target.includes(":nitro")).toBe(true)
+    }
   })
 
   test("resume restores the frozen pipeline, prompt, and routing metadata", async () => {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { goalModeFor, goalModeRejectionError, parseArgs, parseCommand, resolveRunOptions } from "../src/cli"
+import { modelGateways } from "../src/model-routing"
 import { builtInAgents, builtInPipelines, resolvePipeline } from "../src/pipeline"
 import type { Pipeline, RunPlan } from "../src/types"
 
@@ -290,7 +291,7 @@ describe("parseCommand", () => {
       expect(cmd.text).toContain("convoy [prompt]")
       expect(cmd.text).toContain("Commands:")
       expect(cmd.text).toContain("Flags:")
-      expect(cmd.text).toContain("--gateway <configured|direct|openrouter|nitro|vercel>")
+      expect(cmd.text).toContain(`--gateway <${modelGateways.join("|")}>`)
     }
   })
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -63,10 +63,12 @@ describe("parseArgs", () => {
   test("parses --gateway", () => {
     const result = parseArgs(["--gateway", "openrouter"])
     expect(result.gateway).toBe("openrouter")
+    expect(parseArgs(["--gateway", "nitro"]).gateway).toBe("nitro")
   })
 
   test("throws for invalid --gateway", () => {
     expect(() => parseArgs(["--gateway", "invalid"])).toThrow()
+    expect(() => parseArgs(["--gateway", "invalid"])).toThrow('"nitro"')
   })
 
   test("parses --goal with its iteration and plateau controls", () => {
@@ -213,6 +215,7 @@ describe("parseArgs", () => {
   test("parses --gateway with = syntax", () => {
     const result = parseArgs(["--gateway=direct"])
     expect(result.gateway).toBe("direct")
+    expect(parseArgs(["--gateway=nitro"]).gateway).toBe("nitro")
   })
 
   test("parses --only with = syntax", () => {
@@ -287,6 +290,7 @@ describe("parseCommand", () => {
       expect(cmd.text).toContain("convoy [prompt]")
       expect(cmd.text).toContain("Commands:")
       expect(cmd.text).toContain("Flags:")
+      expect(cmd.text).toContain("--gateway <configured|direct|openrouter|nitro|vercel>")
     }
   })
 

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -10,6 +10,7 @@ import {
   checkPipelineResolves,
   ConfigError,
   defaultConfigTemplate,
+  defaultConvoyConfig,
   ejectAgentPrompt,
   isValidModelString,
   loadConvoyConfig,
@@ -755,6 +756,53 @@ describe("model routing config", () => {
 
     // resolveModel looks up the canonical logical identity "zai/glm-5.2".
     expect(config.modelRouting?.overrides).toEqual({ "zai/glm-5.2": { vercel: "vercel/zai/glm-5.2" } })
+  })
+
+  test("parses the nitro gateway and a nitro override target", () => {
+    const config = parse(
+      [
+        "modelRouting:",
+        "  gateway: nitro",
+        "  overrides:",
+        "    zai/glm-5.2:",
+        "      openrouter: openrouter/z-ai/glm-5.2",
+        "      nitro: openrouter/z-ai/glm-5.2:nitro",
+      ].join("\n"),
+    )
+
+    expect(config.modelRouting?.gateway).toBe("nitro")
+    expect(config.modelRouting?.overrides["zai/glm-5.2"]).toEqual({
+      openrouter: "openrouter/z-ai/glm-5.2",
+      nitro: "openrouter/z-ai/glm-5.2:nitro",
+    })
+    expect(() => parse("modelRouting:\n  gateway: automatic")).toThrow("modelRouting.gateway")
+  })
+
+  test("an unknown override target key is dropped from the parsed routing", () => {
+    const config = parse("modelRouting:\n  overrides:\n    zai/glm-5.2:\n      bogus: whatever")
+    expect(config.modelRouting?.overrides["zai/glm-5.2"]).toEqual({})
+  })
+
+  test("override keys with a nitro suffix canonicalize to the logical model", () => {
+    const config = parse("modelRouting:\n  overrides:\n    openrouter/z-ai/glm-5.2:nitro:\n      openrouter: openrouter/z-ai/glm-5.2")
+
+    expect(config.modelRouting?.overrides).toEqual({ "zai/glm-5.2": { openrouter: "openrouter/z-ai/glm-5.2" } })
+  })
+
+  test("serializes a nitro gateway and override target", () => {
+    const config = parse(
+      "modelRouting:\n  gateway: nitro\n  overrides:\n    custom/private-model:\n      nitro: openrouter/acme/private:nitro",
+    )
+
+    const yaml = serializeConvoyConfig(config)
+    expect(yaml).toContain("gateway: nitro")
+    expect(yaml).toContain("nitro: openrouter/acme/private:nitro")
+    expect(parse(yaml).modelRouting).toEqual(config.modelRouting)
+  })
+
+  test("the init template documents nitro in the gateway comment", () => {
+    expect(defaultConvoyConfig).toContain("configured | direct | openrouter | nitro | vercel")
+    expect(defaultConvoyConfig).toContain("nitro: openrouter/z-ai/glm-5.2:nitro")
   })
 
   test("global and project overrides merge after canonicalization", () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test"
 
+import { modelGateways } from "../src/model-routing"
 import {
   buildAgentRegistry,
   checkPipelineResolves,
@@ -789,6 +790,21 @@ describe("model routing config", () => {
     expect(config.modelRouting?.overrides).toEqual({ "zai/glm-5.2": { openrouter: "openrouter/z-ai/glm-5.2" } })
   })
 
+  test("canonicalized override keys that collide fail instead of silently replacing", () => {
+    expect(() =>
+      parse(
+        [
+          "modelRouting:",
+          "  overrides:",
+          "    zai/glm-5.2:",
+          "      openrouter: openrouter/z-ai/glm-5.2",
+          "    zai/glm-5.2:nitro:",
+          "      vercel: vercel/zai/glm-5.2",
+        ].join("\n"),
+      ),
+    ).toThrow('modelRouting.overrides.zai/glm-5.2:nitro canonicalizes to "zai/glm-5.2", same as "zai/glm-5.2"')
+  })
+
   test("serializes a nitro gateway and override target", () => {
     const config = parse(
       "modelRouting:\n  gateway: nitro\n  overrides:\n    custom/private-model:\n      nitro: openrouter/acme/private:nitro",
@@ -801,7 +817,7 @@ describe("model routing config", () => {
   })
 
   test("the init template documents nitro in the gateway comment", () => {
-    expect(defaultConvoyConfig).toContain("configured | direct | openrouter | nitro | vercel")
+    expect(defaultConvoyConfig).toContain(modelGateways.join(" | "))
     expect(defaultConvoyConfig).toContain("nitro: openrouter/z-ai/glm-5.2:nitro")
   })
 

--- a/test/model-routing.test.ts
+++ b/test/model-routing.test.ts
@@ -148,6 +148,19 @@ describe("OpenRouter nitro gateway", () => {
     expect(logicalModel("zai/glm-5.2:nitro").model).toBe("zai/glm-5.2")
   })
 
+  test("repeated :nitro suffixes strip from logical identity and still hit overrides", () => {
+    expect(logicalModel("openrouter/z-ai/glm-5.2:nitro:nitro").model).toBe("zai/glm-5.2")
+    expect(stripOpenRouterNitro("openrouter/z-ai/glm-5.2:nitro:nitro")).toBe("openrouter/z-ai/glm-5.2")
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro:nitro", "nitro")).toMatchObject({
+      logical: "zai/glm-5.2",
+      providerID: "openrouter",
+      modelID: "z-ai/glm-5.2:nitro",
+      target: "openrouter/z-ai/glm-5.2:nitro",
+    })
+    const overrides = { "zai/glm-5.2": { nitro: "openrouter/acme/private:nitro" } }
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro:nitro", "nitro", overrides).target).toBe("openrouter/acme/private:nitro")
+  })
+
   test("nitro falls back to the openrouter override and applies the suffix", () => {
     const overrides = { "custom/private-model": { openrouter: "openrouter/acme/private" } }
     expect(resolveModel("custom/private-model", "nitro", overrides).target).toBe("openrouter/acme/private:nitro")

--- a/test/model-routing.test.ts
+++ b/test/model-routing.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test"
 
-import { logicalModel, resolveModel } from "../src/model-routing"
+import {
+  applyOpenRouterNitro,
+  gatewayLabel,
+  isModelGateway,
+  logicalModel,
+  modelGateways,
+  resolveModel,
+  stripOpenRouterNitro,
+} from "../src/model-routing"
 
 describe("model gateway routing", () => {
   test("routes OpenAI and Anthropic through every gateway", () => {
@@ -28,6 +36,12 @@ describe("model gateway routing", () => {
       modelID: "openai/gpt/reasoning/preview",
       target: "vercel/openai/gpt/reasoning/preview#high",
     })
+    expect(resolveModel("openai/gpt/reasoning/preview#high", "nitro")).toMatchObject({
+      logical: "openai/gpt/reasoning/preview#high",
+      providerID: "openrouter",
+      modelID: "openai/gpt/reasoning/preview:nitro",
+      target: "openrouter/openai/gpt/reasoning/preview:nitro#high",
+    })
   })
 
   test("normalizes zai and z-ai while preserving the logical identity", () => {
@@ -40,6 +54,12 @@ describe("model gateway routing", () => {
   test("routes Moonshot Kimi through gateways without an override", () => {
     expect(resolveModel("moonshotai/kimi-k3", "openrouter").target).toBe("openrouter/moonshotai/kimi-k3")
     expect(resolveModel("openrouter/moonshotai/kimi-k3", "vercel").target).toBe("vercel/moonshotai/kimi-k3")
+    expect(resolveModel("moonshotai/kimi-k3", "nitro").target).toBe("openrouter/moonshotai/kimi-k3:nitro")
+  })
+
+  test("routes xAI Grok through nitro with the dashed alias", () => {
+    expect(resolveModel("xai/grok-4.5", "nitro").target).toBe("openrouter/x-ai/grok-4.5:nitro")
+    expect(resolveModel("openrouter/x-ai/grok-4.5", "nitro").target).toBe("openrouter/x-ai/grok-4.5:nitro")
   })
 
   test("configured remains literal", () => {
@@ -50,6 +70,10 @@ describe("model gateway routing", () => {
       target: "openrouter/z-ai/glm-5.2#high",
     })
     expect(resolveModel("custom/private/model#v2", "configured").target).toBe("custom/private/model#v2")
+  })
+
+  test("configured does not add :nitro to a clean OpenRouter ID", () => {
+    expect(resolveModel("openrouter/z-ai/glm-5.2", "configured").modelID).toBe("z-ai/glm-5.2")
   })
 
   test("explicit overrides enable otherwise unsafe custom routes", () => {
@@ -73,5 +97,82 @@ describe("model gateway routing", () => {
   test("rejects whitespace and terminal controls in model references", () => {
     expect(() => resolveModel("openai/gpt-5.6\nforged", "vercel")).toThrow("without whitespace or control characters")
     expect(() => resolveModel("openai/gpt-5.6#high\u001b[2J", "vercel")).toThrow("without whitespace or control characters")
+    expect(() => resolveModel("openai/gpt-5.6:nitro\nforged", "nitro")).toThrow("without whitespace or control characters")
+  })
+})
+
+describe("OpenRouter nitro gateway", () => {
+  test("applies :nitro to every routable model", () => {
+    expect(resolveModel("openai/gpt-5.6-terra#xhigh", "nitro").target).toBe("openrouter/openai/gpt-5.6-terra:nitro#xhigh")
+    expect(resolveModel("openai/gpt-5.6-terra#xhigh", "nitro").providerID).toBe("openrouter")
+    expect(resolveModel("openai/gpt-5.6-terra#xhigh", "nitro").modelID).toBe("openai/gpt-5.6-terra:nitro")
+    expect(resolveModel("anthropic/claude-opus-5", "nitro").target).toBe("openrouter/anthropic/claude-opus-5:nitro")
+    expect(resolveModel("zai/glm-5.2", "nitro").target).toBe("openrouter/z-ai/glm-5.2:nitro")
+    expect(resolveModel("openrouter/z-ai/glm-5.2", "nitro").target).toBe("openrouter/z-ai/glm-5.2:nitro")
+  })
+
+  test("unwraps a vercel-configured model and routes it through nitro", () => {
+    expect(resolveModel("vercel/openai/gpt-5.6-sol#high", "nitro")).toMatchObject({
+      logical: "openai/gpt-5.6-sol#high",
+      providerID: "openrouter",
+      modelID: "openai/gpt-5.6-sol:nitro",
+      variant: "high",
+      target: "openrouter/openai/gpt-5.6-sol:nitro#high",
+    })
+  })
+
+  test("configured with an existing :nitro keeps it", () => {
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro#high", "configured").target).toBe("openrouter/z-ai/glm-5.2:nitro#high")
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro#high", "configured").modelID).toBe("z-ai/glm-5.2:nitro")
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro#high", "configured").logical).toBe("zai/glm-5.2#high")
+  })
+
+  test("applying nitro to a pre-suffixed model is idempotent", () => {
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro", "nitro").target).toBe("openrouter/z-ai/glm-5.2:nitro")
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro#xhigh", "nitro")).toMatchObject({
+      providerID: "openrouter",
+      modelID: "z-ai/glm-5.2:nitro",
+      variant: "xhigh",
+      target: "openrouter/z-ai/glm-5.2:nitro#xhigh",
+    })
+  })
+
+  test("openrouter, direct, and vercel strip a pre-existing :nitro", () => {
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro", "openrouter").target).toBe("openrouter/z-ai/glm-5.2")
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro", "direct").target).toBe("zai/glm-5.2")
+    expect(resolveModel("openrouter/z-ai/glm-5.2:nitro", "vercel").target).toBe("vercel/zai/glm-5.2")
+  })
+
+  test("logical identity never retains :nitro", () => {
+    expect(logicalModel("openrouter/z-ai/glm-5.2:nitro").model).toBe("zai/glm-5.2")
+    expect(logicalModel("zai/glm-5.2:nitro").model).toBe("zai/glm-5.2")
+  })
+
+  test("nitro falls back to the openrouter override and applies the suffix", () => {
+    const overrides = { "custom/private-model": { openrouter: "openrouter/acme/private" } }
+    expect(resolveModel("custom/private-model", "nitro", overrides).target).toBe("openrouter/acme/private:nitro")
+  })
+
+  test("an explicit nitro override is used as-is", () => {
+    const suffixed = { "custom/private-model": { nitro: "openrouter/acme/private:nitro" } }
+    expect(resolveModel("custom/private-model", "nitro", suffixed).target).toBe("openrouter/acme/private:nitro")
+    // An explicit override without :nitro is also literal (overrides never auto-append).
+    const plain = { "custom/private-model": { nitro: "openrouter/acme/private" } }
+    expect(resolveModel("custom/private-model", "nitro", plain).target).toBe("openrouter/acme/private")
+  })
+
+  test("unsafe namespaces still require an override under nitro", () => {
+    expect(() => resolveModel("custom/private-model", "nitro")).toThrow("modelRouting.overrides")
+  })
+
+  test("markers and helpers match the nitro contract", () => {
+    expect(modelGateways).toEqual(["configured", "direct", "openrouter", "nitro", "vercel"])
+    expect(gatewayLabel("nitro")).toBe("OpenRouter Nitro")
+    expect(isModelGateway("nitro")).toBe(true)
+    expect(isModelGateway("openrouter-nitro")).toBe(false)
+    expect(applyOpenRouterNitro("openrouter/x:nitro")).toBe("openrouter/x:nitro")
+    expect(applyOpenRouterNitro("openrouter/x")).toBe("openrouter/x:nitro")
+    expect(stripOpenRouterNitro("openrouter/x:nitro")).toBe("openrouter/x")
+    expect(stripOpenRouterNitro("openrouter/x")).toBe("openrouter/x")
   })
 })

--- a/test/preflight.test.ts
+++ b/test/preflight.test.ts
@@ -59,6 +59,38 @@ function directOpenAIPlan(): RunPlan {
   return result
 }
 
+function nitroPlan(): RunPlan {
+  const result = plan()
+  const step = result.pipeline.steps[0]!
+  if (step.type !== "agent") throw new Error("expected agent step")
+  step.model = "openrouter/z-ai/glm-5.2:nitro"
+  step.variant = "xhigh"
+  step.resolvedModel = {
+    configured: "zai/glm-5.2#xhigh",
+    logical: "zai/glm-5.2#xhigh",
+    gateway: "nitro",
+    providerID: "openrouter",
+    modelID: "z-ai/glm-5.2:nitro",
+    variant: "xhigh",
+    target: "openrouter/z-ai/glm-5.2:nitro#xhigh",
+  }
+  result.modelRouting.gateway = "nitro"
+  return result
+}
+
+function nitroCatalog(input: { hasUnsuffixed?: boolean; onlySuffixed?: boolean; variants?: string[]; connected?: boolean } = {}) {
+  const models: Record<string, { variants: Record<string, unknown> }> = {}
+  if (input.hasUnsuffixed !== false) models["z-ai/glm-5.2"] = { variants: Object.fromEntries((input.variants ?? ["xhigh"]).map((variant) => [variant, {}])) }
+  if (input.onlySuffixed) {
+    delete models["z-ai/glm-5.2"]
+    models["z-ai/glm-5.2:nitro"] = { variants: Object.fromEntries((input.variants ?? ["xhigh"]).map((variant) => [variant, {}])) }
+  }
+  return {
+    all: [{ id: "openrouter", models }],
+    connected: input.connected === false ? [] : ["openrouter"],
+  }
+}
+
 function catalog(input: { providerID?: string; connected?: boolean; modelID?: string; variants?: string[] } = {}) {
   const providerID = input.providerID ?? "vercel"
   const modelID = input.modelID ?? "openai/gpt-5.6-sol"
@@ -240,6 +272,70 @@ describe("OpenCode run-plan preflight", () => {
     expect(() => validatePreflightTargets(targets, withoutTarget)).toThrow("Model unavailable through Vercel AI Gateway")
     expect(() => validatePreflightTargets(targets, withoutTarget)).toThrow("logical: openai/gpt-5.6-sol")
     expect(() => validatePreflightTargets(targets, withoutTarget)).toThrow("target:  vercel/openai/gpt-5.6-sol")
+  })
+
+  test("nitro preflight looks up the unsuffixed catalog model", () => {
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), nitroCatalog())).not.toThrow()
+  })
+
+  test("nitro preflight fails when the unsuffixed catalog model is missing", () => {
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), nitroCatalog({ hasUnsuffixed: false }))).toThrow(
+      "Model unavailable through OpenRouter Nitro",
+    )
+  })
+
+  test("nitro preflight never looks up the suffixed catalog key", () => {
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), nitroCatalog({ onlySuffixed: true }))).toThrow(
+      "Model unavailable",
+    )
+  })
+
+  test("nitro failure reports the full suffixed physical target", () => {
+    const withoutTarget = nitroCatalog({ hasUnsuffixed: false })
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), withoutTarget)).toThrow(
+      "Model unavailable through OpenRouter Nitro",
+    )
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), withoutTarget)).toThrow("logical: zai/glm-5.2#xhigh")
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), withoutTarget)).toThrow("target:  openrouter/z-ai/glm-5.2:nitro#xhigh")
+  })
+
+  test("nitro variant checks run against the unsuffixed catalog entry", () => {
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), nitroCatalog({ variants: ["high"] }))).toThrow(
+      "Model unavailable",
+    )
+  })
+
+  test("missing openrouter credentials use the generic login hint, not the Vercel key", () => {
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), nitroCatalog({ connected: false }))).toThrow(
+      "Missing provider credentials: openrouter",
+    )
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), nitroCatalog({ connected: false }))).toThrow(
+      "opencode providers login",
+    )
+    expect(() => validatePreflightTargets(preflightTargets(nitroPlan()), nitroCatalog({ connected: false }))).not.toThrow(
+      "AI_GATEWAY_API_KEY",
+    )
+  })
+
+  test("a configured target with a :nitro modelID still preflights the unsuffixed catalog ID", () => {
+    const reviewed = nitroPlan()
+    const step = reviewed.pipeline.steps[0]!
+    if (step.type !== "agent") throw new Error("expected agent step")
+    step.resolvedModel = {
+      configured: "openrouter/z-ai/glm-5.2:nitro#xhigh",
+      logical: "zai/glm-5.2#xhigh",
+      gateway: "configured",
+      providerID: "openrouter",
+      modelID: "z-ai/glm-5.2:nitro",
+      variant: "xhigh",
+      target: "openrouter/z-ai/glm-5.2:nitro#xhigh",
+    }
+    reviewed.modelRouting.gateway = "configured"
+
+    expect(() => validatePreflightTargets(preflightTargets(reviewed), nitroCatalog())).not.toThrow()
+    expect(() => validatePreflightTargets(preflightTargets(reviewed), nitroCatalog({ hasUnsuffixed: false }))).toThrow(
+      "Model unavailable",
+    )
   })
 })
 

--- a/test/review-tui.test.ts
+++ b/test/review-tui.test.ts
@@ -118,6 +118,29 @@ describe("run review TUI", () => {
     expect(lines.some((line) => line.includes("runtime  smart permissions · 2 attachments · judge openrouter/openai/gpt-5.6-terra#xhigh"))).toBe(true)
   })
 
+  test("renders an OpenRouter Nitro gateway and the :nitro remap target", () => {
+    const plan = planWith(
+      [agentStep({ name: "implementer", stepName: "implementer", groupId: "g1", resolvedModel: resolved("zai/glm-5.2#xhigh", "openrouter/z-ai/glm-5.2:nitro#xhigh", "nitro") })],
+      { modelRouting: { gateway: "nitro" } },
+    )
+
+    const lines = plain(runReviewLines(plan, 100))
+
+    expect(lines.some((line) => line.includes("gateway  OpenRouter Nitro"))).toBe(true)
+    expect(lines.some((line) => line.includes("zai/glm-5.2#xhigh → openrouter/z-ai/glm-5.2:nitro#xhigh"))).toBe(true)
+  })
+
+  test("renders a nitro resume override banner with the full labels", () => {
+    const plan = planWith([], {
+      modelRouting: { gateway: "nitro" },
+      resume: { runID: "20260720-135802-5bbh", gatewayOverride: { original: "openrouter", pending: "nitro" } },
+    })
+
+    const lines = plain(runReviewLines(plan, 100))
+
+    expect(lines.some((line) => line.includes("resume override · original OpenRouter · pending phases OpenRouter Nitro"))).toBe(true)
+  })
+
   test("renders a historical PRD that this run will attach", () => {
     const plan = planWith([], {
       prdHistory: {

--- a/test/run-plan.test.ts
+++ b/test/run-plan.test.ts
@@ -104,7 +104,7 @@ test("routing preserves every built-in pipeline's execution structure", () => {
     })
     const originalAgents = original.steps.filter((step): step is AgentStep => step.type === "agent")
 
-    for (const gateway of ["configured", "direct", "openrouter", "vercel"] as const) {
+    for (const gateway of ["configured", "direct", "openrouter", "nitro", "vercel"] as const) {
       const routed = routePipeline(original, gateway, {})
       const routedAgents = routed.steps.filter((step): step is AgentStep => step.type === "agent")
 
@@ -120,15 +120,18 @@ test("routing preserves every built-in pipeline's execution structure", () => {
         }
         const configured = `${originalStep.model}${originalStep.variant ? `#${originalStep.variant}` : ""}`
         const recovered = logicalModel(configured)
-        const logical = `${recovered.model}${recovered.variant ? `#${recovered.variant}` : ""}`
+        const physicalModel = recovered.model.replace(/^zai\//, "z-ai/").replace(/^xai\//, "x-ai/")
+        const variant = recovered.variant ? `#${recovered.variant}` : ""
         const expectedTarget =
           gateway === "configured"
             ? configured
             : gateway === "direct"
-              ? logical
+              ? `${recovered.model}${variant}`
               : gateway === "openrouter"
-                ? `openrouter/${logical.replace(/^zai\//, "z-ai/").replace(/^xai\//, "x-ai/")}`
-                : `vercel/${logical}`
+                ? `openrouter/${physicalModel}${variant}`
+                : gateway === "nitro"
+                  ? `openrouter/${physicalModel}:nitro${variant}`
+                  : `vercel/${recovered.model}${variant}`
 
         expect(step.resolvedModel?.gateway).toBe(gateway)
         expect(step.resolvedModel?.target).toBe(expectedTarget)
@@ -247,6 +250,92 @@ test("the plan freezes the routed branch namer and marks an explicit resume gate
   expect(unchanged.target).not.toHaveProperty("branch")
 })
 
+test("resuming an openrouter run with --gateway nitro marks a nitro pending override", () => {
+  const options: RunOptions = {
+    prompt: "review the change",
+    prdHistory: true,
+    files: [],
+    onlySteps: [],
+    skipSteps: [],
+    resumeRunID: "20260720-135802-5bbh",
+    keepRunDir: true,
+    modelOverride: "",
+    advisorOverride: "",
+    advisorDisabled: false,
+    gateway: "nitro",
+    modelRoutingOverrides: {},
+    tui: false,
+    notify: false,
+    notifications: {},
+    humanReview: false,
+    baseRef: "main",
+    targetDir: "/repo",
+    worktree: false,
+    includeDirty: false,
+    yolo: false,
+    smart: false,
+    smartJudgeModel: "openai/gpt-5.6-sol",
+    pipeline: { name: "review", steps: [] },
+    agents: [],
+    permissions: { allow: [], deny: [] },
+    hooks: { pre: [], post: [], pipelines: {} },
+  }
+
+  const plan = buildRunPlan({ ...options, promptSource: "resume", resumeGateway: "openrouter" })
+  expect(plan.resume).toEqual({ runID: "20260720-135802-5bbh", gatewayOverride: { original: "openrouter", pending: "nitro" } })
+})
+
+test("nitro routes the smart judge and the goal-fix pipeline through the same gateway", () => {
+  const options: RunOptions = {
+    prompt: "score and fix",
+    prdHistory: true,
+    files: [],
+    onlySteps: [],
+    skipSteps: [],
+    resumeRunID: "",
+    keepRunDir: true,
+    modelOverride: "",
+    advisorOverride: "",
+    advisorDisabled: false,
+    gateway: "nitro",
+    modelRoutingOverrides: {},
+    tui: false,
+    notify: false,
+    notifications: {},
+    humanReview: false,
+    baseRef: "main",
+    targetDir: "/repo",
+    worktree: false,
+    includeDirty: false,
+    yolo: false,
+    smart: true,
+    smartJudgeModel: "anthropic/claude-haiku-4.5",
+    goal: 90,
+    goalMaxIterations: 2,
+    goalPlateau: 3,
+    goalFixPipeline: {
+      name: "goal-fix",
+      steps: [
+        { type: "agent", name: "fixer", stepName: "fixer", groupId: "g1", agentName: "goal-fixer", description: "Fix", model: "openai/gpt-5.6-sol", inputFiles: ["prd.md"], inputDiff: true, reportPath: "reports/fixer.md" },
+      ],
+    },
+    pipeline: {
+      name: "ship",
+      steps: [
+        { type: "agent", name: "implementer", stepName: "implementer", groupId: "g1", agentName: "implementer", description: "Implement", model: "openai/gpt-5.6-sol", inputFiles: ["prd.md"], inputDiff: false, reportPath: "reports/implementer.md" },
+      ],
+    },
+    agents: [],
+    permissions: { allow: [], deny: [] },
+    hooks: { pre: [], post: [], pipelines: {} },
+  }
+
+  const plan = buildRunPlan(options)
+  expect(plan.smartJudge?.model).toMatchObject({ gateway: "nitro", target: "openrouter/anthropic/claude-haiku-4.5:nitro" })
+  const fixer = plan.goal?.fixPipeline.steps[0]
+  expect(fixer?.type === "agent" && fixer.resolvedModel?.target).toBe("openrouter/openai/gpt-5.6-sol:nitro")
+})
+
 describe("advisor routing", () => {
   const step = (extra: Partial<AgentStep> = {}): AgentStep => ({
     type: "agent",
@@ -274,6 +363,18 @@ describe("advisor routing", () => {
       providerID: "openrouter",
     })
     expect(routed.advisor).toBe("openrouter/anthropic/claude-opus-5")
+    expect(routed.advisorVariant).toBe("high")
+  })
+
+  test("routes the advisor through nitro with the :nitro suffix", () => {
+    const routed = route(step({ advisor: "anthropic/claude-opus-5", advisorVariant: "high" }), "nitro")
+
+    expect(routed.resolvedAdvisor).toMatchObject({
+      logical: "anthropic/claude-opus-5#high",
+      target: "openrouter/anthropic/claude-opus-5:nitro#high",
+      providerID: "openrouter",
+    })
+    expect(routed.advisor).toBe("openrouter/anthropic/claude-opus-5:nitro")
     expect(routed.advisorVariant).toBe("high")
   })
 

--- a/test/run-review.test.ts
+++ b/test/run-review.test.ts
@@ -147,6 +147,35 @@ describe("renderRunPlan", () => {
     expect(output).toContain("pending phases: As configured")
   })
 
+  test("renders an OpenRouter Nitro gateway and the :nitro target", () => {
+    const plan = samplePlan()
+    plan.modelRouting.gateway = "nitro"
+    const step = plan.pipeline.steps[0]
+    if (step?.type === "agent") {
+      step.resolvedModel = {
+        configured: "zai/glm-5.2#xhigh",
+        logical: "zai/glm-5.2#xhigh",
+        gateway: "nitro",
+        providerID: "openrouter",
+        modelID: "z-ai/glm-5.2:nitro",
+        variant: "xhigh",
+        target: "openrouter/z-ai/glm-5.2:nitro#xhigh",
+      }
+    }
+    const output = renderRunPlan(plan, false)
+    expect(output).toContain("Gateway: OpenRouter Nitro")
+    expect(output).toContain("Logical: zai/glm-5.2#xhigh")
+    expect(output).toContain("Target:  openrouter/z-ai/glm-5.2:nitro#xhigh")
+  })
+
+  test("renders a nitro resume override copy", () => {
+    const plan = samplePlan()
+    plan.resume = { runID: "run-previous", gatewayOverride: { original: "openrouter", pending: "nitro" } }
+    const output = renderRunPlan(plan, false)
+    expect(output).toContain("original: OpenRouter")
+    expect(output).toContain("pending phases: OpenRouter Nitro")
+  })
+
   test("renders full prompt when option is set", () => {
     const plan = samplePlan()
     plan.prompt = { source: "file", text: "Line 1\nLine 2\nLine 3" }


### PR DESCRIPTION
- Route models through OpenRouter with the :nitro throughput variant
- Add gateway selection, labels, overrides, resume, and plan support
- Keep logical model identity unsuffixed for catalog and provider conversion
- Expand routing, CLI, configuration, preflight, and review test coverage