### PR TITLE
feat(worktree): support configurable worktree locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,7 @@ defaults:
   branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731  # proposes worktree branch names (may look up referenced issues); you confirm the name
   commitMessageModel: anthropic/claude-haiku-4-5     # writes the conventional commit `convoy finish` squashes a run into; you edit it before it lands
   worktree: true                   # force a new branch + worktree for every run; false always runs in the current tree. Unset decides per branch (isolate on a trunk, run in place on a branch)
+  worktreeLocation: ~/dev/worktrees/{repo}/{branch}  # where isolated worktrees are created ({repo}/{branch} placeholders, ~ = home). A marker line in the repo's AGENTS.md/README.md outranks this; default ~/.convoy/worktrees
   prdHistory: true                 # store each new run's git-ignored prompt under .convoy/prd-history; false disables writes and historical attachments
   advisor: anthropic/claude-opus-5   # optional; a stronger model consulted at every step's decision points
   advisorMaxCalls: 1000              # optional; consultations allowed per phase attempt (default 1000 — effectively unlimited; set it lower to cap advisor spend)
@@ -836,7 +837,7 @@ Every interactive manual run now displays its fully resolved plan before reposit
 
 ### Isolating a run in a worktree
 
-An isolated run gets a new branch checked out under `~/.convoy/worktrees/<branch>`, leaving your current checkout untouched — which is what makes the branch safely rewritable by [`convoy finish`](#finishing-a-run) afterwards.
+An isolated run gets a new branch checked out in a dedicated worktree, leaving your current checkout untouched — which is what makes the branch safely rewritable by [`convoy finish`](#finishing-a-run) afterwards. Where that worktree lives follows a fixed priority: a `worktree location: ~/dev/worktrees/{repo}/{branch}` marker in `AGENTS.md` or `README.md`, then `defaults.worktreeLocation` in config, then the built-in `~/.convoy/worktrees/<branch>`. `{repo}` and `{branch}` are placeholders; `~` is home. A declared location that can't be used falls through to the next one.
 
 **The default depends on where you are.** On a trunk — `main`, `master`, `develop`, `trunk`, or whatever `origin/HEAD` points at — Convoy isolates, because you almost certainly don't want a pipeline committing straight onto it. Once you're on a branch of your own, it runs in place: you already made the branch you want the work on. A detached HEAD isolates too. Force either end per run with `--worktree` / `--no-worktree`, or permanently with `defaults.worktree: true` / `false`; the launcher shows which way the default went and why, next to the toggle. `--branch <name>` pins the name instead of asking the naming model, which is what an unattended or scripted run should use.
 

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ defaults:
   branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731  # proposes worktree branch names (may look up referenced issues); you confirm the name
   commitMessageModel: anthropic/claude-haiku-4-5     # writes the conventional commit `convoy finish` squashes a run into; you edit it before it lands
   worktree: true                   # force a new branch + worktree for every run; false always runs in the current tree. Unset decides per branch (isolate on a trunk, run in place on a branch)
-  worktreeLocation: ~/dev/worktrees/{repo}/{branch}  # where isolated worktrees are created ({repo}/{branch} placeholders, ~ = home). A marker line in the repo's AGENTS.md/README.md outranks this; default ~/.convoy/worktrees
+  worktreeLocation: ~/dev/worktrees/{repo}/{branch}  # where isolated worktrees are created ({repo}/{branch} placeholders, ~ = home; the branch slug is appended when {branch} is missing). A marker line in the repo's AGENTS.md/README.md outranks this; default ~/.convoy/worktrees
   prdHistory: true                 # store each new run's git-ignored prompt under .convoy/prd-history; false disables writes and historical attachments
   advisor: anthropic/claude-opus-5   # optional; a stronger model consulted at every step's decision points
   advisorMaxCalls: 1000              # optional; consultations allowed per phase attempt (default 1000 — effectively unlimited; set it lower to cap advisor spend)
@@ -837,7 +837,7 @@ Every interactive manual run now displays its fully resolved plan before reposit
 
 ### Isolating a run in a worktree
 
-An isolated run gets a new branch checked out in a dedicated worktree, leaving your current checkout untouched — which is what makes the branch safely rewritable by [`convoy finish`](#finishing-a-run) afterwards. Where that worktree lives follows a fixed priority: a `worktree location: ~/dev/worktrees/{repo}/{branch}` marker in `AGENTS.md` or `README.md`, then `defaults.worktreeLocation` in config, then the built-in `~/.convoy/worktrees/<branch>`. `{repo}` and `{branch}` are placeholders; `~` is home. A declared location that can't be used falls through to the next one.
+An isolated run gets a new branch checked out in a dedicated worktree, leaving your current checkout untouched — which is what makes the branch safely rewritable by [`convoy finish`](#finishing-a-run) afterwards. Where that worktree lives follows a fixed priority: a `worktree location: ~/dev/worktrees/{repo}/{branch}` marker in `AGENTS.md` or `README.md`, then `defaults.worktreeLocation` in config, then the built-in `~/.convoy/worktrees/<branch>`. `{repo}` and `{branch}` are placeholders; `~` is home. A location without `{branch}` gets the branch slug appended, so each worktree still gets its own directory. A declared location that can't be used falls through to the next one.
 
 **The default depends on where you are.** On a trunk — `main`, `master`, `develop`, `trunk`, or whatever `origin/HEAD` points at — Convoy isolates, because you almost certainly don't want a pipeline committing straight onto it. Once you're on a branch of your own, it runs in place: you already made the branch you want the work on. A detached HEAD isolates too. Force either end per run with `--worktree` / `--no-worktree`, or permanently with `defaults.worktree: true` / `false`; the launcher shows which way the default went and why, next to the toggle. `--branch <name>` pins the name instead of asking the naming model, which is what an unattended or scripted run should use.
 

--- a/assets/coverage.svg
+++ b/assets/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="138" height="20" role="img" aria-label="coverage: 92.19%">
-  <title>coverage: 92.19%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="138" height="20" role="img" aria-label="coverage: 92.29%">
+  <title>coverage: 92.29%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="38" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="38" y="14">coverage</text>
-    <text x="107" y="15" fill="#010101" fill-opacity=".3">92.19%</text>
-    <text x="107" y="14">92.19%</text>
+    <text x="107" y="15" fill="#010101" fill-opacity=".3">92.29%</text>
+    <text x="107" y="14">92.29%</text>
   </g>
 </svg>

--- a/openspec/changes/worktree-location/.openspec.yaml
+++ b/openspec/changes/worktree-location/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/worktree-location/design.md
+++ b/openspec/changes/worktree-location/design.md
@@ -35,7 +35,9 @@ Introduce a single resolver, e.g. `resolveWorktreeDir(branch, targetDir, ctx)`, 
 ### 2 — Resolution order with a usability guard
 `resolveWorktreeDir` tries, in order: (1) the documented marker, (2) `config.defaults.worktreeLocation`, (3) the built-in default. For each, it expands the template and checks usability before accepting it; unusable candidates are skipped for the next one.
 
-**Usability check:** resolve the expanded path, ensure its parent exists (`mkdir -p` of the parent) and is a writable directory. If it cannot be made usable, try the next candidate. The built-in `~/.convoy/worktrees` is never skipped unless it is itself unusable.
+**Usability check:** resolve the expanded path and verify — without creating anything — that it is not inside the repository (compared on physical, `realpath`-resolved paths, so a symlinked parent cannot smuggle a path in) and that its nearest existing ancestor is a writable directory. The parent chain is created only by `createIsolatedWorktree` once the run is confirmed, so the launcher preview and collision probes stay read-only. If a candidate cannot be made usable, try the next one. The built-in `~/.convoy/worktrees` is never skipped unless it is itself unusable.
+
+A candidate template without `{branch}` would map every branch — and every collision suffix — onto one directory, so the resolver appends the branch slug to such templates and each branch keeps a directory of its own (`~/wt` → `~/wt/<slug>`).
 
 **Alternative considered:** trusting the marker or config blindly. Rejected — a stale `AGENTS.md` could point worktrees into an unusable location with no recovery.
 
@@ -62,7 +64,7 @@ whose captured value is a template (contains `{repo}` or `{branch}`) or a path. 
 ## Risks / Trade-offs
 
 - **Callers drift again** → the single `resolveWorktreeDir` is the only place paths are derived; tests assert creation, collision, and preview resolve identically.
-- **Template path lands inside the repo or a nested worktree** → `git worktree add` refuses such a path. Guard: if the resolved path is inside `targetDir` (or its worktrees), fall back to the next candidate.
+- **Template path lands inside the repo or a nested worktree** → `git worktree add` refuses such a path. Guard: if the resolved path (compared physically, via `realpath`, so symlinked parents can't defeat the check) is inside `targetDir` (or its worktrees), fall back to the next candidate.
 - **Writability check races with another run** → the existing suffix mechanism and a final `stat` in `branchNameTaken` still guard collisions; a failed create falls back to the next location.
 - **Two repos with the same directory name** (two `calisteniapp`) collide in a `{repo}`-based layout → the existing `-2`, `-3`… suffixing already picks a free branch/path.
 

--- a/openspec/changes/worktree-location/design.md
+++ b/openspec/changes/worktree-location/design.md
@@ -1,0 +1,76 @@
+## Context
+
+See proposal.md (Why) and the `worktree-location` delta spec for the target behavior.
+
+Today every worktree is placed by a single function, `worktreeDirFor(branch)` in `src/worktree.ts`, which returns the fixed path `~/.convoy/worktrees/<branch-slug>`. That function is used by four callers that must agree on the same path:
+
+- `createIsolatedWorktree` — actual creation (has the repo `targetDir`).
+- `branchNameTaken` / `ensureFreeBranchName` — the collision check that appends `-2`, `-3`, … (has `targetDir`).
+- `cli.ts` `checkInteractiveBranchName` — the launcher preview shown before confirmation (has `targetDir`).
+- `finish-command.ts` `resolveFinishDir` — resolves a worktree from a branch name alone, with **no** `targetDir`.
+
+This change generalizes location resolution while keeping all four callers consistent.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A single deterministic resolution order: documented repo convention → `defaults.worktreeLocation` → built-in default.
+- Template support with `{repo}` / `{branch}` placeholders and `~` expansion.
+- A machine-recognizable convention marker in repo docs; loose prose is ignored.
+- Every caller computes the identical resolved path, including collision suffixing.
+
+**Non-Goals:**
+- No change to conventional branch naming (already implemented; this work only verifies it).
+- No interpretation of arbitrary prose documentation via a model — only an explicit marker counts.
+- No renaming or relocation of existing worktrees; the change affects newly created ones only.
+
+## Decisions
+
+### 1. Centralize location resolution in `src/worktree.ts`
+Introduce a single resolver, e.g. `resolveWorktreeDir(branch, targetDir, ctx)`, that returns the final absolute path. Keep `worktreeDirFor(branch)` as a thin wrapper over the built-in default (`~/.convoy/worktrees/<slug>`) for the legacy fallback path.
+
+**Rationale:** one function keeps creation, collision-checking, preview, and lookups aligned; that is precisely what the change is meant to guarantee.
+**Alternative:** spreading the logic across the call sites — rejected because the four callers would drift.
+
+### 2 — Resolution order with a usability guard
+`resolveWorktreeDir` tries, in order: (1) the documented marker, (2) `config.defaults.worktreeLocation`, (3) the built-in default. For each, it expands the template and checks usability before accepting it; unusable candidates are skipped for the next one.
+
+**Usability check:** resolve the expanded path, ensure its parent exists (`mkdir -p` of the parent) and is a writable directory. If it cannot be made usable, try the next candidate. The built-in `~/.convoy/worktrees` is never skipped unless it is itself unusable.
+
+**Alternative considered:** trusting the marker or config blindly. Rejected — a stale `AGENTS.md` could point worktrees into an unusable location with no recovery.
+
+### 3 — Documented convention marker
+Scan the repo root's `AGENTS.md`, then `README.md`, for an explicit recognized line, e.g. a line matching:
+
+`/^\s*(?:worktrees?|worktree[ _-]?location)\s*[:=:-]\s*(.+)$/i`
+
+whose captured value is a template (contains `{repo}` or `{branch}`) or a path. `~` in the value expands to the home directory. The first match wins; no traversal and no prose interpretation.
+
+**Rationale:** cheap and deterministic — a regex over two files — which matches the "recognized, machine-readable marker" requirement.
+**Alternative:** asking the naming model to interpret the docs. More flexible but non-deterministic; rejected for the primary path (a possible later enhancement).
+
+### 4 — `finish --branch` resolves via `git worktree list`
+`resolveFinishDir` no longer reconstructs a fixed path from the branch name. It queries `git worktree list` in the repository's main checkout and matches the entry whose branch name matches. Only when absent does it fall back to `worktreeDirFor(branch)`.
+
+**Reason:** with variable locations, the branch name alone cannot determine the path; the worktree list is the source of truth.
+**Alternative:** matching a template in reverse — impossible because the creating template is not recorded.
+
+### 5 — Config plumbing
+- `defaults.worktreeLocation` added to `src/config.ts` as an optional path (validated), and surfaced in `src/config-tui.ts` with a description.
+- Config is passed into the resolver's context.
+
+## Risks / Trade-offs
+
+- **Callers drift again** → the single `resolveWorktreeDir` is the only place paths are derived; tests assert creation, collision, and preview resolve identically.
+- **Template path lands inside the repo or a nested worktree** → `git worktree add` refuses such a path. Guard: if the resolved path is inside `targetDir` (or its worktrees), fall back to the next candidate.
+- **Writability check races with another run** → the existing suffix mechanism and a final `stat` in `branchNameTaken` still guard collisions; a failed create falls back to the next location.
+- **Two repos with the same directory name** (two `calisteniapp`) collide in a `{repo}`-based layout → the existing `-2`, `-3`… suffixing already picks a free branch/path.
+
+## Migration Plan
+
+- Additive: with no config and no marker, behavior is byte-for-byte the current `~/.convoy/worktrees/<slug>`. Existing worktrees do not move; only new ones are affected.
+- Rollback: remove `defaults.worktreeLocation` (or the doc marker); resolution returns to current behavior with no data migration.
+
+## Open Questions
+
+None — the decisions above are settled and do not require user input.

--- a/openspec/changes/worktree-location/proposal.md
+++ b/openspec/changes/worktree-location/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Convoy (`spin`) always creates isolated git worktrees under the fixed global path `~/.convoy/worktrees/<branch-slug>`. When a project wants its worktrees co-located with the source (or in any other declared location), there is no way to express that convention, so Convoy silently ignores the team's preference. We want Convoy to resolve where a worktree lives through an explicit, deterministic priority order, and to honor a convention a repository documents about itself.
+
+## What Changes
+
+- Add a new configuration key, `defaults.worktreeLocation`, that accepts a path template with `{repo}` and `{branch}` placeholders (e.g. `~/dev/worktrees/{repo}/{branch}`).
+- When a repo documents its own worktree convention (an explicit template marker in `AGENTS.md` or `README.md`), honor it; otherwise fall back to the configured default and finally to the existing fixed path.
+- Keep the current behavior as the fallback: if no convention or config is present, or the resolved location cannot be used, worktrees go under `~/.convoy/worktrees/<branch-slug>`.
+- Ensure all decision points agree on the same resolved path: creation, collision/suffix checks (`-2`, `-3`, …), the launcher preview, and `convoy finish --branch` lookups (via `git worktree list`).
+- Keep branch naming conventional (`feat/…`, `fix/…`, `refactor/…`, `chore/…`, …). This already works today and is only verified, not changed.
+
+## Capabilities
+
+### New Capabilities
+- `worktree-location`: how Convoy resolves and creates the directory for an isolated git worktree, including config override, documented repository convention, the deterministic fallback, and the guard that keeps every caller on the same path.
+
+### Modified Capabilities
+<!-- No existing capabilities exist yet (openspec/specs is empty); this is a new capability. -->
+
+## Impact
+
+- **`src/worktree.ts`**: `worktreeDirFor`, `branchNameTaken`, `ensureFreeBranchName`, `createIsolatedWorktree` — location resolution and collision checks.
+- **`src/config.ts` / `src/config-tui.ts`**: new `defaults.worktreeLocation` key with validation and TUI description.
+- **`src/cli.ts`**: launcher preview of the resolved worktree directory; `--worktree` help text.
+- **`src/finish-command.ts`**: resolve a worktree by branch via `git worktree list` when it is not at the default location.
+- **Docs/help text** that currently hard-codes `~/.convoy/worktrees`.
+- **Tests**: `test/worktree*.test.ts` and new coverage for template resolution, convention detection, and fallback.

--- a/openspec/changes/worktree-location/specs/worktree-location/spec.md
+++ b/openspec/changes/worktree-location/specs/worktree-location/spec.md
@@ -33,6 +33,10 @@ A configured or documented worktree location SHALL support `{repo}` and `{branch
 - **WHEN** the location is `~/dev/worktrees/{repo}/{branch}`, the repository directory is `calisteniapp`, and the branch slug is `feat-new-feature`
 - **THEN** the resolved worktree directory is `~/dev/worktrees/calisteniapp/feat-new-feature`
 
+#### Scenario: Location without `{branch}` still separates branches
+- **WHEN** the configured or documented location has no `{branch}` placeholder (for example the fixed path `~/wt`)
+- **THEN** Convoy appends the branch slug so each branch resolves to its own directory (`~/wt/<branch-slug>`)
+
 ### Requirement: Repository-documented convention
 Convoy SHALL honor an explicit worktree-location convention declared in the repository's documentation (for example `AGENTS.md` or `README.md`) when that declaration is a recognized, machine-readable marker. Loose prose SHALL NOT be interpreted as a convention.
 

--- a/openspec/changes/worktree-location/specs/worktree-location/spec.md
+++ b/openspec/changes/worktree-location/specs/worktree-location/spec.md
@@ -1,0 +1,63 @@
+## Purpose
+
+Defines how Convoy resolves and creates the directory for an isolated git worktree, so a project can declare where its worktrees live and every decision point falls back to a deterministic default.
+
+## ADDED Requirements
+
+### Requirement: Worktree location resolution order
+Convoy SHALL resolve the directory for an isolated worktree from, in order: the repository's documented worktree convention, the configured `defaults.worktreeLocation`, and the built-in default. The first usable location SHALL be used; a declared or configured location that is not usable SHALL be skipped in favor of the next option.
+
+#### Scenario: Repo convention wins over config
+- **WHEN** the repository's documentation declares a worktree convention and `defaults.worktreeLocation` is also set
+- **THEN** Convoy creates the worktree using the repository's documented convention
+
+#### Scenario: Config wins over built-in default
+- **WHEN** no repository convention is declared but `defaults.worktreeLocation` is set
+- **THEN** Convoy creates the worktree using the configured template
+
+#### Scenario: Unusable declared location falls back
+- **WHEN** the documented or configured location cannot be created (missing, non-writable, or unsafe)
+- **THEN** Convoy falls back to the next available option, ultimately the built-in default
+
+### Requirement: Built-in default location
+When no convention or configuration applies, Convoy SHALL create isolated worktrees under `~/.convoy/worktrees/<branch-slug>`, where `<branch-slug>` is a filesystem-safe form of the branch name.
+
+#### Scenario: No convention or config
+- **WHEN** the repository declares no worktree convention and `defaults.worktreeLocation` is unset
+- **THEN** Convoy creates the worktree under `~/.convoy/worktrees/<branch-slug>`
+
+### Requirement: Location templates with placeholders
+A configured or documented worktree location SHALL support `{repo}` and `{branch}` placeholders. `{repo}` SHALL expand to the repository directory name, and `{branch}` SHALL expand to the filesystem-safe branch slug. A leading `~` in a location SHALL expand to the user's home directory.
+
+#### Scenario: Location template expands placeholders
+- **WHEN** the location is `~/dev/worktrees/{repo}/{branch}`, the repository directory is `calisteniapp`, and the branch slug is `feat-new-feature`
+- **THEN** the resolved worktree directory is `~/dev/worktrees/calisteniapp/feat-new-feature`
+
+### Requirement: Repository-documented convention
+Convoy SHALL honor an explicit worktree-location convention declared in the repository's documentation (for example `AGENTS.md` or `README.md`) when that declaration is a recognized, machine-readable marker. Loose prose SHALL NOT be interpreted as a convention.
+
+#### Scenario: Recognized marker in documentation
+- **WHEN** `AGENTS.md` contains an explicit worktree-location marker with a valid template
+- **THEN** Convoy uses that template to create the worktree
+
+#### Scenario: No recognizable marker
+- **WHEN** the documentation contains no explicit, recognized worktree-location marker
+- **THEN** Convoy ignores the documentation and uses the configured or built-in default
+
+### Requirement: Consistent path across decision points
+All Convoy operations that reason about a worktree by its name SHALL resolve to the same path: creation, the collision check that appends `-2`, `-3`, … to avoid clobbering, the launcher preview shown before confirmation, and lookups that locate an existing worktree (via `git worktree list` when it is not at the built-in default). A path already considered taken for a branch SHALL never be handed to `git worktree add` again.
+
+#### Scenario: Suffix avoids collision at a declared location
+- **WHEN** a worktree already exists at the resolved location for a branch
+- **THEN** Convoy uses a suffixed branch and location (`-2`, `-3`, …) so no collision occurs
+
+#### Scenario: Finish locates a non-default worktree
+- **WHEN** `convoy finish --branch <name>` targets a worktree that is not at the built-in default location
+- **THEN** Convoy locates the worktree from the repository's worktree list rather than assuming a fixed path
+
+### Requirement: Conventional branch naming preserved
+Branch names proposed for worktrees SHALL remain conventional and semantic, prefixed with one of `feat`, `fix`, `refactor`, `perf`, `docs`, `test`, `chore`, `build`, `ci`. This change SHALL NOT alter branch-naming behavior.
+
+#### Scenario: Branch naming unchanged
+- **WHEN** Convoy proposes a branch for a new work
+- **THEN** the branch is a conventional, prefixed, semantic name (unchanged by this change)

--- a/openspec/changes/worktree-location/tasks.md
+++ b/openspec/changes/worktree-location/tasks.md
@@ -1,0 +1,30 @@
+## 1. Location resolver in src/worktree.ts
+
+- [ ] 1.1 Add a template expansion helper (`expandLocationTemplate`) that substitutes `{repo}`, `{branch}`, and a leading `~`; verify with unit tests for `~/dev/worktrees/{repo}/{branch}`, missing placeholders, and `~` expansion.
+- [ ] 1.2 Implement `resolveWorktreeDir(branch, targetDir, ctx)` applying the resolution order (documented marker → `defaults.worktreeLocation` → built-in default) with a usability guard (parent made writable via `mkdir -p`); verify unit tests cover the priority order and fallback on an unusable candidate.
+- [ ] 1.3 Add the recognized marker scan of repo-root `AGENTS.md` then `README.md` (regex-based) and verify tests for a matched marker, a non-matching prose-only doc, and a marker with an invalid template falling through.
+- [ ] 1.4 Add a guard rejecting a resolved path that is inside `targetDir` (or its worktrees), falling back to the next candidate; verify with a unit test for a self-nested template.
+- [ ] 1.5 Keep `worktreeDirFor(branch)` as a thin wrapper over the built-in default and verify existing `slugifyBranch`/`worktreeDirFor` tests still pass.
+
+## 2. Collision checks on the resolved path
+
+- [ ] 2.1 Update `branchNameTaken` / `ensureFreeBranchName` to check collisions on the *resolved* location rather than only the default, so suffixes `-2`, `-3`, … apply to declared layouts; verify with tests that a taken resolved path yields a suffixed branch/path.
+- [ ] 2.2 Ensure `createIsolatedWorktree` creates the resolved location (and parent dirs) before `addWorktree`; verify an integration test that a worktree lands at the resolved path.
+
+## 3. Config plumbing
+
+- [ ] 3.1 Add `defaults.worktreeLocation` to `src/config.ts` with validation (optional path/template) and verify config parsing/validation tests pass.
+- [ ] 3.2 Surface the key in `src/config-tui.ts` with a description and verify the config TUI renders it.
+- [ ] 3.3 Wire the config value into the resolver context in `src/cli.ts` and verify a run with `defaults.worktreeLocation` set creates the worktree at the resolved path.
+
+## 4. Launcher preview and finish
+
+- [ ] 4.1 Update `checkInteractiveBranchName` in `src/cli.ts` to preview the resolved directory (not just the default) and verify the preview matches the created path.
+- [ ] 4.2 Update `resolveFinishDir` in `src/finish-command.ts` to locate the worktree via `git worktree list`, falling back to the built-in default only when absent; verify with a test for a non-default worktree.
+- [ ] 4.3 Update `--worktree` help text and any strings hard-coding `~/.convoy/worktrees`; verify the help output reflects configurable locations.
+
+## 5. Tests and validation
+
+- [ ] 5.1 Add/update unit tests in `test/worktree*.test.ts` covering template expansion, marker detection, resolution order, fallback, and collision suffixing; verify `bun test` passes.
+- [ ] 5.2 Add integration coverage for `finish --branch` on a non-default worktree; verify the command locates and finishes the correct worktree.
+- [ ] 5.3 Run `bun run typecheck` and the full test suite; verify no regressions in existing worktree behavior.

--- a/openspec/changes/worktree-location/tasks.md
+++ b/openspec/changes/worktree-location/tasks.md
@@ -1,30 +1,30 @@
 ## 1. Location resolver in src/worktree.ts
 
-- [ ] 1.1 Add a template expansion helper (`expandLocationTemplate`) that substitutes `{repo}`, `{branch}`, and a leading `~`; verify with unit tests for `~/dev/worktrees/{repo}/{branch}`, missing placeholders, and `~` expansion.
-- [ ] 1.2 Implement `resolveWorktreeDir(branch, targetDir, ctx)` applying the resolution order (documented marker → `defaults.worktreeLocation` → built-in default) with a usability guard (parent made writable via `mkdir -p`); verify unit tests cover the priority order and fallback on an unusable candidate.
-- [ ] 1.3 Add the recognized marker scan of repo-root `AGENTS.md` then `README.md` (regex-based) and verify tests for a matched marker, a non-matching prose-only doc, and a marker with an invalid template falling through.
-- [ ] 1.4 Add a guard rejecting a resolved path that is inside `targetDir` (or its worktrees), falling back to the next candidate; verify with a unit test for a self-nested template.
-- [ ] 1.5 Keep `worktreeDirFor(branch)` as a thin wrapper over the built-in default and verify existing `slugifyBranch`/`worktreeDirFor` tests still pass.
+- [x] 1.1 Add a template expansion helper (`expandLocationTemplate`) that substitutes `{repo}`, `{branch}`, and a leading `~`; verify with unit tests for `~/dev/worktrees/{repo}/{branch}`, missing placeholders, and `~` expansion.
+- [x] 1.2 Implement `resolveWorktreeDir(branch, targetDir, ctx)` applying the resolution order (documented marker → `defaults.worktreeLocation` → built-in default) with a usability guard (parent made writable via `mkdir -p`); verify unit tests cover the priority order and fallback on an unusable candidate.
+- [x] 1.3 Add the recognized marker scan of repo-root `AGENTS.md` then `README.md` (regex-based) and verify tests for a matched marker, a non-matching prose-only doc, and a marker with an invalid template falling through.
+- [x] 1.4 Add a guard rejecting a resolved path that is inside `targetDir` (or its worktrees), falling back to the next candidate; verify with a unit test for a self-nested template.
+- [x] 1.5 Keep `worktreeDirFor(branch)` as a thin wrapper over the built-in default and verify existing `slugifyBranch`/`worktreeDirFor` tests still pass.
 
 ## 2. Collision checks on the resolved path
 
-- [ ] 2.1 Update `branchNameTaken` / `ensureFreeBranchName` to check collisions on the *resolved* location rather than only the default, so suffixes `-2`, `-3`, … apply to declared layouts; verify with tests that a taken resolved path yields a suffixed branch/path.
-- [ ] 2.2 Ensure `createIsolatedWorktree` creates the resolved location (and parent dirs) before `addWorktree`; verify an integration test that a worktree lands at the resolved path.
+- [x] 2.1 Update `branchNameTaken` / `ensureFreeBranchName` to check collisions on the *resolved* location rather than only the default, so suffixes `-2`, `-3`, … apply to declared layouts; verify with tests that a taken resolved path yields a suffixed branch/path.
+- [x] 2.2 Ensure `createIsolatedWorktree` creates the resolved location (and parent dirs) before `addWorktree`; verify an integration test that a worktree lands at the resolved path.
 
 ## 3. Config plumbing
 
-- [ ] 3.1 Add `defaults.worktreeLocation` to `src/config.ts` with validation (optional path/template) and verify config parsing/validation tests pass.
-- [ ] 3.2 Surface the key in `src/config-tui.ts` with a description and verify the config TUI renders it.
-- [ ] 3.3 Wire the config value into the resolver context in `src/cli.ts` and verify a run with `defaults.worktreeLocation` set creates the worktree at the resolved path.
+- [x] 3.1 Add `defaults.worktreeLocation` to `src/config.ts` with validation (optional path/template) and verify config parsing/validation tests pass.
+- [x] 3.2 Surface the key in `src/config-tui.ts` with a description and verify the config TUI renders it.
+- [x] 3.3 Wire the config value into the resolver context in `src/cli.ts` and verify a run with `defaults.worktreeLocation` set creates the worktree at the resolved path.
 
 ## 4. Launcher preview and finish
 
-- [ ] 4.1 Update `checkInteractiveBranchName` in `src/cli.ts` to preview the resolved directory (not just the default) and verify the preview matches the created path.
-- [ ] 4.2 Update `resolveFinishDir` in `src/finish-command.ts` to locate the worktree via `git worktree list`, falling back to the built-in default only when absent; verify with a test for a non-default worktree.
-- [ ] 4.3 Update `--worktree` help text and any strings hard-coding `~/.convoy/worktrees`; verify the help output reflects configurable locations.
+- [x] 4.1 Update `checkInteractiveBranchName` in `src/cli.ts` to preview the resolved directory (not just the default) and verify the preview matches the created path.
+- [x] 4.2 Update `resolveFinishDir` in `src/finish-command.ts` to locate the worktree via `git worktree list`, falling back to the built-in default only when absent; verify with a test for a non-default worktree.
+- [x] 4.3 Update `--worktree` help text and any strings hard-coding `~/.convoy/worktrees`; verify the help output reflects configurable locations.
 
 ## 5. Tests and validation
 
-- [ ] 5.1 Add/update unit tests in `test/worktree*.test.ts` covering template expansion, marker detection, resolution order, fallback, and collision suffixing; verify `bun test` passes.
-- [ ] 5.2 Add integration coverage for `finish --branch` on a non-default worktree; verify the command locates and finishes the correct worktree.
-- [ ] 5.3 Run `bun run typecheck` and the full test suite; verify no regressions in existing worktree behavior.
+- [x] 5.1 Add/update unit tests in `test/worktree*.test.ts` covering template expansion, marker detection, resolution order, fallback, and collision suffixing; verify `bun test` passes.
+- [x] 5.2 Add integration coverage for `finish --branch` on a non-default worktree; verify the command locates and finishes the correct worktree.
+- [x] 5.3 Run `bun run typecheck` and the full test suite; verify no regressions in existing worktree behavior.

--- a/openspec/changes/worktree-location/tasks.md
+++ b/openspec/changes/worktree-location/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Location resolver in src/worktree.ts
 
 - [x] 1.1 Add a template expansion helper (`expandLocationTemplate`) that substitutes `{repo}`, `{branch}`, and a leading `~`; verify with unit tests for `~/dev/worktrees/{repo}/{branch}`, missing placeholders, and `~` expansion.
-- [x] 1.2 Implement `resolveWorktreeDir(branch, targetDir, ctx)` applying the resolution order (documented marker → `defaults.worktreeLocation` → built-in default) with a usability guard (parent made writable via `mkdir -p`); verify unit tests cover the priority order and fallback on an unusable candidate.
+- [x] 1.2 Implement `resolveWorktreeDir(branch, targetDir, ctx)` applying the resolution order (documented marker → `defaults.worktreeLocation` → built-in default) with a usability guard (nearest existing ancestor writable, checked without creating anything); verify unit tests cover the priority order and fallback on an unusable candidate.
 - [x] 1.3 Add the recognized marker scan of repo-root `AGENTS.md` then `README.md` (regex-based) and verify tests for a matched marker, a non-matching prose-only doc, and a marker with an invalid template falling through.
 - [x] 1.4 Add a guard rejecting a resolved path that is inside `targetDir` (or its worktrees), falling back to the next candidate; verify with a unit test for a self-nested template.
 - [x] 1.5 Keep `worktreeDirFor(branch)` as a thin wrapper over the built-in default and verify existing `slugifyBranch`/`worktreeDirFor` tests still pass.
@@ -28,3 +28,10 @@
 - [x] 5.1 Add/update unit tests in `test/worktree*.test.ts` covering template expansion, marker detection, resolution order, fallback, and collision suffixing; verify `bun test` passes.
 - [x] 5.2 Add integration coverage for `finish --branch` on a non-default worktree; verify the command locates and finishes the correct worktree.
 - [x] 5.3 Run `bun run typecheck` and the full test suite; verify no regressions in existing worktree behavior.
+
+## 6. Review fixes
+
+- [x] 6.1 A location template without `{branch}` appends the branch slug, so every branch and every collision suffix keeps its own directory; verify with resolution tests and a second-run integration test at a fixed-path location.
+- [x] 6.2 The usability probe is read-only (nearest existing ancestor writable) — the launcher preview and collision checks no longer create directories; `createIsolatedWorktree` alone makes the parent chain; verify resolution leaves the filesystem untouched.
+- [x] 6.3 The inside-repo guard compares physical (`realpath`) paths and only treats a true parent traversal (`..`, `../`) as outside; verify a symlinked parent pointing into the repo falls back to the next candidate.
+- [x] 6.4 The config TUI field is covered by tests asserting it is listed with its template hint and description (the hint moved from a hard-coded key check onto the field itself); verify `test/config-tui.test.ts` passes.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -565,13 +565,15 @@ async function proposeInteractiveBranchName(targetDir: string, input: { prompt: 
 
 /** Sanitizes a candidate branch name and reports the free name it would take, plus its worktree path. */
 async function checkInteractiveBranchName(targetDir: string, name: string): Promise<LaunchBranchCheck> {
-  const { cleanBranchName, ensureFreeBranchName, worktreeDirFor } = await import("./worktree")
+  const { cleanBranchName, ensureFreeBranchName, resolveWorktreeDir } = await import("./worktree")
   // A hand-written name keeps whatever prefix (or none) the user chose; only
   // the model's proposals are held to the conventional `type/` shape.
   const cleaned = cleanBranchName(name, { authored: true })
   if (!cleaned) return { branch: "", dir: "" }
   const free = await ensureFreeBranchName(cleaned, targetDir)
-  return { branch: free, dir: worktreeDirFor(free), ...(free === cleaned ? {} : { suffixed: true }) }
+  // The preview must resolve the same way creation does, so what the user
+  // confirms is the directory the worktree actually lands in.
+  return { branch: free, dir: await resolveWorktreeDir(free, targetDir), ...(free === cleaned ? {} : { suffixed: true }) }
 }
 
 /**
@@ -1288,7 +1290,8 @@ Flags:
   --no-human-step          Drop all human steps (alias: --no-human-review)
   --max-concurrent <n>     Max agents running at once within a parallel group (default: ${defaultMaxConcurrentAgents}); smaller groups are unaffected
   --base <ref>             Branch/base for calculating diffs (default: auto-detected — origin's default branch, else main/master/develop/trunk, else the current branch)
-  --worktree               Run on a fresh branch in its own worktree under ~/.convoy/worktrees
+  --worktree               Run on a fresh branch in its own worktree
+                           (location: repo convention, then defaults.worktreeLocation, then ~/.convoy/worktrees)
   --no-worktree            Run in the current working tree instead
                            (default: worktree on a trunk branch, current tree on any other)
   --branch <name>          Name for the worktree branch, instead of asking the naming model
@@ -1318,8 +1321,8 @@ Config files:
                            present once you eject one, and they shadow the built-in
 
 Config keys:
-  defaults:                model, baseRef, pipeline, worktree, prdHistory, autoAcceptJudgeModel,
-                           branchNameModel, commitMessageModel
+  defaults:                model, baseRef, pipeline, worktree, worktreeLocation, prdHistory,
+                           autoAcceptJudgeModel, branchNameModel, commitMessageModel
   modelRouting:            gateway and explicit per-logical-model overrides
   agents:                  project agents or built-in overrides; prompts live at agents/<name>.md
   pipelines:               named step lists mixing agents and human gates

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -116,20 +116,25 @@ type RowMeta =
   | { t: "add-pipeline" }
   | { t: "builtin"; name: string }
 
-type DefaultField = { key: keyof ConvoyDefaults; type: "model" | "number" | "string" | "boolean" }
+type DefaultField = {
+  key: keyof ConvoyDefaults
+  type: "model" | "number" | "string" | "boolean"
+  /** Shown as the string editor's placeholder instead of the generic "text, empty to clear". */
+  hint?: string
+}
 
 type Row = {
   chunks: (selected: boolean, width: number) => TextChunk[]
   meta?: RowMeta
 }
 
-const defaultFields: DefaultField[] = [
+export const defaultFields: DefaultField[] = [
   { key: "model", type: "model" },
   { key: "autoAcceptJudgeModel", type: "model" },
   { key: "branchNameModel", type: "model" },
   { key: "commitMessageModel", type: "model" },
   { key: "worktree", type: "boolean" },
-  { key: "worktreeLocation", type: "string" },
+  { key: "worktreeLocation", type: "string", hint: "{repo}/{branch} template, empty to clear" },
   { key: "prdHistory", type: "boolean" },
   { key: "baseRef", type: "string" },
   { key: "pipeline", type: "string" },
@@ -629,7 +634,7 @@ export class ConfigEditor {
     this.openInput(
       `defaults.${field.key}`,
       current === undefined ? "" : String(current),
-      field.key === "worktreeLocation" ? "{repo}/{branch} template, empty to clear" : "text, empty to clear",
+      field.hint ?? "text, empty to clear",
       {
         commit: (value) => {
           setDefault(config.defaults, field.key, value.trim() === "" ? undefined : value.trim())
@@ -1988,7 +1993,7 @@ function optionHint(option: ModelChoice | ChooseItem): string {
   return option.hint ?? ""
 }
 
-function describeDefault(key: keyof ConvoyDefaults): string {
+export function describeDefault(key: keyof ConvoyDefaults): string {
   switch (key) {
     case "model":
       return "Default model for steps with no model of their own."

--- a/src/config-tui.ts
+++ b/src/config-tui.ts
@@ -129,6 +129,7 @@ const defaultFields: DefaultField[] = [
   { key: "branchNameModel", type: "model" },
   { key: "commitMessageModel", type: "model" },
   { key: "worktree", type: "boolean" },
+  { key: "worktreeLocation", type: "string" },
   { key: "prdHistory", type: "boolean" },
   { key: "baseRef", type: "string" },
   { key: "pipeline", type: "string" },
@@ -625,12 +626,17 @@ export class ConfigEditor {
       })
       return
     }
-    this.openInput(`defaults.${field.key}`, current === undefined ? "" : String(current), "text, empty to clear", {
-      commit: (value) => {
-        setDefault(config.defaults, field.key, value.trim() === "" ? undefined : value.trim())
-        this.markDirty()
+    this.openInput(
+      `defaults.${field.key}`,
+      current === undefined ? "" : String(current),
+      field.key === "worktreeLocation" ? "{repo}/{branch} template, empty to clear" : "text, empty to clear",
+      {
+        commit: (value) => {
+          setDefault(config.defaults, field.key, value.trim() === "" ? undefined : value.trim())
+          this.markDirty()
+        },
       },
-    })
+    )
   }
 
   private editGateway() {
@@ -1994,6 +2000,8 @@ function describeDefault(key: keyof ConvoyDefaults): string {
       return "Model that writes the squashed commit message for finish (default: anthropic/claude-haiku-4-5)."
     case "worktree":
       return "Run each job on a fresh branch in its own worktree. Unset decides per branch: on for a trunk, off once you're on a branch."
+    case "worktreeLocation":
+      return "Where isolated worktrees are created ({repo}/{branch} template, ~ = home). A marker in AGENTS.md or README.md wins; unset is ~/.convoy/worktrees."
     case "prdHistory":
       return "Store git-ignored copies of prompts in .convoy/prd-history and attach the original branch PRD to opted-in steps. Unset is on."
     case "baseRef":

--- a/src/config.ts
+++ b/src/config.ts
@@ -76,6 +76,14 @@ export type ConvoyDefaults = {
    * not "on": it decides per branch, isolating only when HEAD sits on a trunk.
    */
   worktree?: boolean
+  /**
+   * Where isolated worktrees are created, as a path template with optional
+   * `{repo}` and `{branch}` placeholders and a leading `~` for home (e.g.
+   * `~/dev/worktrees/{repo}/{branch}`). Unset means the built-in
+   * `~/.convoy/worktrees/<branch-slug>`; a convention the repo documents for
+   * itself outranks this, and an unusable location falls back to the next one.
+   */
+  worktreeLocation?: string
   /** Persist and attach the git-ignored original PRD history; defaults to true. */
   prdHistory?: boolean
   /** Advising model for every step that doesn't set its own; unset means no advisor anywhere. */
@@ -268,6 +276,7 @@ defaults:
   # branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731 # optional: model that names worktree branches
   # commitMessageModel: anthropic/claude-haiku-4-5 # optional: model that writes the squashed commit message for "convoy finish"
   # worktree: true # optional: force a fresh branch + worktree for every run; false always runs in the current tree. Unset decides per branch: isolate on a trunk (main/master/develop/trunk or the detected base), run in place on any other branch
+  # worktreeLocation: ~/dev/worktrees/{repo}/{branch} # optional: where isolated worktrees are created ({repo}/{branch} placeholders, ~ = home). A marker in the repo's AGENTS.md/README.md outranks this; unusable locations fall back to ~/.convoy/worktrees
   # prdHistory: true # optional: store a git-ignored copy of each run's prompt in .convoy/prd-history; false disables history writes and scope attachments
   # advisor: anthropic/claude-opus-5 # optional: reviewing model consulted at phase decision points
   # advisorMaxCalls: 1000 # optional: consultation budget per phase attempt; the default is effectively unlimited, set this to put a real cap on it
@@ -639,6 +648,7 @@ function validateDefaults(v: Validator, raw: unknown): ConvoyDefaults {
     "branchNameModel",
     "commitMessageModel",
     "worktree",
+    "worktreeLocation",
     "prdHistory",
     "advisor",
     "advisorMaxCalls",
@@ -655,6 +665,7 @@ function validateDefaults(v: Validator, raw: unknown): ConvoyDefaults {
   if (record.branchNameModel !== undefined) defaults.branchNameModel = v.model(record.branchNameModel, "defaults.branchNameModel")
   if (record.commitMessageModel !== undefined) defaults.commitMessageModel = v.model(record.commitMessageModel, "defaults.commitMessageModel")
   if (record.worktree !== undefined) defaults.worktree = v.boolean(record.worktree, "defaults.worktree")
+  if (record.worktreeLocation !== undefined) defaults.worktreeLocation = v.nonEmptyString(record.worktreeLocation, "defaults.worktreeLocation")
   if (record.prdHistory !== undefined) defaults.prdHistory = v.boolean(record.prdHistory, "defaults.prdHistory")
   if (record.advisor !== undefined) defaults.advisor = v.model(record.advisor, "defaults.advisor")
   if (record.advisorMaxCalls !== undefined) defaults.advisorMaxCalls = v.positiveInt(record.advisorMaxCalls, "defaults.advisorMaxCalls")

--- a/src/config.ts
+++ b/src/config.ts
@@ -276,7 +276,7 @@ defaults:
   # branchNameModel: openrouter/deepseek/deepseek-v4-flash-0731 # optional: model that names worktree branches
   # commitMessageModel: anthropic/claude-haiku-4-5 # optional: model that writes the squashed commit message for "convoy finish"
   # worktree: true # optional: force a fresh branch + worktree for every run; false always runs in the current tree. Unset decides per branch: isolate on a trunk (main/master/develop/trunk or the detected base), run in place on any other branch
-  # worktreeLocation: ~/dev/worktrees/{repo}/{branch} # optional: where isolated worktrees are created ({repo}/{branch} placeholders, ~ = home). A marker in the repo's AGENTS.md/README.md outranks this; unusable locations fall back to ~/.convoy/worktrees
+  # worktreeLocation: ~/dev/worktrees/{repo}/{branch} # optional: where isolated worktrees are created ({repo}/{branch} placeholders, ~ = home; the branch slug is appended when {branch} is missing). A marker in the repo's AGENTS.md/README.md outranks this; unusable locations fall back to ~/.convoy/worktrees
   # prdHistory: true # optional: store a git-ignored copy of each run's prompt in .convoy/prd-history; false disables history writes and scope attachments
   # advisor: anthropic/claude-opus-5 # optional: reviewing model consulted at phase decision points
   # advisorMaxCalls: 1000 # optional: consultation budget per phase attempt; the default is effectively unlimited, set this to put a real cap on it

--- a/src/finish-command.ts
+++ b/src/finish-command.ts
@@ -93,12 +93,17 @@ export async function runFinishCommand(options: FinishOptions, deps: FinishComma
 /** `--branch` finishes another run's worktree; otherwise the current directory is the run's checkout. */
 async function resolveFinishDir(options: FinishOptions): Promise<string> {
   if (!options.branch) return options.targetDir
+  // Worktree locations are configurable (repo convention, defaults.worktreeLocation),
+  // so the branch name alone can't reconstruct a path: the repo's worktree list is
+  // the source of truth. The built-in default is only a fallback for worktrees
+  // created before locations were configurable.
+  const { findWorktreeDirForBranch } = await import("./git")
   const { worktreeDirFor } = await import("./worktree")
-  const dir = worktreeDirFor(options.branch)
+  const dir = (await findWorktreeDirForBranch(options.branch, options.targetDir)) ?? worktreeDirFor(options.branch)
   // Without this the first git call fails on a missing cwd with a spawn error
   // that says nothing about which branch or path was meant.
   if (!(await directoryExists(dir))) {
-    throw new Error(`no convoy worktree for branch "${options.branch}" at ${dir}; run convoy finish from the checkout holding that branch instead`)
+    throw new Error(`no worktree for branch "${options.branch}" at ${dir}; run convoy finish from the checkout holding that branch instead`)
   }
   return dir
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -405,6 +405,34 @@ export async function removeWorktree(dir: string, cwd: string) {
   await execFile("git", ["worktree", "remove", "--", dir], { cwd })
 }
 
+/**
+ * The checkout of `<branch>` among the repo's worktrees, or undefined when no
+ * worktree has that branch checked out. With configurable worktree locations
+ * the branch name alone can't reconstruct a path, so `git worktree list` is the
+ * source of truth for lookups (`convoy finish --branch`).
+ */
+export async function findWorktreeDirForBranch(branch: string, cwd: string): Promise<string | undefined> {
+  const result = await execFile("git", ["worktree", "list", "--porcelain"], { cwd, allowFailure: true })
+  if (result.exitCode !== 0) return undefined
+  let dir: string | undefined
+  let current: string | undefined
+  const flush = () => {
+    if (current === branch && dir) return dir
+    dir = undefined
+    current = undefined
+    return undefined
+  }
+  for (const line of result.stdout.split("\n")) {
+    if (line.startsWith("worktree ")) dir = line.slice("worktree ".length)
+    else if (line.startsWith("branch ")) current = line.slice("branch refs/heads/".length)
+    else if (line === "") {
+      const found = flush()
+      if (found) return found
+    }
+  }
+  return flush()
+}
+
 /** The checked-out branch, or undefined when HEAD is detached. */
 export async function currentBranch(cwd: string): Promise<string | undefined> {
   const result = await execFile("git", ["symbolic-ref", "--quiet", "--short", "HEAD"], { cwd, allowFailure: true })

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,9 +1,10 @@
-import { mkdir, readFile, stat } from "node:fs/promises"
+import { access, constants, mkdir, readFile, stat } from "node:fs/promises"
 import { homedir } from "node:os"
-import { isAbsolute, join, resolve } from "node:path"
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path"
 
 import type { AgentConfig, Config, OpencodeClient } from "@opencode-ai/sdk/v2"
 
+import { loadMergedConvoyConfig, type ConvoyConfig } from "./config"
 import { addWorktree, branchExists } from "./git"
 import { log } from "./log"
 import { startOpencode } from "./opencode"
@@ -110,18 +111,20 @@ function namerOpencodeConfig(): Config {
 }
 
 /**
- * Creates a new git branch checked out in a dedicated worktree under
- * `~/.convoy/worktrees/<slug>`, so Convoy runs against an isolated checkout
- * instead of the user's current working tree. The branch name is decided (and
- * confirmed by the user) before this is called.
+ * Creates a new git branch checked out in a dedicated worktree, so Convoy runs
+ * against an isolated checkout instead of the user's current working tree. The
+ * branch name is decided (and confirmed by the user) before this is called.
+ * The worktree location is resolved through `resolveWorktreeDir` — repo
+ * convention, `defaults.worktreeLocation`, or the built-in default — and the
+ * branch was already collision-checked on that same resolved location.
  */
 export async function createIsolatedWorktree(input: WorktreeInput): Promise<WorktreeResult> {
   const base = input.baseRef ?? "HEAD"
   // Re-check right before creating: the name was validated in the launcher, and
   // anything could have claimed it since (a parallel convoy, a manual branch).
   const branch = await ensureFreeBranchName(input.branch, input.targetDir)
-  const dir = worktreeDirFor(branch)
-  await mkdir(join(convoyHome(), "worktrees"), { recursive: true })
+  const dir = await resolveWorktreeDir(branch, input.targetDir)
+  await mkdir(dirname(dir), { recursive: true })
   await addWorktree(dir, branch, base, input.targetDir)
   log.info(`created worktree at ${dir} on branch ${branch}`)
   return { dir, branch }
@@ -130,6 +133,116 @@ export async function createIsolatedWorktree(input: WorktreeInput): Promise<Work
 /** Where the worktree for `branch` lives; the directory slug flattens the `type/` prefix. */
 export function worktreeDirFor(branch: string): string {
   return join(convoyHome(), "worktrees", slugifyBranch(branch))
+}
+
+/** Optional context for worktree-location resolution. */
+export type WorktreeLocationContext = {
+  /** Pre-loaded merged convoy config; loaded from `targetDir` when omitted. */
+  config?: ConvoyConfig
+}
+
+/**
+ * Substitutes `{repo}`, `{branch}`, and a leading `~` in a worktree-location
+ * template. `{repo}` is the repository directory name and `{branch}` the
+ * filesystem-safe branch slug. Placeholders are optional: a template without
+ * them is a fixed path, and suffixing still separates branches.
+ */
+export function expandLocationTemplate(template: string, values: { repo: string; branch: string }): string {
+  const expanded = template.replaceAll("{repo}", values.repo).replaceAll("{branch}", values.branch)
+  if (expanded === "~") return homedir()
+  if (expanded.startsWith("~/")) return resolve(homedir(), expanded.slice(2))
+  return expanded
+}
+
+/**
+ * A repo can document where it wants its worktrees with an explicit marker
+ * line (`worktree location: ~/dev/wt/{repo}/{branch}`) in AGENTS.md, then
+ * README.md. Only the recognized, machine-readable marker counts — loose prose
+ * ("we keep worktrees elsewhere") is never interpreted. The first match wins.
+ */
+const worktreeMarkerRegex =
+  /^\s*(?:[-*+]\s+|>\s*)?(?:\*\*)?\s*(?:worktree[ _-]?location|worktrees?)\s*(?:\*\*)?\s*[:=\u2013\u2014-]\s*(.+)$/i
+
+/** A marker's captured value must be a template or a path, never a sentence. */
+function looksLikeLocationValue(value: string): boolean {
+  if (/\{(?:repo|branch)\}/.test(value)) return true
+  return value.startsWith("~") || /^(?:\/|\.\.?\/)/.test(value)
+}
+
+export async function documentedWorktreeConvention(targetDir: string): Promise<string | undefined> {
+  for (const name of ["AGENTS.md", "README.md"]) {
+    let text: string
+    try {
+      text = await readFile(join(targetDir, name), "utf8")
+    } catch {
+      continue
+    }
+    // Fenced code blocks are examples (a README showing a sample config.yaml),
+    // not conventions, so the scan never takes a marker from inside one.
+    let inFence = false
+    for (const line of text.split("\n")) {
+      if (/^\s*(?:```|~~~)/.test(line)) {
+        inFence = !inFence
+        continue
+      }
+      if (inFence) continue
+      const match = worktreeMarkerRegex.exec(line)
+      if (!match) continue
+      // Strip the trailing "# explanation" (decoration, not part of the path)
+      // before backticks so a `` `path` # comment `` marker loses both.
+      const value = match[1]!
+        .trim()
+        .replace(/\s+#.*$/, "")
+        .replace(/^`+|`+$/g, "")
+        .trim()
+      if (value && looksLikeLocationValue(value)) return value
+    }
+  }
+  return undefined
+}
+
+/**
+ * Whether a candidate location can actually hold a worktree: absolute, not
+ * inside the repo itself (`git worktree add` refuses that), with a parent that
+ * either exists as a writable directory or can be created. Unusable candidates
+ * are skipped by `resolveWorktreeDir` in favor of the next one.
+ */
+async function usableWorktreeLocation(dir: string, targetDir: string): Promise<boolean> {
+  if (!isAbsolute(dir)) return false
+  const rel = relative(resolve(targetDir), resolve(dir))
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return false
+  const parent = dirname(dir)
+  try {
+    await mkdir(parent, { recursive: true })
+    const info = await stat(parent)
+    if (!info.isDirectory()) return false
+    await access(parent, constants.W_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * The single place a worktree path is derived: repo-documented convention,
+ * then `defaults.worktreeLocation`, then the built-in default. Every caller —
+ * creation, collision checks, the launcher preview, and `finish` lookups —
+ * resolves through this so they can never drift onto different paths. A
+ * declared or configured candidate that cannot be made usable is skipped.
+ */
+export async function resolveWorktreeDir(branch: string, targetDir: string, ctx: WorktreeLocationContext = {}): Promise<string> {
+  const config = ctx.config ?? (await loadMergedConvoyConfig(targetDir))
+  const repo = basename(resolve(targetDir))
+  const slug = slugifyBranch(branch)
+  const candidates: string[] = []
+  const documented = await documentedWorktreeConvention(targetDir)
+  if (documented) candidates.push(documented)
+  if (config?.defaults.worktreeLocation) candidates.push(config.defaults.worktreeLocation)
+  for (const template of candidates) {
+    const candidate = expandLocationTemplate(template, { repo, branch: slug })
+    if (await usableWorktreeLocation(candidate, targetDir)) return candidate
+  }
+  return worktreeDirFor(branch)
 }
 
 /**
@@ -552,23 +665,26 @@ export function fallbackBranchName(): string {
 /**
  * Appends `-2`, `-3`… until neither the branch nor its worktree directory is
  * taken, so re-running a similar prompt doesn't fail `git worktree add` after
- * the run has already been confirmed.
+ * the run has already been confirmed. The directory check runs on the
+ * *resolved* location, so suffixes apply to declared layouts too.
  */
 export async function ensureFreeBranchName(branch: string, targetDir: string, limit = 50): Promise<string> {
+  // Loaded once: every suffix candidate resolves against the same config.
+  const config = await loadMergedConvoyConfig(targetDir)
   for (let suffix = 1; suffix <= limit; suffix++) {
     const candidate = suffix === 1 ? branch : `${branch}-${suffix}`
-    if (!(await branchNameTaken(candidate, targetDir))) return candidate
+    if (!(await branchNameTaken(candidate, targetDir, { config }))) return candidate
   }
   return `${branch}-${randomSlug(4)}`
 }
 
-/** True when the branch exists or its worktree directory is already on disk. */
-export async function branchNameTaken(branch: string, targetDir: string): Promise<boolean> {
+/** True when the branch exists or its resolved worktree directory is already on disk. */
+export async function branchNameTaken(branch: string, targetDir: string, ctx: WorktreeLocationContext = {}): Promise<boolean> {
   if (await branchExists(branch, targetDir)) return true
   // `git worktree add` refuses a path that already exists, so an orphaned
   // directory from an earlier run counts as taken even without a branch.
   try {
-    await stat(worktreeDirFor(branch))
+    await stat(await resolveWorktreeDir(branch, targetDir, ctx))
     return true
   } catch {
     return false

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,4 +1,5 @@
-import { access, constants, mkdir, readFile, stat } from "node:fs/promises"
+import type { Stats } from "node:fs"
+import { access, constants, mkdir, readFile, realpath, stat } from "node:fs/promises"
 import { homedir } from "node:os"
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path"
 
@@ -144,8 +145,9 @@ export type WorktreeLocationContext = {
 /**
  * Substitutes `{repo}`, `{branch}`, and a leading `~` in a worktree-location
  * template. `{repo}` is the repository directory name and `{branch}` the
- * filesystem-safe branch slug. Placeholders are optional: a template without
- * them is a fixed path, and suffixing still separates branches.
+ * filesystem-safe branch slug. A template without `{branch}` expands to a
+ * fixed path; `resolveWorktreeDir` appends the branch slug to those so every
+ * branch — and every collision suffix — still gets a directory of its own.
  */
 export function expandLocationTemplate(template: string, values: { repo: string; branch: string }): string {
   const expanded = template.replaceAll("{repo}", values.repo).replaceAll("{branch}", values.branch)
@@ -203,23 +205,65 @@ export async function documentedWorktreeConvention(targetDir: string): Promise<s
 
 /**
  * Whether a candidate location can actually hold a worktree: absolute, not
- * inside the repo itself (`git worktree add` refuses that), with a parent that
- * either exists as a writable directory or can be created. Unusable candidates
- * are skipped by `resolveWorktreeDir` in favor of the next one.
+ * inside the repo itself (`git worktree add` refuses that), and creatable —
+ * its nearest existing ancestor is a writable directory. Purely
+ * observational: nothing is created here, so the launcher preview and
+ * collision probes never mutate the filesystem before a run is confirmed;
+ * `createIsolatedWorktree` makes the parent chain once the run is real.
+ * Unusable candidates are skipped by `resolveWorktreeDir` for the next one.
  */
 async function usableWorktreeLocation(dir: string, targetDir: string): Promise<boolean> {
   if (!isAbsolute(dir)) return false
-  const rel = relative(resolve(targetDir), resolve(dir))
-  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return false
-  const parent = dirname(dir)
-  try {
-    await mkdir(parent, { recursive: true })
-    const info = await stat(parent)
-    if (!info.isDirectory()) return false
-    await access(parent, constants.W_OK)
-    return true
-  } catch {
-    return false
+  // Compare physical paths: a lexical comparison is fooled by a symlinked
+  // parent that points into (or out of) the repository.
+  const rel = relative(await physicalPath(targetDir), await physicalPath(dir))
+  // Inside the repo (or the repo dir itself) is unusable. Only a true parent
+  // traversal counts as outside, so a sibling literally named `..x` —
+  // `rel === "..x/…"` — is not mistaken for one.
+  if (rel === "" || (rel !== ".." && !rel.startsWith("../") && !isAbsolute(rel))) return false
+  // Walk up to the nearest existing ancestor: a regular file anywhere on the
+  // chain blocks it, and the missing remainder can only be created when that
+  // ancestor is a writable directory.
+  let current = dirname(dir)
+  for (;;) {
+    let info: Stats | null = null
+    try {
+      info = await stat(current)
+    } catch {
+      // Not there yet — climb toward the root.
+    }
+    if (info) {
+      if (!info.isDirectory()) return false
+      try {
+        await access(current, constants.W_OK)
+        return true
+      } catch {
+        return false
+      }
+    }
+    const parent = dirname(current)
+    if (parent === current) return false
+    current = parent
+  }
+}
+
+/**
+ * The physical form of `dir`: its deepest existing prefix is resolved with
+ * `realpath` (following symlinks) and the not-yet-existing tail is reattached
+ * as-is, so a path that does not exist yet can still be compared physically.
+ */
+async function physicalPath(dir: string): Promise<string> {
+  let current = dir
+  for (;;) {
+    try {
+      const real = await realpath(current)
+      const tail = relative(current, dir)
+      return tail ? join(real, tail) : real
+    } catch {
+      const parent = dirname(current)
+      if (parent === current) return resolve(dir)
+      current = parent
+    }
   }
 }
 
@@ -239,7 +283,11 @@ export async function resolveWorktreeDir(branch: string, targetDir: string, ctx:
   if (documented) candidates.push(documented)
   if (config?.defaults.worktreeLocation) candidates.push(config.defaults.worktreeLocation)
   for (const template of candidates) {
-    const candidate = expandLocationTemplate(template, { repo, branch: slug })
+    const expanded = expandLocationTemplate(template, { repo, branch: slug })
+    // A template without `{branch}` would map every branch — and every
+    // collision suffix — onto one directory, so the branch slug is appended
+    // and each branch keeps a directory of its own (`~/wt` → `~/wt/<slug>`).
+    const candidate = template.includes("{branch}") ? expanded : join(expanded, slug)
     if (await usableWorktreeLocation(candidate, targetDir)) return candidate
   }
   return worktreeDirFor(branch)

--- a/test/config-tui.test.ts
+++ b/test/config-tui.test.ts
@@ -7,7 +7,9 @@ import {
   asStepObject,
   collapseStep,
   claudeModelPickerState,
+  defaultFields,
   deleteAt,
+  describeDefault,
   dissolveParallel,
   ejectMember,
   isHumanStep,
@@ -299,6 +301,26 @@ describe("claudeModelPickerState", () => {
   test("sets index to 0 when current is empty string", () => {
     const state = claudeModelPickerState("")
     expect(state.index).toBe(0)
+  })
+})
+
+describe("defaults fields", () => {
+  test("worktreeLocation is listed as a string field with its template hint", () => {
+    const field = defaultFields.find((field) => field.key === "worktreeLocation")
+    expect(field?.type).toBe("string")
+    expect(field?.hint).toContain("{repo}/{branch}")
+  })
+
+  test("worktreeLocation renders a description naming the template and the marker override", () => {
+    const description = describeDefault("worktreeLocation")
+    expect(description).toContain("{repo}/{branch}")
+    expect(description).toContain("AGENTS.md")
+  })
+
+  test("every listed defaults field renders a description", () => {
+    for (const field of defaultFields) {
+      expect(describeDefault(field.key)).not.toBe("")
+    }
   })
 })
 

--- a/test/finish-command-integration.test.ts
+++ b/test/finish-command-integration.test.ts
@@ -110,4 +110,41 @@ describe("runFinishCommand integration with git", () => {
       await rm(dir, { recursive: true, force: true })
     }
   })
+
+  test("--branch locates a worktree at a non-default location via git worktree list", async () => {
+    const dir = setupRepo()
+    const wtRoot = mkdtempSync(join(tmpdir(), "convoy-finish-wt-"))
+    const wt = join(wtRoot, "custom-located")
+    git(["worktree", "add", "-b", "feat/elsewhere", "--", wt, "main"], dir)
+    git(["commit", "-q", "--allow-empty", "-m", "feat: add login (1/2)", "--author=Convoy <convoy@local>"], wt)
+    git(["commit", "-q", "--allow-empty", "-m", "fix: typo (2/2)", "--author=Convoy <convoy@local>"], wt)
+    const writes: string[] = []
+    const stdout = spyOn(process.stdout, "write").mockImplementation((chunk: string) => {
+      writes.push(chunk)
+      return true
+    })
+
+    try {
+      await runFinishCommand({ targetDir: dir, branch: "feat/elsewhere", dryRun: true, baseRef: "main" }, deps)
+
+      expect(writes.join("")).toContain("--dry-run: nothing was changed")
+      expect(writes.join("")).toContain("feat: add login")
+      expect(writes.join("")).toContain("2 convoy commits")
+    } finally {
+      stdout.mockRestore()
+      await rm(dir, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("--branch throws a clear error when no worktree holds the branch", async () => {
+    const dir = setupRepo()
+    try {
+      await expect(
+        runFinishCommand({ targetDir: dir, branch: "feat/never-created", dryRun: true, baseRef: "main" }, deps),
+      ).rejects.toThrow("no worktree for branch \"feat/never-created\"")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
 })

--- a/test/worktree-location.test.ts
+++ b/test/worktree-location.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { execFileSync } from "node:child_process"
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { homedir, tmpdir } from "node:os"
 import { basename, join, resolve } from "node:path"
 
@@ -222,6 +222,66 @@ describe("resolveWorktreeDir", () => {
       await rm(repo, { recursive: true, force: true })
     }
   })
+
+  test("a template without {branch} still gives each branch its own directory", async () => {
+    const repo = await tempDir("convoy-wt-loc-fixed-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      const config = configWithLocation(join(wtRoot, "wt"))
+      expect(await resolveWorktreeDir("feat/one", repo, { config })).toBe(join(wtRoot, "wt", "feat-one"))
+      expect(await resolveWorktreeDir("feat/two", repo, { config })).toBe(join(wtRoot, "wt", "feat-two"))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("a fixed-path marker is honored with the slug appended", async () => {
+    const repo = await tempDir("convoy-wt-loc-fixed-marker-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      await writeFile(join(repo, "AGENTS.md"), `worktree location: ${join(wtRoot, "fixed")}\n`)
+      expect(await resolveWorktreeDir("feat/x", repo)).toBe(join(wtRoot, "fixed", "feat-x"))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("a symlinked parent pointing into the repo is rejected on the physical path", async () => {
+    const repo = await tempDir("convoy-wt-loc-link-")
+    const outside = await tempDir("convoy-wt-loc-outside-")
+    try {
+      await symlink(repo, join(outside, "repo-link"))
+      // Lexically outside the repo, physically inside — the guard must fall back.
+      const config = configWithLocation(join(outside, "repo-link", "wt", "{branch}"))
+      expect(await resolveWorktreeDir("feat/x", repo, { config })).toBe(worktreeDirFor("feat/x"))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(outside, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("resolution is read-only until creation", () => {
+  test("resolving and collision probes create no directories", async () => {
+    const repo = await tempDir("convoy-wt-loc-readonly-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      const config = configWithLocation(join(wtRoot, "deep", "nested", "{branch}"))
+      expect(await resolveWorktreeDir("feat/x", repo, { config })).toBe(join(wtRoot, "deep", "nested", "feat-x"))
+      expect(await branchNameTaken("feat/x", repo, { config })).toBe(false)
+      // The probe must leave the declared location's parent chain untouched.
+      const parentCreated = await stat(join(wtRoot, "deep")).then(
+        () => true,
+        () => false,
+      )
+      expect(parentCreated).toBe(false)
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
 })
 
 describe("collision checks on the resolved location", () => {
@@ -248,6 +308,41 @@ describe("collision checks on the resolved location", () => {
       await mkdir(join(wtRoot, "feat-x"), { recursive: true })
       const free = await ensureFreeBranchName("feat/x", repo)
       expect(free).toBe("feat/x-2")
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("suffixing separates directories at a fixed-path location", async () => {
+    const repo = await tempDir("convoy-wt-loc-fixed-suffix-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      await writeRepoConfig(repo, `defaults:\n  worktreeLocation: ${join(wtRoot, "fixed")}\n`)
+      await mkdir(join(wtRoot, "fixed", "feat-x"), { recursive: true })
+      const free = await ensureFreeBranchName("feat/x", repo)
+      expect(free).toBe("feat/x-2")
+      expect(await resolveWorktreeDir(free, repo)).toBe(join(wtRoot, "fixed", "feat-x-2"))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("a second worktree against a fixed-path location gets its own directory", async () => {
+    const repo = await tempDir("convoy-wt-loc-fixed-create-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      git(["init", "-q", "-b", "main"], repo)
+      git(["config", "user.email", "test@test.com"], repo)
+      git(["config", "user.name", "Tester"], repo)
+      git(["commit", "-q", "--allow-empty", "-m", "chore: initial"], repo)
+      await writeRepoConfig(repo, `defaults:\n  worktreeLocation: ${join(wtRoot, "fixed")}\n`)
+      const first = await createIsolatedWorktree({ targetDir: repo, branch: "feat/first" })
+      const second = await createIsolatedWorktree({ targetDir: repo, branch: "feat/second" })
+      expect(first.dir).toBe(join(wtRoot, "fixed", "feat-first"))
+      expect(second.dir).toBe(join(wtRoot, "fixed", "feat-second"))
+      expect(second.branch).toBe("feat/second")
     } finally {
       await rm(repo, { recursive: true, force: true })
       await rm(wtRoot, { recursive: true, force: true })

--- a/test/worktree-location.test.ts
+++ b/test/worktree-location.test.ts
@@ -1,0 +1,320 @@
+import { describe, expect, test } from "bun:test"
+import { execFileSync } from "node:child_process"
+import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises"
+import { homedir, tmpdir } from "node:os"
+import { basename, join, resolve } from "node:path"
+
+import { parseConvoyConfig } from "../src/config"
+import { findWorktreeDirForBranch } from "../src/git"
+import { convoyHome } from "../src/workspace"
+import {
+  branchNameTaken,
+  createIsolatedWorktree,
+  documentedWorktreeConvention,
+  ensureFreeBranchName,
+  expandLocationTemplate,
+  resolveWorktreeDir,
+  worktreeDirFor,
+} from "../src/worktree"
+
+function git(args: string[], cwd: string): string {
+  return execFileSync("git", ["-c", "commit.gpgsign=false", ...args], { cwd, encoding: "utf8" }).trim()
+}
+
+async function tempDir(prefix: string): Promise<string> {
+  return mkdtemp(join(tmpdir(), prefix))
+}
+
+async function writeRepoConfig(repo: string, yaml: string) {
+  await mkdir(join(repo, ".convoy"), { recursive: true })
+  await writeFile(join(repo, ".convoy", "config.yaml"), yaml)
+}
+
+function configWithLocation(location: string) {
+  return parseConvoyConfig(`defaults:\n  worktreeLocation: ${location}\n`, "test", process.cwd())
+}
+
+describe("expandLocationTemplate", () => {
+  test("expands {repo} and {branch} and a leading ~", () => {
+    const expanded = expandLocationTemplate("~/dev/worktrees/{repo}/{branch}", { repo: "calisteniapp", branch: "feat-new-feature" })
+    expect(expanded).toBe(resolve(homedir(), "dev/worktrees/calisteniapp/feat-new-feature"))
+  })
+
+  test("expands a bare ~ to home", () => {
+    expect(expandLocationTemplate("~", { repo: "r", branch: "b" })).toBe(homedir())
+  })
+
+  test("a template without placeholders passes through unchanged", () => {
+    expect(expandLocationTemplate("/absolute/worktrees", { repo: "r", branch: "b" })).toBe("/absolute/worktrees")
+  })
+
+  test("repeated placeholders are all expanded", () => {
+    expect(expandLocationTemplate("~/wt/{branch}/{branch}", { repo: "r", branch: "x" })).toBe(join(homedir(), "wt/x/x"))
+  })
+})
+
+describe("documentedWorktreeConvention", () => {
+  test("reads a plain marker from AGENTS.md", async () => {
+    const dir = await tempDir("convoy-wt-loc-marker-")
+    try {
+      await writeFile(join(dir, "AGENTS.md"), "# Guide\n\nworktree location: ~/dev/wt/{repo}/{branch}\n")
+      expect(await documentedWorktreeConvention(dir)).toBe("~/dev/wt/{repo}/{branch}")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("accepts bulleted and README forms, AGENTS.md first", async () => {
+    const dir = await tempDir("convoy-wt-loc-bullet-")
+    try {
+      await writeFile(join(dir, "README.md"), "Setup:\n\n- worktrees: ~/wt/{branch}\n")
+      expect(await documentedWorktreeConvention(dir)).toBe("~/wt/{branch}")
+      await writeFile(join(dir, "AGENTS.md"), "> worktree-location: /abs/wt/{repo}\n")
+      expect(await documentedWorktreeConvention(dir)).toBe("/abs/wt/{repo}")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("ignores prose that is not a recognized marker", async () => {
+    const dir = await tempDir("convoy-wt-loc-prose-")
+    try {
+      await writeFile(
+        join(dir, "AGENTS.md"),
+        ["Worktrees keep work isolated.", "We organize worktrees below.", "The worktrees live elsewhere, ask Ops."].join("\n"),
+      )
+      expect(await documentedWorktreeConvention(dir)).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("a marker whose value is not a path or template falls through", async () => {
+    const dir = await tempDir("convoy-wt-loc-invalid-")
+    try {
+      await writeFile(join(dir, "AGENTS.md"), "worktree location: see the wiki for details\n")
+      expect(await documentedWorktreeConvention(dir)).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("returns undefined when neither doc exists", async () => {
+    const dir = await tempDir("convoy-wt-loc-empty-")
+    try {
+      expect(await documentedWorktreeConvention(dir)).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("ignores a marker inside a fenced code block (an example, not a convention)", async () => {
+    const dir = await tempDir("convoy-wt-loc-fence-")
+    try {
+      await writeFile(
+        join(dir, "AGENTS.md"),
+        ["## Example config.yaml", "", "```yaml", "worktree location: ~/wt/{branch}", "```", ""].join("\n"),
+      )
+      expect(await documentedWorktreeConvention(dir)).toBeUndefined()
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("a real marker outside a fence is still honored after a fenced example", async () => {
+    const dir = await tempDir("convoy-wt-loc-fence-after-")
+    try {
+      await writeFile(
+        join(dir, "AGENTS.md"),
+        ["```yaml", "worktree location: ~/wt/example/{branch}", "```", "", "worktree location: ~/wt/real/{repo}/{branch}"].join("\n"),
+      )
+      expect(await documentedWorktreeConvention(dir)).toBe("~/wt/real/{repo}/{branch}")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("strips a trailing # comment and surrounding backticks from the marker value", async () => {
+    const dir = await tempDir("convoy-wt-loc-comment-")
+    try {
+      await writeFile(join(dir, "AGENTS.md"), "worktree location: `~/wt/{repo}/{branch}` # team convention\n")
+      expect(await documentedWorktreeConvention(dir)).toBe("~/wt/{repo}/{branch}")
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("resolveWorktreeDir", () => {
+  test("built-in default when no convention or config applies", async () => {
+    const repo = await tempDir("convoy-wt-loc-builtin-")
+    try {
+      const dir = await resolveWorktreeDir("feat/add-onboarding", repo)
+      expect(dir).toBe(worktreeDirFor("feat/add-onboarding"))
+      expect(dir).toBe(join(convoyHome(), "worktrees", "feat-add-onboarding"))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+    }
+  })
+
+  test("repo convention wins over config", async () => {
+    const repo = await tempDir("convoy-wt-loc-priority-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      await writeFile(join(repo, "AGENTS.md"), "worktree location: ~/wt-from-marker/{repo}/{branch}\n")
+      const dir = await resolveWorktreeDir("feat/x", repo, { config: configWithLocation("~/wt-from-config/{branch}") })
+      expect(dir).toBe(join(homedir(), "wt-from-marker", basename(repo), "feat-x"))
+      expect(wtRoot).toBeTruthy()
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("config wins over the built-in default", async () => {
+    const repo = await tempDir("convoy-wt-loc-config-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      const dir = await resolveWorktreeDir("feat/x", repo, {
+        config: configWithLocation(join(wtRoot, "wt-{repo}-{branch}")),
+      })
+      expect(dir).toBe(join(wtRoot, `wt-${basename(repo)}-feat-x`))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("an unusable declared location falls back to config, then built-in", async () => {
+    const repo = await tempDir("convoy-wt-loc-fallback-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      // A regular file blocks the parent the marker would need.
+      await writeFile(join(wtRoot, "blocker"), "not a directory")
+      await writeFile(join(repo, "AGENTS.md"), `worktree location: ${join(wtRoot, "blocker", "sub", "{branch}")}\n`)
+      const dir = await resolveWorktreeDir("feat/x", repo, { config: configWithLocation(join(wtRoot, "cfg/{branch}")) })
+      expect(dir).toBe(join(wtRoot, "cfg", "feat-x"))
+      await rm(join(repo, "AGENTS.md"))
+      const fallback = await resolveWorktreeDir("feat/x", repo, { config: configWithLocation(join(wtRoot, "blocker", "sub", "{branch}")) })
+      expect(fallback).toBe(worktreeDirFor("feat/x"))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("a resolved path inside the repo is rejected", async () => {
+    const repo = await tempDir("convoy-wt-loc-nested-")
+    try {
+      const dir = await resolveWorktreeDir("feat/x", repo, { config: configWithLocation(`${repo}/{branch}`) })
+      expect(dir).toBe(worktreeDirFor("feat/x"))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+    }
+  })
+
+  test("a relative template is unusable and falls back", async () => {
+    const repo = await tempDir("convoy-wt-loc-relative-")
+    try {
+      const dir = await resolveWorktreeDir("feat/x", repo, { config: configWithLocation("relative/{branch}") })
+      expect(dir).toBe(worktreeDirFor("feat/x"))
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("collision checks on the resolved location", () => {
+  test("branchNameTaken sees an existing directory at a declared location", async () => {
+    const repo = await tempDir("convoy-wt-loc-taken-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      const config = configWithLocation(join(wtRoot, "{branch}"))
+      const dir = await resolveWorktreeDir("feat/x", repo, { config })
+      await mkdir(dir, { recursive: true })
+      expect(await branchNameTaken("feat/x", repo, { config })).toBe(true)
+      expect(await branchNameTaken("feat/y", repo, { config })).toBe(false)
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("ensureFreeBranchName suffixes against the declared layout", async () => {
+    const repo = await tempDir("convoy-wt-loc-suffix-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      await writeRepoConfig(repo, `defaults:\n  worktreeLocation: ${join(wtRoot, "{branch}")}\n`)
+      await mkdir(join(wtRoot, "feat-x"), { recursive: true })
+      const free = await ensureFreeBranchName("feat/x", repo)
+      expect(free).toBe("feat/x-2")
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("createIsolatedWorktree lands at the resolved location", async () => {
+    const repo = await tempDir("convoy-wt-loc-create-")
+    const wtRoot = await tempDir("convoy-wt-loc-target-")
+    try {
+      git(["init", "-q", "-b", "main"], repo)
+      git(["config", "user.email", "test@test.com"], repo)
+      git(["config", "user.name", "Tester"], repo)
+      git(["commit", "-q", "--allow-empty", "-m", "chore: initial"], repo)
+      await writeRepoConfig(repo, `defaults:\n  worktreeLocation: ${join(wtRoot, "{repo}", "{branch}")}\n`)
+      const result = await createIsolatedWorktree({ targetDir: repo, branch: "feat/located" })
+      expect(result.branch).toBe("feat/located")
+      expect(result.dir).toBe(join(wtRoot, basename(repo), "feat-located"))
+      // A linked worktree's .git is a file pointing at the repo's worktree metadata.
+      const info = await stat(join(result.dir, ".git"))
+      expect(info.isFile()).toBe(true)
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wtRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("findWorktreeDirForBranch", () => {
+  test("locates a worktree registered in the repo's worktree list", async () => {
+    const repo = await tempDir("convoy-wt-loc-list-")
+    const wt = await tempDir("convoy-wt-loc-listed-")
+    try {
+      git(["init", "-q", "-b", "main"], repo)
+      git(["config", "user.email", "test@test.com"], repo)
+      git(["config", "user.name", "Tester"], repo)
+      git(["commit", "-q", "--allow-empty", "-m", "chore: initial"], repo)
+      git(["worktree", "add", "-b", "feat/custom", "--", wt, "main"], repo)
+      // git reports the physical path, so compare against the realpath of the worktree.
+      const physical = await realpath(wt)
+      expect(await findWorktreeDirForBranch("feat/custom", repo)).toBe(physical)
+      expect(await findWorktreeDirForBranch("feat/unknown", repo)).toBeUndefined()
+    } finally {
+      await rm(repo, { recursive: true, force: true })
+      await rm(wt, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("config validation for defaults.worktreeLocation", () => {
+  test("accepts a path template", () => {
+    const config = parseConvoyConfig("defaults:\n  worktreeLocation: ~/wt/{repo}/{branch}\n", "test", process.cwd())
+    expect(config.defaults.worktreeLocation).toBe("~/wt/{repo}/{branch}")
+  })
+
+  test("rejects a non-string value", () => {
+    expect(() => parseConvoyConfig("defaults:\n  worktreeLocation: 3\n", "test", process.cwd())).toThrow()
+  })
+})
+
+describe("README marker against this repo's own docs", () => {
+  test("convoy's README config example is not misread as a convention", async () => {
+    // The documented-config example line `worktree: true …` must not become a
+    // location; the value is neither a template nor a path.
+    const repoRoot = resolve(import.meta.dir, "..")
+    const readme = await readFile(join(repoRoot, "README.md"), "utf8")
+    expect(readme).toContain("worktree: true")
+    expect(await documentedWorktreeConvention(repoRoot)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
- Resolve documented and configured location templates with repo and branch placeholders
- Fall back safely when configured locations are unusable
- Use resolved worktree paths for creation, previews, collision checks, and finish lookups
- Add configuration documentation and integration coverage