### PR TITLE
feat(tui): anchor the header clock bottom-left and dim the pipeline border

### DIFF
--- a/src/tui.ts
+++ b/src/tui.ts
@@ -2694,7 +2694,11 @@ export class TuiProgress implements ProgressUI {
     this.pipelineBox.width = compact ? "100%" : pipelineWidth
     this.pipelineBox.height = compact ? pipelineHeight : "100%"
     this.rightBox.height = compact ? "auto" : "100%"
-    this.pipelineBox.borderColor = this.contentFocused ? theme.borderDim : theme.accent
+    // The pipeline panel keeps its dim border even while it owns the keyboard:
+    // the accent highlight lives on the content panel alone, so the focus
+    // state reads as "reading" versus "piloting" rather than two competing
+    // bright frames.
+    this.pipelineBox.borderColor = theme.borderDim
     this.feedBox.borderColor = this.contentFocused ? theme.accent : theme.borderDim
 
     // Detail panel: either one concrete phase or an aggregate for a selected
@@ -2748,12 +2752,13 @@ export class TuiProgress implements ProgressUI {
   }
 
   /**
-   * The header is one status row: run state on the left, session-wide totals
-   * (elapsed, cost, tokens) on the right. A second row appears only when the
-   * run is a goal loop (target, iteration, score trajectory) or a meter is
-   * hot enough to be worth an interruption (see limitChips); the panel grows
-   * to fit it. Phase status lives in the pipeline panel and the full meters
-   * behind [u].
+   * The header is one status row — run state (a ◆ marks the live state) on
+   * the left, session-wide totals (cost, tokens) on the right — plus a second
+   * row that always leads with the elapsed clock in the bottom-left spot, the
+   * same place in every run. In goal mode the loop's readout (target,
+   * iteration, score trajectory) follows the clock on that row, with hot meter
+   * chips right-aligned. Phase status lives in the pipeline panel and the full
+   * meters behind [u].
    */
   private headerContent(now: number, width: number): StyledText[] {
     const usage = totalUsage(this.phases)
@@ -2774,9 +2779,10 @@ export class TuiProgress implements ProgressUI {
     }
     // Elapsed time freezes at the moment the run ended.
     const endAt = this.finished?.at ?? now
+    const clock = fg(theme.text)(formatElapsed(endAt - this.startedAt))
+    const goal = this.goalRowSegments()
+    const chips = this.limitChips(now)
     const totals: TextChunk[] = [
-      fg(theme.text)(formatElapsed(endAt - this.startedAt)),
-      fg(theme.faint)("  ·  "),
       fg(theme.green)(formatMoney(merged.cost + merged.advisorCost)),
       ...(merged.advisorAttempted
         ? [fg(theme.faint)(` (${formatMoney(merged.cost)} exec + ${formatMoney(merged.advisorCost)} adv)`)]
@@ -2793,27 +2799,25 @@ export class TuiProgress implements ProgressUI {
         ? [bold(fg(theme.yellow)("paused")), fg(theme.faint)(" · p resume")]
         : this.controlState === "pausing"
           ? [bold(fg(theme.cyan)("pausing")), fg(theme.faint)(` · ${this.controlActivePhases} active`)]
-          : [fg(theme.dim)("running")]
+          : [fg(theme.accent)("◆ "), fg(theme.dim)("running")]
     if (this.keepAwake?.status === "on" && !this.finished) status.push(fg(theme.faint)("  ·  "), fg(theme.cyan)("☕ awake"))
-    const row1 = padBetween(status, totals, width)
+    const rows = [padBetween(status, totals, width)]
 
-    const rows = [row1]
-    const goal = this.goalRowSegments()
-    const chips = this.limitChips(now)
-    if (goal.length > 0 || chips.length > 0) {
-      const sep = fg(theme.faint)("  ·  ")
-      const left: TextChunk[] = []
-      for (const segment of goal) {
-        if (left.length > 0) left.push(sep)
-        left.push(...segment.chunks)
-      }
-      const right: TextChunk[] = []
-      for (const segment of chips) {
-        if (right.length > 0) right.push(sep)
-        right.push(...segment.chunks)
-      }
-      rows.push(padBetween(left, right, width))
+    // The second row always leads with the clock in the bottom-left spot —
+    // the same place in every run, goal or not — followed by the loop's
+    // readout when there is one; hot meter chips right-align.
+    const sep = fg(theme.faint)("  ·  ")
+    const left: TextChunk[] = [clock]
+    for (const segment of goal) {
+      left.push(sep)
+      left.push(...segment.chunks)
     }
+    const right: TextChunk[] = []
+    for (const segment of chips) {
+      if (right.length > 0) right.push(sep)
+      right.push(...segment.chunks)
+    }
+    rows.push(padBetween(left, right, width))
     return rows
   }
 

--- a/test/tui.test.ts
+++ b/test/tui.test.ts
@@ -1185,6 +1185,13 @@ describe("goal loop header", () => {
       // The current iteration hasn't scored yet: the trajectory trails off.
       expect(frame).toContain("71 → …")
       expect(frame).not.toContain("run completed")
+      // The clock keeps its bottom-left spot in goal mode too; the loop's
+      // readout follows it on the same row.
+      const goalRow = lineContaining(frame, "goal 90")
+      expect(goalRow).toMatch(/\d+:\d{2} {2}· {2}goal 90/)
+      // The totals row carries cost and tokens, never the clock.
+      const statusRow = lineContaining(frame, "tokens")
+      expect(statusRow).not.toMatch(/\d+:\d{2}/)
     } finally {
       dashboard.stop()
     }
@@ -1351,13 +1358,13 @@ describe("goal loop header", () => {
       dashboard.phaseStarted("implement")
       await Bun.sleep(1100)
       await renderOnce()
-      // The header clock has advanced past zero.
-      expect(captureCharFrame()).not.toContain("·  0:00")
+      // The header clock (under the status word) has advanced past zero.
+      expect(captureCharFrame()).not.toContain("0:00")
 
       dashboard.resetPipeline([{ name: "fix", description: "" }], { runID: "run-2", targetDir: process.cwd(), runDir: "", pipeline: { name: "goal-fix", steps: [] } })
       await renderOnce()
       // The clock kept running from the loop's start rather than the new run's.
-      expect(captureCharFrame()).not.toContain("·  0:00")
+      expect(captureCharFrame()).not.toContain("0:00")
     } finally {
       dashboard.stop()
     }
@@ -1365,20 +1372,24 @@ describe("goal loop header", () => {
 })
 
 describe("dashboard header status row", () => {
-  test("a plain pipeline stays one row: status on the left, totals on the right", async () => {
+  test("a plain pipeline spreads two rows: ◆ running + totals, clock below", async () => {
     const { dashboard, renderOnce, captureCharFrame } = await createDashboard(120, 40)
     try {
       dashboard.phaseStarted("implement")
       await renderOnce()
       const frame = captureCharFrame()
       const beforePipeline = frame.slice(0, frame.indexOf("╭─ pipeline")).trim().split("\n")
-      // dir line + header top border + the single status row + bottom border.
-      expect(beforePipeline).toHaveLength(4)
+      // dir line + header top border + status row + clock row + bottom border.
+      expect(beforePipeline).toHaveLength(5)
       const statusRow = beforePipeline[2]!
-      expect(statusRow).toContain("running")
+      expect(statusRow).toContain("◆ running")
       expect(statusRow).toContain("tokens")
-      // No goal segments, no stray meter placeholders on the only row.
-      expect(statusRow).not.toContain("goal ")
+      // The clock moved under the status word; the totals keep cost + tokens.
+      const clockRow = beforePipeline[3]!
+      expect(clockRow).toMatch(/│ \d+:\d{2}/)
+      expect(clockRow).not.toContain("tokens")
+      // No goal segments, no stray meter placeholders on either row.
+      expect(beforePipeline.join("\n")).not.toContain("goal ")
       expect(statusRow).not.toContain("…")
     } finally {
       dashboard.stop()


### PR DESCRIPTION
## What

Two dashboard polish changes:

**Header layout — the clock always lives bottom-left.**
- The live state is now marked with a `◆` before `running`, so the left column is no longer a lone dim word in non-goal runs.
- The elapsed clock moved from the head of the right totals to the second row, directly under the status word — the same spot in **every** run, goal mode or not.
- In goal mode the loop's readout (`goal 90 · iter 2/4 · 71 → 84 · +13`) follows the clock on that row, so the session numbers stay distributed instead of piling onto the right.
- The right side of row 1 keeps cost and tokens only.

**Pipeline border stays dim.**
- The pipeline panel no longer takes the accent color when it owns the keyboard focus; it is always `borderDim`. The accent highlight lives on the content panel alone, so the focus state reads as *reading* vs *piloting* rather than two competing bright frames.

## Verification

- `bun run typecheck` — clean
- `bun test test/tui.test.ts` — 80 pass
- `bun test` (full suite) — 2094 pass, 0 fail
- Rendered previews in plain, live-goal, and finished-goal modes

Layout after the change:

```
plain:                          goal:
│ ◆ running   /bin/zsh.00 · ↑↓ tokens │ │ ◆ running   /bin/zsh.00 · ↑↓ tokens │
│ 0:00                          │ │ 0:00 · goal 90 · iter 2/4 …  │
```