### PR TITLE
feat(openspec): add openspec-aware scoring and opencode installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,41 @@ Verdicts map to the score: `ready` (≥90) · `ready-with-caveats` (75–89) · 
 
 **Calibrate before you trust it.** The first few scored runs will grade "differently" from your judgment. Run `review` against 2–3 PRs you already know are good or bad, compare your expectation to the score, and adjust `.convoy/quality-rubric.md` (weights, anchors, deductions) until the score matches your call. The rubric is a contract; like any contract, it is only useful once you agree with it — and since `ship` gates your pull requests on it, calibrate it before you rely on that gate.
 
+## OpenSpec-native reviews
+
+When a repository uses [OpenSpec](https://openspec.dev/), Convoy reads the change contract from the repository instead of a `.convoy/prd-history` entry:
+
+```
+openspec/
+  changes/<id>/        proposal.md · specs/** · design.md · tasks.md
+  archive/<id>/        ignored
+  specs/<capability>/  spec.md
+```
+
+The active change is resolved the same way by `/convoy` and the runtime:
+
+1. an explicit `--change <id>` (or `/convoy <id>`);
+2. exactly one non-archived change under `openspec/changes/`;
+3. multiple, and the branch name matches a change id (`feat/add-foo` ↔ `add-foo`);
+4. multiple, no branch match: compose the changes whose touched files appear in the diff;
+5. none: review falls back to today's behavior (default prompt + diff inference), and `implement` refuses with "no change; run /opsx:propose".
+
+When a change resolves, Convoy attaches the **spec bundle** — the current `openspec/specs/**` plus the change's proposal, design, and delta specs — in place of the oldest `.convoy/prd-history` entry (which stays untouched for non-OpenSpec repos, so nothing else changes). The `prd` (30%) and `scope` (10%) quality dimensions are graded against the change's **Requirements/Scenarios** instead of a diff-inferred brief. Convoy never writes the `openspec/` layout: `/opsx:propose` and archiving belong to OpenSpec itself.
+
+```bash
+# review the single active change on this branch
+convoy -p review
+
+# or pin one explicitly
+convoy --change add-login -p review
+
+# install the OpenCode integration: /spin, /convoy, and the convoy-run helper
+convoy opencode install
+convoy opencode status
+```
+
+`convoy opencode install` puts **/spin** (branch + worktree, then move this session there) and **/convoy [pipe]** (run the pipeline against the active change) next to `/opsx:propose`. They are Convoy's payload; `/opsx:propose` and archiving stay OpenSpec's, and the operator's global `/write-plan` and `/implement` stay the non-OpenSpec fallback.
+
 ## Goal mode
 
 Goal mode answers the "when is it enough?" question mechanically: **don't stop until the branch scores at or above a target**, or until the score stops improving.

--- a/opencode/bin/convoy-run
+++ b/opencode/bin/convoy-run
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# convoy-run — run a Convoy pipeline against the OpenSpec change active in the
+# current directory. Installed by `convoy opencode install` into OpenCode's
+# config dir and invoked by the /convoy slash command.
+#
+# Usage:
+#   convoy-run [pipeline]
+#
+# The pipeline defaults to "review". The active OpenSpec change resolves inside
+# Convoy (single non-archived change, branch match, or an explicit
+# CONVOY_CHANGE id, which is forwarded as --change and wins every heuristic).
+
+set -euo pipefail
+
+pipeline="${1:-${CONVOY_PIPELINE:-review}}"
+
+command -v convoy >/dev/null 2>&1 || {
+  echo "convoy is not on PATH; install it first (see the Convoy README)." >&2
+  exit 1
+}
+
+# No arrays: macOS ships bash 3.2, where expanding an empty array under `set -u`
+# is an unbound-variable error.
+
+if [[ ! -d openspec ]]; then
+  echo "no openspec/ in this directory; run /opsx:propose first." >&2
+  exit 1
+fi
+
+echo "running convoy -p $pipeline against the active OpenSpec change"
+if [[ -n "${CONVOY_CHANGE:-}" ]]; then
+  exec convoy -p "$pipeline" --no-tui --no-confirm --change "$CONVOY_CHANGE"
+fi
+exec convoy -p "$pipeline" --no-tui --no-confirm

--- a/opencode/bin/convoy-run.d.ts
+++ b/opencode/bin/convoy-run.d.ts
@@ -1,0 +1,4 @@
+// Types for the extensionless convoy-run payload. tsc resolves this sibling
+// `.d.ts`; Bun's `with { type: "text" }` import still loads the script itself.
+declare const text: string
+export default text

--- a/opencode/commands/convoy.md
+++ b/opencode/commands/convoy.md
@@ -1,0 +1,24 @@
+---
+description: Run a Convoy pipeline against the OpenSpec change active in this directory
+model: openrouter/deepseek/deepseek-v4-flash-0731#high
+tools: bash
+---
+
+Run Convoy on the OpenSpec change active in the current directory.
+
+1. Determine the active OpenSpec change under `openspec/changes/` (a single
+   non-archived change, the branch-named change, or `--change <id>` when the
+   operator said so). If there is no active change, tell the user to run
+   `/opsx:propose` first and stop.
+2. If the `convoy` binary is on PATH, run:
+
+   ```
+   convoy -p <pipeline-or-review> --no-tui --no-confirm
+   ```
+
+   without inventing a prompt: the spec bundle is the contract and an OpenSpec
+   change must already be attached. Prefer `-p review` for a report-only run
+   and `-p implement` for a writable run; the operator may name a custom
+   pipeline with `/convoy <pipeline-name>`.
+3. Report the pipeline's outcome and the run id back to the operator. Never
+   push, merge, or open pull requests — that stays a human decision.

--- a/opencode/commands/spin.md
+++ b/opencode/commands/spin.md
@@ -1,0 +1,26 @@
+---
+description: Create a branch and worktree for this change and move this session there
+model: openrouter/deepseek/deepseek-v4-flash-0731#high
+tools: bash
+---
+
+Create an isolated branch + worktree for the OpenSpec change the operator is
+about to work on, and move this session into it.
+
+1. Derive the branch name from the OpenSpec change the operator names
+   (`/spin add-login` → `feat/add-login`), or from the current intent when no
+   change exists yet (fall back to `feat/<what-the-operator-is-doing>`).
+2. With git, create the branch and worktree, e.g.:
+
+   ```
+   git worktree add -b feat/add-login ../add-login main
+   ```
+
+   Confirm the new branch is checked out with `git branch --show-current`.
+3. Move this session to the new worktree: point an attached/`opencode` session
+   at the new directory. If the TUI cannot follow the new working directory,
+   degrade to opening a new OpenCode session (a fork) rooted at the worktree
+   and tell the operator where the original session went.
+
+Keep the move local — creating the branch and worktree is the whole job. Do not
+push, merge, or run any pipeline afterwards unless the operator asks.

--- a/prompts/quality-score-report.md
+++ b/prompts/quality-score-report.md
@@ -6,7 +6,7 @@ This is an audit-only phase: do not modify the repository. You have bash, so ver
 
 ## Inputs
 
-1. `prd.md` — the task brief.
+1. The working contract the scorers graded against: the attached **OpenSpec change bundle** (proposal + current specs + delta specs, whose Requirements/Scenarios are the `prd` contract) when an active change resolved; otherwise `prd.md` — the task brief.
 2. Two or more independent `quality-scorer` reports (each scored the same artifact against the same rubric, with no shared context).
 3. The cumulative diff and the repository around it.
 4. `.convoy/quality-rubric.md`, when present, and `.convoy/quality-bar.md`, when present — the same contracts the scorers used.
@@ -19,7 +19,7 @@ This is an audit-only phase: do not modify the repository. You have bash, so ver
    - Deduplicate. Keep the severity the taxonomy implies, not the one the scorer happened to assign.
 2. **Verify the load-bearing claims yourself.**
    - Re-run only the load-bearing or missing checks (test, typecheck, lint, build) and record real results. The scope step's Checks section covers the baseline, so do not repeat the whole suite when the evidence is already there. This confirms the `operational` and `tests` evidence the scorers could only reason about statically.
-   - Spot-check the top `mustFix` findings against the actual code: does each one name a real problem at a real location?
+   - Spot-check the top `mustFix` findings against the actual code: does each one name a real problem at a real location? When an OpenSpec bundle is attached, check contested `prd` findings against the change's Requirements/Scenarios rather than a reading of the diff alone.
    - If a claim fails verification, adjust the affected dimension and say exactly why.
 3. **Recompute.** Recalculate the weighted total from the reconciled dimensions (weights: `prd` 30, `tests` 20, `security` 15, `maintainability` 15, `operational` 10, `scope` 10 — unless the project rubric overrides them), then apply each surviving finding's deduction to its own dimension (critical −15, major −8, minor −2, floor at 0). A change whose only findings are minor cannot end below 80.
 4. **Persist the final score.** Call `write_report` with the report narrative in `markdown`, and `dimensions`, `mustFix`, optional `gaps`, and optional `confidence`. Do not pass or manufacture `score` or `verdict`: Convoy derives them and writes the canonical fence.

--- a/prompts/quality-scorer.md
+++ b/prompts/quality-scorer.md
@@ -10,13 +10,15 @@ A reviewer is asked to find problems; an open-ended question gets an open-ended 
 
 ## Inputs
 
-1. `prd.md` — the task brief. This is the contract for *what* was asked.
+1. **The working contract**, in priority order:
+   - The attached **OpenSpec change bundle** — the current `openspec/specs/**` plus the active `openspec/changes/<id>/` proposal, design delta, and delta specs — when an active change resolved on this checkout. Its **Requirements/Scenarios** (cited by id) are the contract for `prd`, and its scope is the contract for `scope`.
+   - Otherwise `prd.md` — the task brief (and the checkout's historical PRD, when attached). This is the contract for *what* was asked.
 2. The attached reports from previous phases — evidence about what happened, never a substitute for inspecting the artifact yourself. The scope report's **Checks** section (when attached) is real execution evidence: the scope step ran the repo's checks once and recorded command, exit code, and output — grade `operational`/`tests` against it rather than rerunning anything.
 3. The cumulative diff against the base branch, plus the repository around it.
 4. `.convoy/quality-rubric.md`, when present in the repository — it **overrides** the rubric embedded in this prompt. If the file exists, use it as the authoritative rubric (same dimension names, same 0–100 anchors, same severity definitions; it may adjust weights or deduction values).
 5. `.convoy/quality-bar.md`, when present — a concrete comparison target (reference implementation, target test suite, latency/throughput target, or a known-good example). See "The bar rule" below.
 
-Inspect the actual artifact: the diff, the files it touches, the tests that exercise it. **Never grade a summary written by the builder.** If a claim in a previous report is load-bearing for a dimension, verify it against the artifact before scoring that dimension.
+Inspect the actual artifact: the diff, the files it touches, the tests that exercise it. **Never grade a summary written by the builder.** Never infer intent from the diff when an OpenSpec bundle or a PRD is attached — the contract names what was asked; the diff only answers whether it is met. If a claim in a previous report is load-bearing for a dimension, verify it against the artifact before scoring that dimension.
 
 ## The rubric (v1)
 
@@ -24,16 +26,16 @@ Score six dimensions from 0 to 100, then combine by weight. The anchors apply pe
 
 | Dimension | Weight | What it measures |
 |---|---|---|
-| `prd` | 30% | The PRD is implemented: every requirement, including edge cases and non-happy paths. |
-| `tests` | 20% | Behavioral coverage of the PRD's promises, not line coverage. |
+| `prd` | 30% | The working contract is implemented: with an OpenSpec change attached, every **Requirement/Scenario** (by id) in the change's spec, including edge cases and non-happy paths; otherwise every promise of the PRD. |
+| `tests` | 20% | Behavioral coverage of the working contract's promises, not line coverage. |
 | `security` | 15% | Security and robustness of the touched code only: input validation, authorization, injection, secrets, unsafe deserialization, error handling. |
 | `maintainability` | 15% | Pattern alignment with this repository (cite establishing evidence), complexity, duplication, naming, dead code, boundaries. |
 | `operational` | 10% | Build, typecheck, lint, and tests are green; i18n, migrations, no debug code, no accidental churn. |
-| `scope` | 10% | Only what was asked changed: no unrelated refactors, dependency churn, or file churn. |
+| `scope` | 10% | Only what the working contract asked changed: with an OpenSpec bundle, the change's declared scope; otherwise the PRD. No unrelated refactors, dependency churn, or file churn. |
 
 ### Anchored scales
 
-- **`prd`** — 100: every promise implemented, plausible edge cases handled. 90: every promise implemented, a minor edge case untested or unresolved. 75: one promise missing or a real edge case broken. 60: multiple promises missing or a core flow broken. Below 60: core promises unfulfilled.
+- **`prd`** — 100: every contract promise implemented (the change's Requirements/Scenarios when an OpenSpec bundle is attached; otherwise the PRD's), plausible edge cases handled. 90: every contract promise implemented, a minor edge case untested or unresolved. 75: one promise missing or a real edge case broken. 60: multiple promises missing or a core flow broken. Below 60: core promises unfulfilled.
 - **`tests`** — 100: every promise has a test that would fail if the implementation were reverted, edge cases included, suite green. 90: every promise protected, some edge cases uncovered. 75: a central promise unprotected, or tests that assert nothing (superficial). 60: most new behavior untested. Below 60: no meaningful tests for the change. Line coverage is reported as a datum, never as a score.
 - **`security`** — 100: nothing exploitable in the touched code. 90: minor hardening opportunities only. 75: a real but non-exploitable robustness gap. 60: an exploitable issue in the touched code. Below 60: a critical vulnerability.
 - **`maintainability`** — 100: the change looks like it was written by someone who already works in this repository. 90: minor cleanup only. 75: a pattern violation with establishing evidence, or avoidable complexity. 60: systemic misalignment. Below 60: the change fights the repository.
@@ -44,7 +46,7 @@ Score six dimensions from 0 to 100, then combine by weight. The anchors apply pe
 
 Classify every finding against these definitions, **never by the worst thing you happened to find**. A change with only minor findings cannot be scored as failing, no matter how many minors exist.
 
-- **`critical`** — breaks a core promise of the PRD; exploitable in touched code; corrupts data; or breaks the build/tests of the main path. Deduction: **−15** from the affected dimension.
+- **`critical`** — breaks a core promise of the working contract (the change's Requirements/Scenarios when an OpenSpec bundle is attached, else the PRD); exploitable in touched code; corrupts data; or breaks the build/tests of the main path. Deduction: **−15** from the affected dimension.
 - **`major`** — breaks an edge case or a non-core path; a central promise has no protecting test; or a repo-pattern violation with establishing evidence. Deduction: **−8**.
 - **`minor`** — style, consistency, optional improvements, or speculation. Deduction: **−2**.
 

--- a/prompts/review-scope.md
+++ b/prompts/review-scope.md
@@ -8,11 +8,15 @@ Default scope is the attached diff: this branch or pull request against the base
 
 Do not widen the review to untouched code. The one exception is code the change makes newly reachable or newly wrong; name it explicitly and tie it to the changed line that exposes it. Widen scope only when `prd.md` explicitly asks for a repository-wide review.
 
+## Working spec (OpenSpec)
+
+When an OpenSpec change bundle is attached — the current `openspec/specs/**` plus this branch's active `openspec/changes/<id>/` proposal, design delta, and delta spec files — that bundle is the contract for this review. Under **Scope**, quote the change's proposal title and cite the **Requirements/Scenarios** (by id) that the change must satisfy. Do not reconstruct product intent from the diff while the bundle is attached: OpenSpec's ADDED/MODIFIED/REMOVED deltas already encode what was asked and what changed, and the working spec is the authoritative map for the reviewers and scorers that follow you.
+
 ## Historical PRD
 
-A historical PRD may be attached alongside this run's `prd.md`. This run's `prd.md` is the request for the current pipeline (often a generic review prompt); the historical PRD, when present, is the original product intent for this branch.
+A historical PRD may be attached alongside this run's `prd.md` when the repository has no OpenSpec change bundle. This run's `prd.md` is the request for the current pipeline (often a generic review prompt); the historical PRD, when present, is the original product intent for this branch.
 
-Prefer the historical PRD for what was asked and why. Do not reconstruct a product brief from the diff when it is attached. Under **Scope**, quote its title and the decisions that matter so later auditors and quality scorers can cite the original intent without re-reading the attachment. When no historical PRD is attached, say so under **Scope** and infer intent from the diff as before.
+Prefer the historical PRD for what was asked and why. Do not reconstruct a product brief from the diff when it is attached. Under **What the change must satisfy**, quote its title and the decisions that matter so later auditors and quality scorers can cite the original intent without re-reading the attachment. When neither an OpenSpec bundle nor a historical PRD is attached, say so under **What the change must satisfy** and infer intent from the diff as a last resort.
 
 ## Objective
 
@@ -46,7 +50,7 @@ Safety rules:
 
 Return a concise Markdown report with:
 
-- **Scope**: changed areas, user-facing behavior, non-obvious side effects.
+- **What the change must satisfy**: the working contract — the attached OpenSpec change bundle's Requirements/Scenarios (with change id and proposal title), else the historical PRD's intent, else a stated diff-inferred scope. Name the changed areas and user-facing behavior against that contract; call out non-obvious side effects.
 - **Checks**: a table of the checks you ran — check / command / exit / summary — plus the verdict. Follow it with **Checks not run**: checks the repository supports that you skipped, and why.
 - **Patterns discovered**: concrete repo conventions later phases must enforce. One entry per convention, each with three parts: the convention stated as a rule, the **evidence** (`path:line` of existing code, or the doc line, that establishes it), and a **violation test** — how a later reviewer can tell mechanically whether the change breaks it. A convention you cannot point at evidence for is a personal preference; leave it out.
 - **Risk map**: files/modules deserving bug, clean-code, and security focus.

--- a/src/built-in-opencode.ts
+++ b/src/built-in-opencode.ts
@@ -1,0 +1,23 @@
+import convoyMd from "../opencode/commands/convoy.md" with { type: "text" }
+import spinMd from "../opencode/commands/spin.md" with { type: "text" }
+import convoyRun from "../opencode/bin/convoy-run" with { type: "text" }
+
+/**
+ * OpenCode install payload embedded as text at bundle time, so a standalone
+ * `convoy` binary can run `convoy opencode install` without a source checkout.
+ * Every file under opencode/commands/ and opencode/bin/ must have an import
+ * above and an entry here (a test in opencode-install.test.ts enforces this).
+ */
+export type BuiltInOpenCodePayloadFile = {
+  /** Path relative to the OpenCode config dir (e.g. `commands/convoy.md`). */
+  relPath: string
+  content: string
+  /** Unix mode applied after write. Set for helpers invoked as commands. */
+  mode?: number
+}
+
+export const builtInOpenCodePayload: readonly BuiltInOpenCodePayloadFile[] = [
+  { relPath: "commands/convoy.md", content: convoyMd },
+  { relPath: "commands/spin.md", content: spinMd },
+  { relPath: "bin/convoy-run", content: convoyRun, mode: 0o755 },
+]

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { dirname, join, resolve } from "node:path"
 
 import { buildAgentRegistry, ejectAgentPrompt, emptyHooksConfig, globalConfigPath, loadMergedConvoyConfig, selectPipelineSpec, writeDefaultGlobalConfig, writeDefaultProjectConfig, type ConvoyDefaults } from "./config"
 import { readControlFile } from "./control-client"
-import { detectBaseRef, currentBranch, resolveWorktreeDefault } from "./git"
+import { detectBaseRef, currentBranch, listChangedFiles, resolveWorktreeDefault } from "./git"
 import { openRouterKeySources } from "./limits"
 import { log } from "./log"
 import { builtInAgents, defaultGptModel, defaultGptVariant, defaultPipeline, defaultPipelineName, hasWritableStep, resolvePipeline, splitModelVariant, validateStepFilters } from "./pipeline"
@@ -12,6 +12,8 @@ import { defaultMaxConcurrentAgents, parseModel } from "./runner"
 import { buildRunPlan, type BuildRunPlanInput } from "./run-plan"
 import { confirmRunPlan, renderRunPlan } from "./run-review"
 import { loadPrdHistoryPreview } from "./prd-history"
+import { loadOpenSpecBundle } from "./openspec"
+import type { OpenCodeInstallOptions } from "./opencode-install"
 import { isModelGateway, modelGatewayChoices, modelGateways, type ModelGateway } from "./model-routing"
 import { browseRuns, isControlLive, isServerLive } from "./runs"
 import { deleteKeychainSecret, keychainAvailable, storeKeychainSecret } from "./secrets"
@@ -75,6 +77,8 @@ export type ParsedArgs = {
   goalMaxIterations?: number
   /** --goal-plateau: stop when a fix iteration improves the score by less than this many points. */
   goalPlateau?: number
+  /** --change: explicit OpenSpec change id; wins over every selection heuristic. */
+  change?: string
 }
 
 export type InitOptions = {
@@ -95,6 +99,7 @@ export type CliCommand =
   | { type: "auth"; provider: "openrouter"; action: "set" | "remove" | "status" }
   | { type: "version" }
   | { type: "update"; checkOnly: boolean }
+  | { type: "opencode"; action: "install" | "status" | "uninstall"; options: OpenCodeInstallOptions }
   | { type: "coordinate"; launchPath: string }
 
 export async function parseAndRun(argv: string[]) {
@@ -124,6 +129,11 @@ export async function parseAndRun(argv: string[]) {
   if (command.type === "update") {
     const { runUpdate } = await import("./update")
     writeUpdateResult(await runUpdate({ checkOnly: command.checkOnly }))
+    return
+  }
+  if (command.type === "opencode") {
+    const { runOpenCodeCommand } = await import("./opencode-install")
+    await runOpenCodeCommand(command.action, command.options)
     return
   }
   if (command.type === "runs") {
@@ -220,7 +230,28 @@ async function buildReviewedPlan(input: BuildRunPlanInput): Promise<RunPlan> {
     branch,
     excludeRunID: input.resumeRunID || undefined,
   })
-  return buildRunPlan({ ...input, prdHistoryPreview: preview })
+  // An OpenSpec contract, when the repo has one: discovered against the launch
+  // checkout (before any worktree isolate), so /convoy resolves the change the
+  // same way the runtime attaches it later in the same directory.
+  const openspec = await loadOpenSpecBundle({
+    targetDir: input.targetDir,
+    explicitId: input.change,
+    branch,
+    ...(input.baseRef && input.baseRef !== "HEAD" ? { diffFiles: await listChangedFiles(input.baseRef, input.targetDir).catch(() => []) } : {}),
+  })
+  // An explicitly pinned change is authoritative: resolving to nothing must
+  // refuse the run rather than silently fall back to diff inference — the
+  // operator asked for that contract, and a typo or an archived id should
+  // surface here, before any worktree or agent run.
+  if (input.change && (!openspec || openspec.changeIds.length === 0)) {
+    throw new Error(`--change "${input.change}" matched no active change under openspec/changes/ (archived or absent; run without --change to auto-resolve)`)
+  }
+  // Selection rule 5: in an OpenSpec repo, implement needs a change contract;
+  // review keeps today's diff-inference fallback.
+  if (openspec && openspec.changeIds.length === 0 && input.pipeline.name === defaultPipelineName) {
+    throw new Error("no change; run /opsx:propose first (or pass --change <id>)")
+  }
+  return buildRunPlan({ ...input, prdHistoryPreview: preview, ...(openspec ? { openspec } : {}) })
 }
 
 /** The result of deciding whether goal mode applies to a resolved run. */
@@ -743,6 +774,18 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
     if (parsed.help) return { type: "help", text: finishHelp() }
     return { type: "finish", options: parsed }
   }
+  if (argv[0] === "opencode") {
+    const rest = argv.slice(1)
+    if (rest.length === 0 || rest[0] === "--help" || rest[0] === "-h") return { type: "help", text: opencodeHelp() }
+    const action = rest[0]
+    if (action !== "install" && action !== "status" && action !== "uninstall") {
+      throw new Error("usage: convoy opencode install|status|uninstall [--dir <path>]")
+    }
+    const parsed = parseOpenCodeArgs(rest.slice(1))
+    if (parsed.help) return { type: "help", text: opencodeHelp() }
+    const options: OpenCodeInstallOptions = { ...(parsed.dir ? { dir: parsed.dir } : {}) }
+    return { type: "opencode", action, options }
+  }
 
   const parsed = parseArgs(argv)
   if (parsed.help) return { type: "help", text: help() }
@@ -868,6 +911,38 @@ function parseInitArgs(argv: string[]): ParsedInitArgs {
   return parsed
 }
 
+type ParsedOpenCodeArgs = OpenCodeInstallOptions & { help?: boolean }
+
+function parseOpenCodeArgs(argv: string[]): ParsedOpenCodeArgs {
+  const parsed: ParsedOpenCodeArgs = {}
+  for (let i = 0; i < argv.length; i++) {
+    const raw = argv[i]!
+    if (!raw.startsWith("-")) throw new Error("usage: convoy opencode install|status|uninstall [--dir <path>]")
+    const { flag, value } = splitFlag(raw)
+
+    const takeValue = () => {
+      if (value !== undefined) return value
+      const next = argv[++i]
+      if (next === undefined || (next.startsWith("-") && next !== "-")) throw new Error(`${flag} requires a value`)
+      return next
+    }
+
+    switch (flag) {
+      case "--help":
+      case "-h":
+        if (value !== undefined) throw new Error(`${flag} does not take a value`)
+        parsed.help = true
+        return parsed
+      case "--dir":
+        parsed.dir = resolve(process.cwd(), takeValue())
+        break
+      default:
+        throw new Error(`unknown opencode flag: ${flag}`)
+    }
+  }
+  return parsed
+}
+
 /** Applies the precedence chain and resolves the pipeline the run will execute. */
 export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOptions, "prompt">> {
   const config = await loadMergedConvoyConfig(parsed.targetDir)
@@ -927,6 +1002,7 @@ export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOpt
     skipSteps: parsed.skipSteps,
     resumeRunID: parsed.resumeRunID ?? "",
     prdHistory: defaults.prdHistory ?? true,
+    ...(parsed.change ? { change: parsed.change } : {}),
     keepRunDir: parsed.keepRunDir ?? true,
     modelOverride: parsed.modelOverride ?? "",
     advisorOverride: parsed.advisorOverride ?? "",
@@ -1134,6 +1210,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
       case "--branch":
         parsed.branch = takeValue()
         break
+      case "--change":
+        parsed.change = takeValue()
+        break
       case "--base":
         parsed.baseRef = takeValue()
         break
@@ -1200,6 +1279,7 @@ Usage:
   convoy runs [run-id]
   convoy config
   convoy auth openrouter
+  convoy opencode install|status|uninstall
 
 Commands:
   convoy                   Open an interactive TUI launcher to pick a pipeline,
@@ -1218,6 +1298,8 @@ Commands:
   config                   View and edit the global (~/.convoy) and current project config in a TUI
   auth openrouter          Store an OpenRouter management key in the macOS Keychain for the
                            header credits meter (--remove deletes it; "auth status" lists sources)
+  opencode ...             Install /spin and /convoy as OpenCode slash commands + the convoy-run
+                           helper into OpenCode's config dir ("convoy opencode --help" for options)
 
 Flags:
   --version, -V            Print Convoy's version, commit, and build platform
@@ -1255,6 +1337,10 @@ Flags:
   --no-worktree            Run in the current working tree instead
                            (default: worktree on a trunk branch, current tree on any other)
   --branch <name>          Name for the worktree branch, instead of asking the naming model
+  --change <id>            OpenSpec change id to review/implement (openspec/changes/<id>).
+                           Resolves the spec bundle (current specs + that change) as the scoring
+                           contract and overrides every selection heuristic. Runs without it
+                           on a single-change branch auto-resolve the active change.
   --goal <1-100>           Goal mode: keep fixing until the quality score reaches this value.
                            Requires a writable scored pipeline (any pipeline ending in a
                            quality-score-report step with a writing step). The ship pipeline
@@ -1315,6 +1401,21 @@ function writeUpdateResult(result: UpdateResult) {
     case "updated":
       process.stdout.write(`updated convoy ${result.currentVersion} → v${result.latestVersion} (${result.assetName})\n`)
   }
+}
+
+function opencodeHelp() {
+  return `convoy opencode install|status|uninstall [--dir <path>]
+
+Install /spin and /convoy as OpenCode slash commands, plus the convoy-run
+helper, so they sit next to /opsx:propose in OpenCode's config directory.
+
+  install    Copy (or refresh) Convoy's own OpenCode payload. Idempotent.
+  status     Report which payload files are installed (and their convoy version).
+  uninstall  Remove only Convoy-owned files; anything else in <dir> is left alone.
+
+Options:
+  --dir <path>  OpenCode config directory (OPENCODE_CONFIG_DIR, else ~/.config/opencode)
+`
 }
 
 function initHelp() {

--- a/src/git.ts
+++ b/src/git.ts
@@ -307,6 +307,20 @@ export async function writeDiff(path: string, baseRef: string, cwd: string) {
   await writeFile(path, diff.stdout)
 }
 
+/**
+ * The file paths changed in the working-tree diff against `baseRef`. Used by
+ * OpenSpec's compose rule (active-change selection when multiple changes exist
+ * and no branch matches). Best-effort: a failed diff resolves to an empty list.
+ */
+export async function listChangedFiles(baseRef: string, cwd: string): Promise<string[]> {
+  const names = await execFile("git", ["diff", "--name-only", baseRef], { cwd, allowFailure: true })
+  if (names.exitCode !== 0) return []
+  return names.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
 export async function addAllAndCommit(message: string, cwd: string) {
   await execFile("git", ["add", "-A"], { cwd })
 

--- a/src/opencode-install.ts
+++ b/src/opencode-install.ts
@@ -1,8 +1,9 @@
-import { copyFile, mkdir, readdir, readFile, rm } from "node:fs/promises"
+import { chmod, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises"
 import { existsSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 import { homedir } from "node:os"
 
+import { builtInOpenCodePayload, type BuiltInOpenCodePayloadFile } from "./built-in-opencode"
 import { shortVersion } from "./version"
 
 /**
@@ -10,8 +11,9 @@ import { shortVersion } from "./version"
  *
  * Deploys Convoy's OpenSpec-native OpenCode payload — the `/spin` and `/convoy`
  * slash commands and the `convoy-run` helper — into OpenCode's config directory
- * so they sit next to `/opsx:propose`. The payload lives in this repo under
- * `opencode/commands/*.md` and `opencode/bin/*`.
+ * so they sit next to `/opsx:propose`. The payload is embedded at bundle time
+ * from `opencode/commands/*.md` and `opencode/bin/*`, so a standalone binary
+ * installs the same files a source checkout would.
  *
  * Resolution order for the destination dir: `--dir <path>` (explicitly supplied
  * to the CLI), else `OPENCODE_CONFIG_DIR` (the same variable Convoy already
@@ -26,8 +28,7 @@ export type OpenCodeInstallOptions = {
   dir?: string
 }
 
-/** The committed payload root: `<repo>/opencode`, relative to this module. */
-const payloadRoot = resolve(import.meta.dir, "..", "opencode")
+export type OpenCodePayloadFile = BuiltInOpenCodePayloadFile
 
 export function openCodeConfigDir(options: OpenCodeInstallOptions = {}): string {
   if (options.dir) return resolve(options.dir)
@@ -35,25 +36,9 @@ export function openCodeConfigDir(options: OpenCodeInstallOptions = {}): string 
   return join(homedir(), ".config", "opencode")
 }
 
-export type OpenCodePayloadFile = {
-  /** Path relative to the config dir (e.g. `commands/convoy.md`). */
-  relPath: string
-  /** Absolute source path in this repo. */
-  source: string
-}
-
 /** Lists the payload Convoy owns, relative to the config dir, sorted for determinism. */
-export async function openCodePayloadFiles(): Promise<OpenCodePayloadFile[]> {
-  const out: OpenCodePayloadFile[] = []
-  for (const kind of ["commands", "bin"]) {
-    const dir = join(payloadRoot, kind)
-    if (!(await dirExists(dir))) continue
-    for (const name of (await readdir(dir)).sort()) {
-      if (name.startsWith(".")) continue
-      out.push({ relPath: join(kind, name), source: join(dir, name) })
-    }
-  }
-  return out
+export function openCodePayloadFiles(): OpenCodePayloadFile[] {
+  return builtInOpenCodePayload.map((file) => ({ ...file }))
 }
 
 export type OpenCodeInstallResult = {
@@ -64,11 +49,12 @@ export type OpenCodeInstallResult = {
 
 export async function installOpenCode(options: OpenCodeInstallOptions = {}): Promise<OpenCodeInstallResult> {
   const dir = openCodeConfigDir(options)
-  const files = await openCodePayloadFiles()
+  const files = openCodePayloadFiles()
   for (const file of files) {
     const dest = join(dir, file.relPath)
     await mkdir(dirname(dest), { recursive: true })
-    await copyFile(file.source, dest)
+    await writeFile(dest, file.content, "utf8")
+    if (file.mode !== undefined) await chmod(dest, file.mode)
   }
   return { dir, installed: files.map((file) => file.relPath) }
 }
@@ -88,7 +74,7 @@ export type OpenCodeStatusResult = {
 
 export async function openCodeStatus(options: OpenCodeInstallOptions = {}): Promise<OpenCodeStatusResult> {
   const dir = openCodeConfigDir(options)
-  const files = await openCodePayloadFiles()
+  const files = openCodePayloadFiles()
   const records: OpenCodeStatusRecord[] = []
   for (const file of files) {
     const dest = join(dir, file.relPath)
@@ -96,7 +82,7 @@ export async function openCodeStatus(options: OpenCodeInstallOptions = {}): Prom
       records.push({ relPath: file.relPath, installed: false, matchesBundled: false })
       continue
     }
-    const same = (await readFile(dest, "utf8").catch(() => "")) === (await readFile(file.source, "utf8").catch(() => ""))
+    const same = (await readFile(dest, "utf8").catch(() => "")) === file.content
     records.push({ relPath: file.relPath, installed: true, matchesBundled: same })
   }
   return { dir, version: shortVersion(), records }
@@ -112,7 +98,7 @@ export type OpenCodeUninstallResult = {
 
 export async function uninstallOpenCode(options: OpenCodeInstallOptions = {}): Promise<OpenCodeUninstallResult> {
   const dir = openCodeConfigDir(options)
-  const files = await openCodePayloadFiles()
+  const files = openCodePayloadFiles()
   const removed: string[] = []
   const kept: string[] = []
   for (const file of files) {

--- a/src/opencode-install.ts
+++ b/src/opencode-install.ts
@@ -1,0 +1,176 @@
+import { copyFile, mkdir, readdir, readFile, rm } from "node:fs/promises"
+import { existsSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { homedir } from "node:os"
+
+import { shortVersion } from "./version"
+
+/**
+ * `convoy opencode install|status|uninstall`
+ *
+ * Deploys Convoy's OpenSpec-native OpenCode payload — the `/spin` and `/convoy`
+ * slash commands and the `convoy-run` helper — into OpenCode's config directory
+ * so they sit next to `/opsx:propose`. The payload lives in this repo under
+ * `opencode/commands/*.md` and `opencode/bin/*`.
+ *
+ * Resolution order for the destination dir: `--dir <path>` (explicitly supplied
+ * to the CLI), else `OPENCODE_CONFIG_DIR` (the same variable Convoy already
+ * feeds its own server at runtime), else `~/.config/opencode`.
+ *
+ * Uninstall removes only Convoy-owned files (exactly the payload it installs),
+ * never the rest of the directory, so another tool's files are left alone.
+ */
+
+export type OpenCodeInstallOptions = {
+  /** Where to resolve the OpenCode config dir. `OPENCODE_CONFIG_DIR` or `~/.config/opencode` otherwise. */
+  dir?: string
+}
+
+/** The committed payload root: `<repo>/opencode`, relative to this module. */
+const payloadRoot = resolve(import.meta.dir, "..", "opencode")
+
+export function openCodeConfigDir(options: OpenCodeInstallOptions = {}): string {
+  if (options.dir) return resolve(options.dir)
+  if (process.env.OPENCODE_CONFIG_DIR) return resolve(process.env.OPENCODE_CONFIG_DIR)
+  return join(homedir(), ".config", "opencode")
+}
+
+export type OpenCodePayloadFile = {
+  /** Path relative to the config dir (e.g. `commands/convoy.md`). */
+  relPath: string
+  /** Absolute source path in this repo. */
+  source: string
+}
+
+/** Lists the payload Convoy owns, relative to the config dir, sorted for determinism. */
+export async function openCodePayloadFiles(): Promise<OpenCodePayloadFile[]> {
+  const out: OpenCodePayloadFile[] = []
+  for (const kind of ["commands", "bin"]) {
+    const dir = join(payloadRoot, kind)
+    if (!(await dirExists(dir))) continue
+    for (const name of (await readdir(dir)).sort()) {
+      if (name.startsWith(".")) continue
+      out.push({ relPath: join(kind, name), source: join(dir, name) })
+    }
+  }
+  return out
+}
+
+export type OpenCodeInstallResult = {
+  dir: string
+  /** relPaths written (or refreshed). */
+  installed: string[]
+}
+
+export async function installOpenCode(options: OpenCodeInstallOptions = {}): Promise<OpenCodeInstallResult> {
+  const dir = openCodeConfigDir(options)
+  const files = await openCodePayloadFiles()
+  for (const file of files) {
+    const dest = join(dir, file.relPath)
+    await mkdir(dirname(dest), { recursive: true })
+    await copyFile(file.source, dest)
+  }
+  return { dir, installed: files.map((file) => file.relPath) }
+}
+
+export type OpenCodeStatusRecord = {
+  relPath: string
+  installed: boolean
+  /** The installed copy byte-for-byte matches the bundled payload (only meaningful when installed). */
+  matchesBundled: boolean
+}
+
+export type OpenCodeStatusResult = {
+  dir: string
+  version: string
+  records: OpenCodeStatusRecord[]
+}
+
+export async function openCodeStatus(options: OpenCodeInstallOptions = {}): Promise<OpenCodeStatusResult> {
+  const dir = openCodeConfigDir(options)
+  const files = await openCodePayloadFiles()
+  const records: OpenCodeStatusRecord[] = []
+  for (const file of files) {
+    const dest = join(dir, file.relPath)
+    if (!existsSync(dest)) {
+      records.push({ relPath: file.relPath, installed: false, matchesBundled: false })
+      continue
+    }
+    const same = (await readFile(dest, "utf8").catch(() => "")) === (await readFile(file.source, "utf8").catch(() => ""))
+    records.push({ relPath: file.relPath, installed: true, matchesBundled: same })
+  }
+  return { dir, version: shortVersion(), records }
+}
+
+export type OpenCodeUninstallResult = {
+  dir: string
+  /** Convoy-owned payload files removed. */
+  removed: string[]
+  /** Payload files that were not installed, so present only in the bundled copy. */
+  kept: string[]
+}
+
+export async function uninstallOpenCode(options: OpenCodeInstallOptions = {}): Promise<OpenCodeUninstallResult> {
+  const dir = openCodeConfigDir(options)
+  const files = await openCodePayloadFiles()
+  const removed: string[] = []
+  const kept: string[] = []
+  for (const file of files) {
+    const dest = join(dir, file.relPath)
+    if (existsSync(dest)) {
+      await rm(dest, { force: true })
+      removed.push(file.relPath)
+    } else {
+      kept.push(file.relPath)
+    }
+  }
+  // Tidy empty Convoy-owned subdirectories left behind, but never one the user
+  // has put files in.
+  for (const kind of ["commands", "bin"]) {
+    const dirPath = join(dir, kind)
+    if (!(await dirExists(dirPath))) continue
+    if ((await readdir(dirPath)).length === 0) await rm(dirPath, { force: true }).catch(() => undefined)
+  }
+  return { dir, removed, kept }
+}
+
+export async function runOpenCodeCommand(action: "install" | "status" | "uninstall", options: OpenCodeInstallOptions = {}) {
+  switch (action) {
+    case "install": {
+      const result = await installOpenCode(options)
+      process.stdout.write(`installed /spin, /convoy, and convoy-run into ${result.dir}\n`)
+      for (const rel of result.installed) process.stdout.write(`  ${rel}\n`)
+      return
+    }
+    case "status": {
+      const result = await openCodeStatus(options)
+      process.stdout.write(`convoy OpenCode files (${result.version}) in ${result.dir}:\n`)
+      const width = result.records.reduce((max, record) => Math.max(max, record.relPath.length), 0)
+      for (const record of result.records) {
+        const state = !record.installed
+          ? "not installed"
+          : record.matchesBundled
+            ? "installed"
+            : "installed — differs from this copy"
+        process.stdout.write(`  ${record.relPath.padEnd(width)}  ${state}\n`)
+      }
+      return
+    }
+    case "uninstall": {
+      const result = await uninstallOpenCode(options)
+      process.stdout.write(`removed convoy files from ${result.dir}\n`)
+      for (const rel of result.removed) process.stdout.write(`  ${rel}\n`)
+      if (result.kept.length > 0) process.stdout.write(`  already absent: ${result.kept.join(", ")}\n`)
+      return
+    }
+  }
+}
+
+async function dirExists(dir: string): Promise<boolean> {
+  try {
+    await readdir(dir)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/src/openspec.ts
+++ b/src/openspec.ts
@@ -1,0 +1,242 @@
+import { lstat, readdir, readFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
+/**
+ * OpenSpec-native scoring contract.
+ *
+ * Convoy never writes OpenSpec state: `openspec/changes/<id>/{proposal.md,
+ * specs/**, design.md, tasks.md}` is produced by the OpenSpec authoring tool
+ * (outside this repo) and archived under `openspec/archive/`. This module only
+ * reads that layout and turns it into a spec bundle — the current specs under
+ * `openspec/specs/` plus the files of the active change(s) — that the runner
+ * attaches in place of the single oldest `.convoy/prd-history` entry.
+ *
+ * The selection order (shared by `/convoy` and the runtime) is:
+ *   1. explicit `--change <id>` (or `/convoy <id>`);
+ *   2. exactly one non-archived change in `openspec/changes/`;
+ *   3. multiple, and the current branch name matches a change id (`feat/add-foo`
+ *      ↔ `add-foo`);
+ *   4. multiple, no branch match: compose the changes whose touched files appear
+ *      in the diff against the base;
+ *   5. none → no OpenSpec contract.
+ *
+ * `resolveChange` is pure and free of I/O so the whole selection order is
+ * unit-testable; the thin `loadOpenSpecBundle` caller does the filesystem reads.
+ */
+
+export const openspecDirName = "openspec"
+
+export type OpenSpecChange = {
+  id: string
+  /**
+   * Files the change touches, matched against the working diff in the compose
+   * path. Derived best-effort from the change's own markdown (proposal/design/
+   * tasks and delta specs); an empty list simply means the compose rule will
+   * never auto-select this change, which is the safe direction.
+   */
+  touchedFiles: readonly string[]
+  /** Every markdown file the change carries, relative to the repo root. */
+  specFiles: readonly string[]
+}
+
+/** The resolved contract the run plan freezes and the runner attaches. */
+export type OpenSpecBundle = {
+  changeIds: readonly string[]
+  /** Spec bundle file paths relative to the repo root: current specs + the active changes' files. */
+  specFiles: readonly string[]
+  /**
+   * Absolute path of the checkout the bundle was resolved against (the launch
+   * checkout). An isolated worktree starts from the base ref, so a freshly
+   * proposed — still uncommitted — change exists only here; the runner falls
+   * back to this root when a spec file is absent from the run's checkout.
+   */
+  rootDir?: string
+}
+
+/**
+ * Whether a `openspec/changes/` entry names a change dir. The archive binder,
+ * dotfiles, and stray root drop-ins (a proposal.md accidentally left at the top
+ * level) are not changes.
+ */
+export function isOpenSpecChangeId(id: string): boolean {
+  if (!id) return false
+  if (id === "archive") return false
+  if (id.startsWith(".")) return false
+  if (id.endsWith(".md")) return false
+  return true
+}
+
+/** `feat/add-foo` (or a bare `add-foo`) → `add-foo`; `undefined` when there is no branch. */
+export function branchIdFromBranch(branch?: string): string | undefined {
+  if (!branch) return undefined
+  const slash = branch.indexOf("/")
+  const candidate = slash === -1 ? branch : branch.slice(slash + 1)
+  return candidate || undefined
+}
+
+export type ResolveChangeInput = {
+  /** Rule 1: the explicit `--change <id>`; wins over every heuristic. */
+  explicitId?: string
+  /** Raw basename entries of `openspec/changes/` (including `archive/` and stray files). */
+  changesDirEntries: readonly string[]
+  /** Per-change context (touched files, spec files) keyed by change id. */
+  changesById: ReadonlyMap<string, OpenSpecChange>
+  /** Current branch name, for rule 3. */
+  branch?: string
+  /** Files touched in the working-tree diff against the base, for rule 4. */
+  diffFiles: readonly string[]
+}
+
+/**
+ * The selection order as a pure function. Returns the ids of the changes that
+ * apply to the current directory, or an empty array when none does.
+ */
+export function resolveChange(input: ResolveChangeInput): readonly string[] {
+  const changes = input.changesDirEntries.filter(isOpenSpecChangeId)
+  if (changes.length === 0) return []
+
+  const explicit = input.explicitId?.trim()
+  if (explicit) return changes.includes(explicit) ? [explicit] : []
+
+  if (changes.length === 1) return changes
+
+  const branchId = branchIdFromBranch(input.branch)
+  if (branchId && changes.includes(branchId)) return [branchId]
+
+  // Rule 4: compose every change whose touched files appear in the diff. A
+  // change with no derived touched files can never match, and that is fine — the
+  // compose path is a heuristic, never the source of authority (--change is).
+  return changes.filter((id) => {
+    const touched = input.changesById.get(id)?.touchedFiles
+    if (!touched || touched.length === 0) return false
+    return touched.some((file) => input.diffFiles.includes(file))
+  })
+}
+
+/**
+ * Discovers the active change(s) and materializes the spec bundle. Returns
+ * `undefined` when the repository has no `openspec/` at all — that is the
+ * brownfield signal that keeps today's `.convoy/prd-history` behavior intact
+ * (the bundle must be additive on detection only). A bundle with empty
+ * `changeIds` (openspec present, nothing selected) also keeps the historical
+ * fallback: selection rule 5 explicitly falls back to today's review behavior.
+ */
+export async function loadOpenSpecBundle(input: {
+  targetDir: string
+  explicitId?: string
+  branch?: string
+  diffFiles?: readonly string[]
+}): Promise<OpenSpecBundle | undefined> {
+  const openspecRoot = join(input.targetDir, openspecDirName)
+  if (!(await dirExists(openspecRoot))) return undefined
+
+  const changesDir = join(openspecRoot, "changes")
+  const changesDirEntries = await readDirNames(changesDir)
+  const changesById = new Map<string, OpenSpecChange>()
+  for (const id of changesDirEntries.filter(isOpenSpecChangeId)) {
+    const changeRoot = join(changesDir, id)
+    const relativeMds = await collectMarkdownFiles(changeRoot)
+    const touchedFiles = new Set<string>()
+    for (const relative of relativeMds) {
+      try {
+        const body = await readFile(join(changeRoot, relative), "utf8")
+        for (const token of filePathTokens(body)) touchedFiles.add(stripLeadingDotSlash(token))
+      } catch {
+        // A change that loses a file mid-edit still resolves by its id.
+      }
+    }
+    changesById.set(id, {
+      id,
+      touchedFiles: [...touchedFiles].sort(),
+      specFiles: relativeMds.map((relative) => join(openspecDirName, "changes", id, relative)),
+    })
+  }
+
+  const currentSpecFiles = await collectDirRelativeMarkdown(join(openspecRoot, "specs"), join(openspecDirName, "specs"))
+
+  const selected = resolveChange({
+    explicitId: input.explicitId,
+    changesDirEntries,
+    changesById,
+    branch: input.branch,
+    diffFiles: input.diffFiles ?? [],
+  })
+
+  const changeSpecFiles = selected.flatMap((id) => changesById.get(id)?.specFiles ?? [])
+  return {
+    changeIds: selected,
+    specFiles: [...currentSpecFiles, ...changeSpecFiles],
+    rootDir: resolve(input.targetDir),
+  }
+}
+
+async function dirExists(dir: string): Promise<boolean> {
+  try {
+    await readdir(dir)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/** Returns every markdown file under `root`, as paths relative to `root`. */
+async function collectMarkdownFiles(root: string): Promise<string[]> {
+  return collectDirRelativeMarkdown(root, ".")
+}
+
+/**
+ * Walks `root` and returns every hidden-skipping `.md` path, relative to `root`,
+ * sorted. Symlinks are never followed — file links, directory links, and a
+ * symlinked walk root (e.g. `openspec/specs` → somewhere outside the repo)
+ * contribute nothing rather than attaching out-of-repo files to the contract.
+ */
+async function collectDirRelativeMarkdown(root: string, relativeRoot: string): Promise<string[]> {
+  let dirents
+  try {
+    // lstat, not stat/readdir: a symlinked root is not a directory here, so the
+    // walk stops instead of silently following the link out of the repository.
+    if (!(await lstat(root)).isDirectory()) return []
+    dirents = await readdir(root, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const out: string[] = []
+  for (const entry of dirents) {
+    if (entry.name.startsWith(".")) continue
+    if (entry.isSymbolicLink()) continue
+    const relative = join(relativeRoot, entry.name)
+    if (entry.isDirectory()) {
+      out.push(...(await collectDirRelativeMarkdown(join(root, entry.name), relative)))
+    } else if (entry.name.endsWith(".md")) {
+      out.push(relative)
+    }
+  }
+  return out.sort()
+}
+
+/**
+ * Returns the sorted names of a directory's real (non-symlink) entries, or an
+ * empty list when absent. A symlink named like a change id is not a change.
+ */
+async function readDirNames(dir: string): Promise<string[]> {
+  try {
+    const dirents = await readdir(dir, { withFileTypes: true })
+    return dirents
+      .filter((entry) => !entry.isSymbolicLink())
+      .map((entry) => entry.name)
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+/** Relative path tokens that look like files (contain a `/` and an extension). */
+const filePathTokenPattern = /\b(?:\.{0,2}\/)?[\w.-]+(?:\/[\w.-]+)*\.[A-Za-z0-9]+\b/g
+
+function filePathTokens(content: string): string[] {
+  return [...new Set(content.match(filePathTokenPattern) ?? [])]
+}
+
+function stripLeadingDotSlash(path: string): string {
+  return path.startsWith("./") ? path.slice(2) : path
+}

--- a/src/review-tui.ts
+++ b/src/review-tui.ts
@@ -54,7 +54,7 @@ export function runReviewLines(plan: RunPlan, width: number, options: RunReviewR
   } else {
     rows.push(continuation([fg(theme.dim)("runs in the current checkout")]))
   }
-  pushHistoryRows(rows, plan, value)
+  pushContractRows(rows, plan, value)
   rows.push(plain(""))
 
   rows.push(labelRow("gateway", [fg(theme.text)(gatewayLabel(plan.modelRouting.gateway))]))
@@ -98,6 +98,30 @@ export function runReviewLines(plan: RunPlan, width: number, options: RunReviewR
   }
 
   return rows
+}
+
+function pushContractRows(rows: StyledText[], plan: RunPlan, value: number) {
+  const openspecWins = Boolean(plan.openspec && plan.openspec.changeIds.length > 0)
+  // One contract: an active OpenSpec change supersedes historical PRD, so the
+  // review must not claim both will attach.
+  if (openspecWins) {
+    pushOpenSpecRows(rows, plan, value)
+    return
+  }
+  pushHistoryRows(rows, plan, value)
+  pushOpenSpecRows(rows, plan, value)
+}
+
+function pushOpenSpecRows(rows: StyledText[], plan: RunPlan, value: number) {
+  if (!plan.openspec) return
+  if (plan.openspec.changeIds.length === 0) {
+    rows.push(labelRow("openspec", [fg(theme.dim)(truncate("no active change · scope will infer from the diff", value))]))
+    return
+  }
+  const ids = sanitizeReviewInline(plan.openspec.changeIds.join(", "))
+  const count = plan.openspec.specFiles.length
+  const headline = `${ids} · contract attached (${count} spec file${count === 1 ? "" : "s"})`
+  rows.push(labelRow("openspec", [fg(theme.teal)(truncate(headline, value))]))
 }
 
 function pushHistoryRows(rows: StyledText[], plan: RunPlan, value: number) {

--- a/src/run-plan.ts
+++ b/src/run-plan.ts
@@ -1,4 +1,5 @@
 import { resolveModel, type ModelGateway, type ModelRoutingOverrides } from "./model-routing"
+import type { OpenSpecBundle } from "./openspec"
 import type { PrdHistoryPreview } from "./prd-history"
 import { defaultGoalMaxIterations, defaultGoalPlateau } from "./quality-score"
 import { stepRunnerFor } from "./step-runners"
@@ -15,6 +16,8 @@ export type BuildRunPlanInput = RunOptions & {
   resumeGateway?: ModelGateway
   /** Precomputed checkout preview; `buildRunPlan` does not touch the filesystem. */
   prdHistoryPreview?: PrdHistoryPreview
+  /** Precomputed OpenSpec contract; `buildRunPlan` does not touch the filesystem. */
+  openspec?: OpenSpecBundle
 }
 
 /** Purely resolves the complete execution shape; it performs no filesystem or process effects. */
@@ -61,6 +64,7 @@ export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
     ...(judge ? { smartJudge: { model: judge } } : {}),
     hooks,
     attachments: [...input.files],
+    ...(input.openspec ? { openspec: input.openspec } : {}),
     ...(input.prdHistoryPreview ? { prdHistory: input.prdHistoryPreview } : {}),
     permissions: input.yolo ? "yolo" : input.smart ? "smart" : "interactive",
     ...(goal ? { goal } : {}),

--- a/src/run-review.ts
+++ b/src/run-review.ts
@@ -27,6 +27,7 @@ export function renderRunPlan(plan: RunPlan, compact = false, options: RunPlanRe
     `  Diff base: ${sanitizeInline(plan.target.baseRef)} · working tree: ${plan.target.dirty ? "include dirty" : "clean required"}`,
     `  Worktree: ${plan.target.worktree ? `yes · branch ${plan.target.branch ? sanitizeInline(plan.target.branch) : "named at start"}` : "no"}`,
     ...prdHistoryPlanLines(plan),
+    ...openspecPlanLines(plan),
     `Pipeline: ${sanitizeInline(plan.pipeline.name)} · ${plan.pipeline.steps.length} steps`,
     `Gateway: ${gatewayLabel(plan.modelRouting.gateway)}${plan.modelRouting.gateway === "nitro" ? " · every OpenRouter model routed by throughput (injected for this run only)" : ""}`,
     `Advisors: ${plan.pipeline.steps.filter((step) => step.type === "agent" && Boolean(plannedStepAdvisor(step))).length}/${plan.pipeline.steps.filter((step) => step.type === "agent").length} steps advised`,
@@ -107,12 +108,25 @@ export async function confirmRunPlan(plan: RunPlan): Promise<boolean> {
 }
 
 function prdHistoryPlanLines(plan: RunPlan): string[] {
+  // An active OpenSpec change is the contract; do not also claim the historical
+  // PRD will attach (the runner supersedes it).
+  if (plan.openspec && plan.openspec.changeIds.length > 0) return []
   if (!plan.prdHistory) return []
   const copy = prdHistoryPreviewCopy(plan.prdHistory)
   if (!copy) return []
   const headline = sanitizeInline(copy.headline)
   if (copy.detail) return [`PRD history: ${headline}`, `  ${sanitizeInline(copy.detail)}`]
   return [`PRD history: ${headline}`]
+}
+
+function openspecPlanLines(plan: RunPlan): string[] {
+  if (!plan.openspec) return []
+  if (plan.openspec.changeIds.length === 0) {
+    return ["OpenSpec: openspec/ present but no active change — scope falls back to the diff"]
+  }
+  const ids = sanitizeInline(plan.openspec.changeIds.join(", "))
+  const count = plan.openspec.specFiles.length
+  return [`OpenSpec change: ${ids} · contract attached (${count} spec files)`]
 }
 
 function sanitize(value: string) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1249,7 +1249,7 @@ export async function preparePhaseRun(
 
   const phaseFiles = await fileParts(inputs, workspace.dir, "skip")
   const contextFiles = await projectContextFileParts(projectContextFiles, options.targetDir)
-  const historyFiles = options.prdHistory && phase.prdHistory ? await historicalPrdFileParts(options.targetDir, workspace.runID) : []
+  const historyFiles = options.prdHistory && phase.prdHistory ? await scopeContractFiles(options, workspace.runID) : []
   const attachments = [...contextFiles, ...phaseFiles, ...historyFiles, ...extraFiles]
   const prompt = buildPhasePrompt(workspace, phase)
   const model = selectedModel(phase, options.modelOverride)
@@ -1279,6 +1279,42 @@ async function historicalPrdFileParts(targetDir: string, excludeRunID: string): 
     log.warn(`couldn't read PRD history: ${formatSdkError(error)}`)
     return []
   }
+}
+
+/**
+ * The scope contract for a prdHistory-opted phase: the OpenSpec spec bundle when
+ * an active change resolved on this checkout, else the single oldest historical
+ * PRD. The bundle supersedes history only on detection — a repo without
+ * `openspec/`, or one with no active change, keeps today's behavior exactly.
+ */
+async function scopeContractFiles(options: RunOptions, excludeRunID: string): Promise<FilePartInput[]> {
+  const bundle = options.plan?.openspec
+  if (bundle && bundle.changeIds.length > 0) {
+    try {
+      // Prefer the run's checkout. An isolated worktree starts from the base
+      // ref, so a freshly proposed (uncommitted) change exists only in the
+      // launch checkout the plan was resolved against — fall back to it rather
+      // than silently dropping the contract the operator consented to.
+      const paths: string[] = []
+      for (const file of bundle.specFiles) {
+        const inRun = join(options.targetDir, file)
+        if (existsSync(inRun)) {
+          paths.push(inRun)
+          continue
+        }
+        const inLaunch = bundle.rootDir ? join(bundle.rootDir, file) : undefined
+        if (inLaunch && existsSync(inLaunch)) paths.push(inLaunch)
+      }
+      if (paths.length < bundle.specFiles.length) {
+        log.warn(`OpenSpec spec bundle: ${bundle.specFiles.length - paths.length} of ${bundle.specFiles.length} spec files resolved in neither the run's nor the launch checkout; skipped`)
+      }
+      return await fileParts(paths, options.targetDir, "skip")
+    } catch (error) {
+      log.warn(`couldn't attach OpenSpec spec bundle: ${formatSdkError(error)}`)
+      return []
+    }
+  }
+  return historicalPrdFileParts(options.targetDir, excludeRunID)
 }
 
 async function projectContextFileParts(paths: string[], targetDir: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import type { AdvisorAuditPolicy } from "./advisor-events"
 import type { LoopGuardSettings } from "./loop-guard"
 import type { NotificationSettings } from "./notifications"
+import type { OpenSpecBundle } from "./openspec"
 import type { PrdHistoryPreview } from "./prd-history"
 import type { AutoAccept, ProgressUI } from "./progress"
 import type { StepRunnerId } from "./step-runners"
@@ -10,6 +11,8 @@ export type RunOptions = {
   prompt: string
   /** Whether this run persists and attaches the project's git-ignored PRD history. */
   prdHistory: boolean
+  /** Explicit OpenSpec change id (`--change <id>`); resolves the spec bundle contract. */
+  change?: string
   files: string[]
   onlySteps: string[]
   skipSteps: string[]
@@ -310,6 +313,13 @@ export type RunPlan = {
   smartJudge?: { model: ResolvedModel }
   hooks: HookSet
   attachments: string[]
+  /**
+   * The frozen OpenSpec contract for this run, resolved before confirmation so
+   * the plan preview can name the active change and the runner can attach its
+   * spec bundle in place of the oldest historical PRD. Absent when the repo has
+   * no `openspec/` (brownfield: exact today's behavior).
+   */
+  openspec?: OpenSpecBundle
   /**
    * Operator-facing preview of the checkout's historical PRD. Computed before
    * confirmation (never inside `buildRunPlan`) so the launcher and CLI review

--- a/test/cli-parser.test.ts
+++ b/test/cli-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
-import { resolveRunOptions } from "../src/cli"
+import { parseArgs, parseCommand, resolveRunOptions } from "../src/cli"
 
 describe("resolveRunOptions", () => {
   test("returns options with defaults applied", async () => {
@@ -34,6 +34,7 @@ describe("resolveRunOptions", () => {
       promptFile: undefined,
       help: undefined,
       advisor: undefined,
+      change: undefined,
     }
 
     const options = await resolveRunOptions(parsed)
@@ -42,5 +43,75 @@ describe("resolveRunOptions", () => {
     expect(options.pipeline).toBeDefined()
     expect(options.pipeline.steps.length).toBeGreaterThan(0)
     expect(typeof options.gateway).toBe("string")
+  })
+
+  test("--change carries into resolved run options", async () => {
+    const options = await resolveRunOptions({
+      files: [],
+      onlySteps: [],
+      skipSteps: [],
+      targetDir: process.cwd(),
+      keepRunDir: undefined,
+      modelOverride: undefined,
+      advisorOverride: undefined,
+      advisorDisabled: undefined,
+      tui: undefined,
+      notify: undefined,
+      humanReview: undefined,
+      maxConcurrent: undefined,
+      baseRef: undefined,
+      worktree: undefined,
+      branch: undefined,
+      baseDetectionDir: undefined,
+      includeDirty: undefined,
+      yolo: undefined,
+      smart: undefined,
+      smartModel: undefined,
+      gateway: undefined,
+      planOnly: undefined,
+      noConfirm: undefined,
+      resumeRunID: undefined,
+      pipeline: undefined,
+      prompt: undefined,
+      promptFile: undefined,
+      help: undefined,
+      change: "add-login",
+    })
+    expect(options.change).toBe("add-login")
+  })
+
+  test("parseArgs turns --change add-foo into parsed.change", () => {
+    expect(parseArgs(["--change", "add-foo"]).change).toBe("add-foo")
+    expect(parseArgs(["--change=add-bar"]).change).toBe("add-bar")
+  })
+
+  test("parseCommand parses opencode install|status|uninstall as a subcommand", async () => {
+    const install = await parseCommand(["opencode", "install"])
+    expect(install.type).toBe("opencode")
+    if (install.type === "opencode") {
+      expect(install.action).toBe("install")
+    }
+
+    const status = await parseCommand(["opencode", "status"])
+    expect(status.type).toBe("opencode")
+    if (status.type === "opencode") expect(status.action).toBe("status")
+
+    const uninstall = await parseCommand(["opencode", "uninstall", "--dir", "/tmp/oc"])
+    expect(uninstall.type).toBe("opencode")
+    if (uninstall.type === "opencode") {
+      expect(uninstall.action).toBe("uninstall")
+      expect(uninstall.options.dir).toBe("/tmp/oc")
+    }
+  })
+
+  test("parseCommand rejects an unknown opencode subcommand and unknown flags", async () => {
+    await expect(parseCommand(["opencode", "frobnicate"])).rejects.toThrow("usage: convoy opencode")
+    await expect(parseCommand(["opencode", "install", "--bogus"])).rejects.toThrow("unknown opencode flag")
+  })
+
+  test("parseCommand surfaces opencode help with no subcommand", async () => {
+    const cmd = await parseCommand(["opencode"])
+    expect(cmd.type).toBe("help")
+    if (cmd.type === "help") expect(cmd.text).toContain("convoy opencode install|status|uninstall")
   })
 })

--- a/test/opencode-install.test.ts
+++ b/test/opencode-install.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { existsSync } from "node:fs"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { installOpenCode, openCodeConfigDir, openCodePayloadFiles, openCodeStatus, uninstallOpenCode } from "../src/opencode-install"
+
+const dirs: string[] = []
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function withOpenCodeConfigDir<T>(body: (configDir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "convoy-opencode-config-"))
+  dirs.push(dir)
+  const configDir = join(dir, "config", "opencode")
+  const previous = process.env.OPENCODE_CONFIG_DIR
+  process.env.OPENCODE_CONFIG_DIR = configDir
+  try {
+    return await body(configDir)
+  } finally {
+    if (previous === undefined) delete process.env.OPENCODE_CONFIG_DIR
+    else process.env.OPENCODE_CONFIG_DIR = previous
+  }
+}
+
+describe("convoy opencode install", () => {
+  test("writes the three payload files into OPENCODE_CONFIG_DIR, byte-for-byte from the bundled payload", async () => {
+    await withOpenCodeConfigDir(async (configDir) => {
+      const result = await installOpenCode()
+      expect(result.dir).toBe(configDir)
+      expect([...result.installed].sort()).toEqual(["bin/convoy-run", "commands/convoy.md", "commands/spin.md"])
+
+      expect(existsSync(join(configDir, "commands", "spin.md"))).toBe(true)
+      expect(existsSync(join(configDir, "commands", "convoy.md"))).toBe(true)
+      expect(existsSync(join(configDir, "bin", "convoy-run"))).toBe(true)
+
+      const bundled = await openCodePayloadFiles()
+      for (const file of bundled) {
+        expect(await readFile(join(configDir, file.relPath), "utf8")).toBe(await readFile(file.source, "utf8"))
+      }
+    })
+  })
+
+  test("re-running install is idempotent and refreshes a tampered copy", async () => {
+    await withOpenCodeConfigDir(async (configDir) => {
+      const first = await installOpenCode()
+      const payload = await openCodePayloadFiles()
+      const spinDest = join(configDir, "commands", "spin.md")
+      const spinSource = payload.find((file) => file.relPath === "commands/spin.md")!.source
+
+      await writeFile(spinDest, "# tampered\n")
+      const second = await installOpenCode()
+      expect(second.installed).toEqual(first.installed)
+      expect(await readFile(spinDest, "utf8")).toBe(await readFile(spinSource, "utf8"))
+    })
+  })
+
+  test("status reports installed payload files and their convoy version", async () => {
+    await withOpenCodeConfigDir(async (configDir) => {
+      expect(openCodeConfigDir()).toBe(configDir)
+      const missing = await openCodeStatus()
+      expect(missing.records.every((record) => !record.installed)).toBe(true)
+
+      await installOpenCode()
+      const present = await openCodeStatus()
+      expect(present.dir).toBe(configDir)
+      expect(present.version).toContain("v")
+      const installed = present.records.filter((record) => record.installed)
+      expect(installed.map((record) => record.relPath).sort()).toEqual(["bin/convoy-run", "commands/convoy.md", "commands/spin.md"])
+      expect(installed.every((record) => record.matchesBundled)).toBe(true)
+    })
+  })
+
+  test("uninstall removes only Convoy-owned files and leaves a sentinel alone", async () => {
+    await withOpenCodeConfigDir(async (configDir) => {
+      await installOpenCode()
+      const sentinel = join(configDir, "user-file.txt")
+      await writeFile(sentinel, "keep me\n")
+
+      const result = await uninstallOpenCode()
+      expect(result.removed.sort()).toEqual(["bin/convoy-run", "commands/convoy.md", "commands/spin.md"])
+      expect(result.kept).toEqual([])
+      expect(existsSync(join(configDir, "commands", "spin.md"))).toBe(false)
+      expect(existsSync(sentinel)).toBe(true)
+      expect(await readFile(sentinel, "utf8")).toBe("keep me\n")
+
+      // A second uninstall has nothing left to remove.
+      const again = await uninstallOpenCode()
+      expect(again.removed).toEqual([])
+    })
+  })
+
+  test("--dir resolves the destination directly, independent of OPENCODE_CONFIG_DIR", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-opencode-dir-"))
+    dirs.push(dir)
+    const target = join(dir, "custom")
+    const result = await installOpenCode({ dir: target })
+    expect(result.dir).toBe(target)
+    expect(existsSync(join(target, "commands", "convoy.md"))).toBe(true)
+  })
+})

--- a/test/opencode-install.test.ts
+++ b/test/opencode-install.test.ts
@@ -1,9 +1,10 @@
 import { afterAll, describe, expect, test } from "bun:test"
 import { existsSync } from "node:fs"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
+import { builtInOpenCodePayload } from "../src/built-in-opencode"
 import { installOpenCode, openCodeConfigDir, openCodePayloadFiles, openCodeStatus, uninstallOpenCode } from "../src/opencode-install"
 
 const dirs: string[] = []
@@ -37,24 +38,41 @@ describe("convoy opencode install", () => {
       expect(existsSync(join(configDir, "commands", "convoy.md"))).toBe(true)
       expect(existsSync(join(configDir, "bin", "convoy-run"))).toBe(true)
 
-      const bundled = await openCodePayloadFiles()
+      const bundled = openCodePayloadFiles()
       for (const file of bundled) {
-        expect(await readFile(join(configDir, file.relPath), "utf8")).toBe(await readFile(file.source, "utf8"))
+        expect(await readFile(join(configDir, file.relPath), "utf8")).toBe(file.content)
       }
+      expect((await stat(join(configDir, "bin", "convoy-run"))).mode & 0o777).toBe(0o755)
     })
+  })
+
+  test("embedded OpenCode payload stays in sync with the opencode/ directory", async () => {
+    const root = join(import.meta.dir, "..", "opencode")
+    const onDisk: string[] = []
+    for (const kind of ["commands", "bin"] as const) {
+      for (const name of (await readdir(join(root, kind))).sort()) {
+        // convoy-run.d.ts is a tsc sibling, not payload.
+        if (name.startsWith(".") || name.endsWith(".d.ts")) continue
+        onDisk.push(join(kind, name))
+      }
+    }
+    expect(builtInOpenCodePayload.map((file) => file.relPath).sort()).toEqual(onDisk.sort())
+    for (const file of builtInOpenCodePayload) {
+      expect(file.content).toBe(await readFile(join(root, file.relPath), "utf8"))
+    }
   })
 
   test("re-running install is idempotent and refreshes a tampered copy", async () => {
     await withOpenCodeConfigDir(async (configDir) => {
       const first = await installOpenCode()
-      const payload = await openCodePayloadFiles()
+      const payload = openCodePayloadFiles()
       const spinDest = join(configDir, "commands", "spin.md")
-      const spinSource = payload.find((file) => file.relPath === "commands/spin.md")!.source
+      const spin = payload.find((file) => file.relPath === "commands/spin.md")!
 
       await writeFile(spinDest, "# tampered\n")
       const second = await installOpenCode()
       expect(second.installed).toEqual(first.installed)
-      expect(await readFile(spinDest, "utf8")).toBe(await readFile(spinSource, "utf8"))
+      expect(await readFile(spinDest, "utf8")).toBe(spin.content)
     })
   })
 

--- a/test/openspec.test.ts
+++ b/test/openspec.test.ts
@@ -1,0 +1,414 @@
+import { afterAll, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { buildRunPlan } from "../src/run-plan"
+import { renderRunPlan } from "../src/run-review"
+import { parseCommand } from "../src/cli"
+import type { RunOptions } from "../src/types"
+import {
+  branchIdFromBranch,
+  isOpenSpecChangeId,
+  loadOpenSpecBundle,
+  openspecDirName,
+  resolveChange,
+  type OpenSpecChange,
+} from "../src/openspec"
+
+const dirs: string[] = []
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+function change(id: string, touchedFiles: string[], specFiles: string[]): OpenSpecChange {
+  return { id, touchedFiles, specFiles }
+}
+
+describe("OpenSpec change discovery", () => {
+  test("a change dir is any entry that is not the archive binder, a dotfile, or a stray markdown file", () => {
+    expect(isOpenSpecChangeId("add-login")).toBe(true)
+    expect(isOpenSpecChangeId("archive")).toBe(false)
+    expect(isOpenSpecChangeId(".hidden")).toBe(false)
+    expect(isOpenSpecChangeId("README.md")).toBe(false)
+  })
+
+  test("branch-to-id matching strips a type/ prefix: feat/add-foo → add-foo", () => {
+    expect(branchIdFromBranch("feat/add-foo")).toBe("add-foo")
+    expect(branchIdFromBranch("add-foo")).toBe("add-foo")
+    expect(branchIdFromBranch("feat/nested/add-foo")).toBe("nested/add-foo")
+    expect(branchIdFromBranch(undefined)).toBeUndefined()
+  })
+
+  test("returns the single non-archived change in openspec/changes/", () => {
+    expect(
+      resolveChange({
+        changesDirEntries: ["add-foo", "archive", "README.md"],
+        changesById: new Map([["add-foo", change("add-foo", [], [])]]),
+        diffFiles: [],
+      }),
+    ).toEqual(["add-foo"])
+  })
+
+  test("skips archive/ and any .md that is not a change dir", () => {
+    expect(
+      resolveChange({
+        changesDirEntries: ["archive", "README.md", "design.md", ".gitkeep"],
+        changesById: new Map(),
+        diffFiles: [],
+      }),
+    ).toEqual([])
+  })
+
+  test("with multiple changes, the branch name picks its change id", () => {
+    expect(
+      resolveChange({
+        changesDirEntries: ["add-foo", "add-bar"],
+        changesById: new Map([
+          ["add-foo", change("add-foo", [], [])],
+          ["add-bar", change("add-bar", [], [])],
+        ]),
+        branch: "feat/add-bar",
+        diffFiles: [],
+      }),
+    ).toEqual(["add-bar"])
+  })
+
+  test("with multiple changes and no branch match, composes the changes whose touched files appear in the diff", () => {
+    expect(
+      resolveChange({
+        changesDirEntries: ["add-foo", "add-bar"],
+        changesById: new Map([
+          ["add-foo", change("add-foo", ["src/foo.ts", "lib/foo.ts"], [])],
+          ["add-bar", change("add-bar", ["src/bar.ts"], [])],
+        ]),
+        branch: "main",
+        diffFiles: ["src/foo.ts", "src/baz.ts"],
+      }),
+    ).toEqual(["add-foo"])
+  })
+
+  test("composes every change that touches the diff when several match", () => {
+    expect(
+      resolveChange({
+        changesDirEntries: ["add-foo", "add-bar", "add-baz"],
+        changesById: new Map([
+          ["add-foo", change("add-foo", ["src/shared.ts"], [])],
+          ["add-bar", change("add-bar", ["src/shared.ts"], [])],
+          ["add-baz", change("add-baz", ["src/other.ts"], [])],
+        ]),
+        branch: "main",
+        diffFiles: ["src/shared.ts"],
+      }),
+    ).toEqual(["add-foo", "add-bar"])
+  })
+
+  test("a non-matching branch with several changes selects nothing instead of guessing", () => {
+    expect(
+      resolveChange({
+        changesDirEntries: ["add-foo", "add-bar"],
+        changesById: new Map([
+          ["add-foo", change("add-foo", [], [])],
+          ["add-bar", change("add-bar", [], [])],
+        ]),
+        branch: "main",
+        diffFiles: [],
+      }),
+    ).toEqual([])
+  })
+
+  test("explicit --change overrides all heuristics", () => {
+    expect(
+      resolveChange({
+        explicitId: "baz-qux",
+        changesDirEntries: ["add-foo", "baz-qux", "add-bar"],
+        changesById: new Map([
+          ["add-foo", change("add-foo", [], [])],
+          ["add-bar", change("add-bar", [], [])],
+          ["baz-qux", change("baz-qux", ["src/baz.ts"], [])],
+        ]),
+        branch: "feat/add-bar",
+        diffFiles: ["src/baz.ts"],
+      }),
+    ).toEqual(["baz-qux"])
+  })
+
+  test("an explicit id that is archived or absent selects nothing", () => {
+    expect(
+      resolveChange({
+        explicitId: "nope",
+        changesDirEntries: ["add-foo", "archive"],
+        changesById: new Map([["add-foo", change("add-foo", [], [])]]),
+        diffFiles: [],
+      }),
+    ).toEqual([])
+  })
+
+  test("empty openspec/changes/ resolves to no change", () => {
+    expect(resolveChange({ changesDirEntries: [], changesById: new Map(), diffFiles: [] })).toEqual([])
+  })
+
+  test("loadOpenSpecBundle returns undefined when openspec/ is absent, and never throws", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-openspec-absent-"))
+    dirs.push(dir)
+    expect(await loadOpenSpecBundle({ targetDir: dir })).toBeUndefined()
+  })
+
+  test("materializes the bundle: current specs plus the active change's files, never archive", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-openspec-bundle-"))
+    dirs.push(dir)
+    await mkdir(join(dir, openspecDirName, "specs", "auth"), { recursive: true })
+    await mkdir(join(dir, openspecDirName, "specs", "payments"), { recursive: true })
+    await mkdir(join(dir, openspecDirName, "changes", "add-login", "specs", "auth"), { recursive: true })
+    await mkdir(join(dir, openspecDirName, "archive", "old-change"), { recursive: true })
+    await writeFile(join(dir, openspecDirName, "specs", "auth", "spec.md"), "# Auth spec\n")
+    await writeFile(join(dir, openspecDirName, "specs", "payments", "spec.md"), "# Payments spec\n")
+    await writeFile(join(dir, openspecDirName, "changes", "add-login", "proposal.md"), "# Add Login\n")
+    await writeFile(join(dir, openspecDirName, "changes", "add-login", "specs", "auth", "spec.md"), "## ADDED Scenarios\n")
+    await writeFile(join(dir, openspecDirName, "archive", "old-change", "proposal.md"), "# Old\n")
+
+    const bundle = await loadOpenSpecBundle({ targetDir: dir })
+    expect(bundle).toBeDefined()
+    expect(bundle!.changeIds).toEqual(["add-login"])
+    expect([...bundle!.specFiles].sort()).toEqual(
+      [
+        "openspec/specs/auth/spec.md",
+        "openspec/specs/payments/spec.md",
+        "openspec/changes/add-login/proposal.md",
+        "openspec/changes/add-login/specs/auth/spec.md",
+      ].sort(),
+    )
+  })
+
+  test("never follows symlinks: a change-dir .md link, a symlinked change dir, and a symlinked specs root attach nothing", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-openspec-symlink-"))
+    dirs.push(dir)
+    const outside = await mkdtemp(join(tmpdir(), "convoy-openspec-outside-"))
+    dirs.push(outside)
+    await writeFile(join(outside, "leak.md"), "# outside the repository\n")
+
+    await mkdir(join(dir, openspecDirName, "changes", "add-login"), { recursive: true })
+    await writeFile(join(dir, openspecDirName, "changes", "add-login", "proposal.md"), "# Add Login\n")
+    // Committed symlinks whose targets live outside the repository must never
+    // reach the spec bundle the runner attaches to agent prompts.
+    await symlink(join(outside, "leak.md"), join(dir, openspecDirName, "changes", "add-login", "leak.md"))
+    await symlink(outside, join(dir, openspecDirName, "changes", "evil"))
+    await symlink(outside, join(dir, openspecDirName, "specs"))
+
+    const bundle = await loadOpenSpecBundle({ targetDir: dir })
+    expect(bundle).toBeDefined()
+    expect(bundle!.changeIds).toEqual(["add-login"])
+    expect(bundle!.specFiles).toEqual(["openspec/changes/add-login/proposal.md"])
+  })
+
+  test("loader honors --change over the branch heuristic", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-openspec-explicit-"))
+    dirs.push(dir)
+    await mkdir(join(dir, openspecDirName, "changes", "add-foo", "specs"), { recursive: true })
+    await mkdir(join(dir, openspecDirName, "changes", "add-bar"), { recursive: true })
+    await writeFile(join(dir, openspecDirName, "changes", "add-foo", "proposal.md"), "# Foo\n")
+    await writeFile(join(dir, openspecDirName, "changes", "add-bar", "proposal.md"), "# Bar\n")
+
+    expect((await loadOpenSpecBundle({ targetDir: dir, branch: "feat/add-foo" }))?.changeIds).toEqual(["add-foo"])
+    expect((await loadOpenSpecBundle({ targetDir: dir, branch: "feat/other", explicitId: "add-bar" }))?.changeIds).toEqual(["add-bar"])
+  })
+
+  test("loader persists an empty bundle (openspec present, nothing selected), distinct from absent", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-openspec-empty-"))
+    dirs.push(dir)
+    await mkdir(join(dir, openspecDirName, "archive", "old-change"), { recursive: true })
+    await mkdir(join(dir, openspecDirName, "changes"), { recursive: true })
+    await writeFile(join(dir, openspecDirName, "changes", "README.md"), "# changes\n")
+
+    const bundle = await loadOpenSpecBundle({ targetDir: dir, branch: "main", diffFiles: ["src/nowhere.ts"] })
+    expect(bundle).toBeDefined()
+    expect(bundle!.changeIds).toEqual([])
+  })
+
+  test("a reviewed plan freezes the bundle and --plan previews the active change without an agent", () => {
+    const options: RunOptions = {
+      prompt: "review",
+      prdHistory: true,
+      change: "add-login",
+      files: [],
+      onlySteps: [],
+      skipSteps: [],
+      resumeRunID: "",
+      keepRunDir: true,
+      modelOverride: "",
+      advisorOverride: "",
+      advisorDisabled: false,
+      tui: false,
+      notify: false,
+      notifications: {},
+      humanReview: false,
+      baseRef: "main",
+      targetDir: "/repo",
+      worktree: false,
+      includeDirty: false,
+      yolo: false,
+      smart: false,
+      smartJudgeModel: "openai/gpt-5.6-sol",
+      pipeline: { name: "review", steps: [] },
+      agents: [],
+      permissions: { allow: [], deny: [] },
+      hooks: { pre: [], post: [], pipelines: {} },
+    }
+    const bundle = {
+      changeIds: ["add-login"],
+      specFiles: ["openspec/specs/auth/spec.md", "openspec/changes/add-login/proposal.md"],
+    }
+    const plan = buildRunPlan({ ...options, openspec: bundle })
+    expect(plan.openspec).toEqual(bundle)
+    expect(Object.isFrozen(plan.openspec)).toBe(true)
+
+    const rendered = renderRunPlan(plan)
+    expect(rendered).toContain("OpenSpec change: add-login")
+    expect(rendered).toContain("contract attached (2 spec files)")
+  })
+
+  test("a plan without resolves previews the diff fallback instead of an OpenSpec line", () => {
+    const options: RunOptions = {
+      prompt: "test",
+      prdHistory: true,
+      files: [],
+      onlySteps: [],
+      skipSteps: [],
+      resumeRunID: "",
+      keepRunDir: true,
+      modelOverride: "",
+      advisorOverride: "",
+      advisorDisabled: false,
+      tui: false,
+      notify: false,
+      notifications: {},
+      humanReview: false,
+      baseRef: "main",
+      targetDir: "/repo",
+      worktree: false,
+      includeDirty: false,
+      yolo: false,
+      smart: false,
+      smartJudgeModel: "openai/gpt-5.6-sol",
+      pipeline: { name: "review", steps: [] },
+      agents: [],
+      permissions: { allow: [], deny: [] },
+      hooks: { pre: [], post: [], pipelines: {} },
+    }
+    const plan = buildRunPlan({ ...options, openspec: { changeIds: [], specFiles: [] } })
+    expect(plan.openspec?.changeIds).toEqual([])
+    expect(renderRunPlan(plan)).toContain("no active change — scope falls back to the diff")
+  })
+})
+
+describe("--change wiring through the reviewed run plan", () => {
+  async function git(args: string[], cwd: string): Promise<void> {
+    const proc = Bun.spawn(["git", "-c", "commit.gpgsign=false", ...args], {
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "convoy-test",
+        GIT_AUTHOR_EMAIL: "convoy-test@example.invalid",
+        GIT_COMMITTER_NAME: "convoy-test",
+        GIT_COMMITTER_EMAIL: "convoy-test@example.invalid",
+      },
+    })
+    if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")}: ${await new Response(proc.stderr).text()}`)
+  }
+
+  async function repoOn(branch: string): Promise<string> {
+    const dir = await mkdtemp(join(tmpdir(), "convoy-openspec-cli-"))
+    dirs.push(dir)
+    await git(["init", "-q", "-b", branch], dir)
+    await writeFile(join(dir, "README.md"), "# test\n")
+    await git(["add", "README.md"], dir)
+    await git(["commit", "-qm", "initial"], dir)
+    return dir
+  }
+
+  /** Two active changes plus the current auth spec, as /opsx:propose would leave them. */
+  async function repoWithTwoChanges(branch: string): Promise<string> {
+    const repo = await repoOn(branch)
+    for (const id of ["add-foo", "add-bar"]) {
+      await mkdir(join(repo, openspecDirName, "changes", id), { recursive: true })
+      await writeFile(join(repo, openspecDirName, "changes", id, "proposal.md"), `# ${id}\n`)
+    }
+    await mkdir(join(repo, openspecDirName, "specs", "auth"), { recursive: true })
+    await writeFile(join(repo, openspecDirName, "specs", "auth", "spec.md"), "# Auth spec\n")
+    return repo
+  }
+
+  async function runPlanFor(argv: string[]) {
+    const command = await parseCommand(argv)
+    if (command.type !== "run") throw new Error(`expected a run command, got ${command.type}`)
+    return command.options.plan
+  }
+
+  test("--change add-foo freezes that change's bundle and the main specs into the plan", async () => {
+    const repo = await repoWithTwoChanges("main")
+
+    const plan = await runPlanFor(["--dir", repo, "--change", "add-foo", "review this"])
+    expect(plan?.openspec?.changeIds).toEqual(["add-foo"])
+    expect(plan?.openspec?.specFiles).toContain("openspec/specs/auth/spec.md")
+    expect(plan?.openspec?.specFiles).toContain("openspec/changes/add-foo/proposal.md")
+    expect(plan?.openspec?.specFiles).not.toContain("openspec/changes/add-bar/proposal.md")
+  })
+
+  test("exactly one active change auto-resolves with zero operator input", async () => {
+    const repo = await repoOn("main")
+    await mkdir(join(repo, openspecDirName, "changes", "add-login"), { recursive: true })
+    await writeFile(join(repo, openspecDirName, "changes", "add-login", "proposal.md"), "# Add Login\n")
+
+    const plan = await runPlanFor(["--dir", repo, "review this"])
+    expect(plan?.openspec?.changeIds).toEqual(["add-login"])
+    expect(plan?.openspec?.specFiles).toContain("openspec/changes/add-login/proposal.md")
+  })
+
+  test("with several changes, the branch name picks its change (feat/add-foo → add-foo)", async () => {
+    const repo = await repoWithTwoChanges("main")
+    await mkdir(join(repo, "src"), { recursive: true })
+    await writeFile(join(repo, "src", "foo.ts"), "export {}\n")
+    await git(["add", "src"], repo)
+    await git(["checkout", "-q", "-b", "feat/add-foo"], repo)
+    await git(["commit", "-qm", "foo"], repo)
+
+    const plan = await runPlanFor(["--dir", repo, "review this"])
+    expect(plan?.openspec?.changeIds).toEqual(["add-foo"])
+  })
+
+  test("a checkout without openspec/ keeps plan.openspec undefined (today's behavior)", async () => {
+    const repo = await repoOn("main")
+
+    const plan = await runPlanFor(["--dir", repo, "review this"])
+    expect(plan?.openspec).toBeUndefined()
+  })
+
+  test("--change with an unknown id refuses instead of silently reviewing without a contract", async () => {
+    const repo = await repoWithTwoChanges("main")
+
+    await expect(runPlanFor(["--dir", repo, "--change", "nope", "review this"])).rejects.toThrow("--change \"nope\"")
+    // A repo without openspec/ refuses too: the pinned id cannot exist there.
+    const plain = await repoOn("main")
+    await expect(runPlanFor(["--dir", plain, "--change", "add-foo", "review this"])).rejects.toThrow("--change \"add-foo\"")
+  })
+
+  test("implement refuses when openspec/ is present but no change is active (selection rule 5)", async () => {
+    const repo = await repoOn("main")
+    await mkdir(join(repo, openspecDirName, "changes"), { recursive: true })
+    await writeFile(join(repo, openspecDirName, "changes", "README.md"), "# changes\n")
+
+    await expect(runPlanFor(["--dir", repo, "-p", "implement", "build it"])).rejects.toThrow("/opsx:propose")
+  })
+
+  test("review keeps the diff-inference fallback when openspec/ is present but no change is active", async () => {
+    const repo = await repoOn("main")
+    await mkdir(join(repo, openspecDirName, "changes"), { recursive: true })
+    await writeFile(join(repo, openspecDirName, "changes", "README.md"), "# changes\n")
+
+    const plan = await runPlanFor(["--dir", repo, "-p", "review", "review this"])
+    expect(plan?.openspec?.changeIds).toEqual([])
+  })
+})

--- a/test/runner-hosted.test.ts
+++ b/test/runner-hosted.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test"
 import { existsSync } from "node:fs"
-import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -12,6 +12,7 @@ import { buildRunPlan } from "../src/run-plan"
 import { noopProgress } from "../src/progress"
 import { builtInAgents } from "../src/pipeline"
 import { prdHistoryDir, readPrdHistoryIndex, writePrdHistory } from "../src/prd-history"
+import { loadOpenSpecBundle } from "../src/openspec"
 import { prepareWorktreeForRun } from "../src/cli"
 import { HerdrReporter } from "../src/herdr"
 
@@ -588,6 +589,90 @@ describe("run() with a hosted progress", () => {
     } finally {
       await rm(workspace, { recursive: true, force: true })
       await rm(repo, { recursive: true, force: true })
+    }
+  })
+
+  test("attaches the OpenSpec spec bundle instead of the historical PRD when a change resolved", async () => {
+    const repo = await cleanRepo()
+    const workspace = await mkdtemp(join(tmpdir(), "convoy-openspec-phase-"))
+    const phase = {
+      type: "agent" as const,
+      name: "scope",
+      stepName: "scope",
+      groupId: "g1",
+      agentName: "review-scope",
+      description: "scope",
+      model: "openai/gpt-5.6-terra",
+      inputFiles: [],
+      inputDiff: false,
+      reportPath: "reports/scope.md",
+      readOnly: true,
+      prdHistory: true,
+    }
+    try {
+      await writePrdHistory({ targetDir: repo, runID: "original", prompt: "original PRD", pipeline: "implement", branch: "main" })
+      await mkdir(join(repo, "openspec", "changes", "add-login", "specs", "auth"), { recursive: true })
+      await mkdir(join(repo, "openspec", "specs", "auth"), { recursive: true })
+      await writeFile(join(repo, "openspec", "changes", "add-login", "proposal.md"), "# Add Login\n")
+      await writeFile(join(repo, "openspec", "changes", "add-login", "specs", "auth", "spec.md"), "## ADDED Scenarios\n")
+      await writeFile(join(repo, "openspec", "specs", "auth", "spec.md"), "# Auth spec\n")
+
+      const bundle = await loadOpenSpecBundle({ targetDir: repo })
+      expect(bundle).toBeDefined()
+      const options = makeOptions(repo)
+      const plan = buildRunPlan({ ...options, openspec: bundle!, promptSource: "inline" })
+      const prepared = await preparePhaseRun({ dir: workspace, runID: "current" }, phase, { ...options, plan }, [], [])
+
+      const filenames = prepared.attachments.map((part) => part.filename)
+      expect(filenames).toContain("proposal.md")
+      expect(filenames).toContain("spec.md")
+      // The bundle supersedes the checkout's historical PRD.
+      expect(filenames).not.toContain("original.prd.md")
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+      await rm(repo, { recursive: true, force: true })
+    }
+  })
+
+  test("attaches the spec bundle from the launch checkout when the run's checkout lacks it (isolated worktree)", async () => {
+    // An isolated worktree starts from the base ref, so a freshly proposed —
+    // still uncommitted — change exists only in the launch checkout the plan
+    // was resolved against. The contract must not silently vanish there.
+    const launch = await cleanRepo()
+    const isolated = await cleanRepo()
+    const workspace = await mkdtemp(join(tmpdir(), "convoy-openspec-fallback-"))
+    const phase = {
+      type: "agent" as const,
+      name: "scope",
+      stepName: "scope",
+      groupId: "g1",
+      agentName: "review-scope",
+      description: "scope",
+      model: "openai/gpt-5.6-terra",
+      inputFiles: [],
+      inputDiff: false,
+      reportPath: "reports/scope.md",
+      readOnly: true,
+      prdHistory: true,
+    }
+    try {
+      await mkdir(join(launch, "openspec", "changes", "add-login"), { recursive: true })
+      await writeFile(join(launch, "openspec", "changes", "add-login", "proposal.md"), "# Add Login\n")
+
+      const bundle = await loadOpenSpecBundle({ targetDir: launch })
+      expect(bundle).toBeDefined()
+      expect(bundle!.rootDir).toBe(launch)
+      // The run executes in a checkout that does not carry the change files.
+      const options = makeOptions(isolated)
+      const plan = buildRunPlan({ ...options, openspec: bundle!, promptSource: "inline" })
+      const prepared = await preparePhaseRun({ dir: workspace, runID: "current" }, phase, { ...options, plan }, [], [])
+
+      const filenames = prepared.attachments.map((part) => part.filename)
+      expect(filenames).toContain("proposal.md")
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+      await rm(launch, { recursive: true, force: true })
+      await rm(isolated, { recursive: true, force: true })
     }
   })
 


### PR DESCRIPTION
- Add OpenSpec change discovery and scoring contract resolution
- Add convoy opencode install for /spin, /convoy, and convoy-run
- Preserve prompt-based fallback when no active OpenSpec changes exist
- Update review prompts, runtime planning, and CLI behavior
- Add comprehensive OpenSpec, installer, parser, and runner tests