### PR TITLE
feat(close): improve feature close workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,12 @@ One resumable sequence, each step checked before it runs:
 1. **Preflight** — clean tree (commit or stash), all tasks complete (naming the missing count), no live run attached (wait for or stop it).
 2. **Sync** — merge the base branch into the feature branch inside the worktree. Conflicts stop with the conflict listed; resolve, commit, and `close --resume`.
 3. **Archive** — through the OpenSpec CLI (`openspec archive`), never by hand: the change moves to the archive layout and the result is committed on the feature branch under your identity.
-4. **Squash** — the same authorship-anchored walk `convoy finish` uses: your commits survive, convoy's collapse into one conventional commit.
-5. **Merge** — into the base branch from the main checkout (which must already sit on the base branch and be clean; Convoy never moves your checkout for you).
+4. **Squash** — the same authorship-anchored walk `convoy finish` uses: your commits survive, convoy's collapse into one conventional commit. That commit's message is composed by a model-backed writer (with a deterministic fallback when no model answers): the scope is always the single touched capability, the subject is a readable imperative line, and the change id is named in the body. In a terminal you confirm or edit the message before it lands; `--message` overrides it exactly and skips composition.
+5. **Merge** — into the base branch from the main checkout (which must already sit on the base branch and be clean; Convoy never moves your checkout for you). Fast-forward when the base hasn't moved, and whichever shape ran — fast-forward or merge commit — is narrated.
 
-Push, branch delete, and worktree removal are printed as follow-up commands and never run automatically.
+In a terminal the sequence renders as a live checklist: completed, skipped (with reason), and failed steps stay visible as they happen, and a `close --resume` shows the finished steps already checked. Headless runs print the same facts as a plain stdout summary and attempt nothing interactive.
+
+Push, worktree removal, and branch deletion are separate, deliberate offers — never automatic. Push uses the base branch's configured remote with an explicit refspec, and is unavailable (with the setup step printed instead) when the base branch has no upstream. Worktree removal must succeed before branch deletion is offered, because git refuses to delete a checked-out branch. Headless runs print the equivalent commands in that same safe order.
 
 ## Goal mode
 

--- a/assets/coverage.svg
+++ b/assets/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="138" height="20" role="img" aria-label="coverage: 92.16%">
-  <title>coverage: 92.16%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="138" height="20" role="img" aria-label="coverage: 92.03%">
+  <title>coverage: 92.03%</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
     <stop offset=".1" stop-color="#aaa" stop-opacity=".1"/>
@@ -17,7 +17,7 @@
   <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
     <text x="38" y="15" fill="#010101" fill-opacity=".3">coverage</text>
     <text x="38" y="14">coverage</text>
-    <text x="107" y="15" fill="#010101" fill-opacity=".3">92.16%</text>
-    <text x="107" y="14">92.16%</text>
+    <text x="107" y="15" fill="#010101" fill-opacity=".3">92.03%</text>
+    <text x="107" y="14">92.03%</text>
   </g>
 </svg>

--- a/openspec/changes/close-ux/.openspec.yaml
+++ b/openspec/changes/close-ux/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-29

--- a/openspec/changes/close-ux/design.md
+++ b/openspec/changes/close-ux/design.md
@@ -1,0 +1,76 @@
+# Close UX — Design
+
+## Context
+
+`convoy close` is currently a headless driver: `runClose` performs preflight → sync → archive → squash → merge and `runCloseCommand` explains the outcome afterward, with cleanup printed as raw git commands. The squashed commit defaults to `` `${branchPrefix}: ${changeID}` `` even though `src/commit-message.ts` already contains the read-only conventional-commit writer used by `convoy finish`. The archive step moves the proposal and delta specs before the squash runs, so message context must be captured before that mutation. The TUI stack already provides progress rendering, finish's deliberate follow-up pattern, and `editMessageInEditor`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce a hand-written-looking conventional commit with enforced capability scope, readable imperative subject, and the change id in the body.
+- Keep the local close sequence observable and report its merge shape.
+- Offer cleanup safely when interactive while preserving a scriptable, factual headless path.
+
+**Non-Goals:**
+
+- Changing `convoy finish` beyond inheriting the new default writer model.
+- Adding `--no-ff` or changing merge policy; fast-forward remains preferred when possible.
+- Waiting for GitHub Actions or other remote CI checks; this surface covers the local close sequence and its optional push.
+- Redesigning the board, archive-on-main remediation, or the squash walk itself.
+
+## Decisions
+
+### D1 — Snapshot message context before archive, then compose and normalize
+
+Before `openspec archive` moves the live change, close snapshots the proposal excerpt, change id, touched capability set, and collapsible commit subjects. After archive has committed its result — when the final diffstat exists — close sends that snapshot plus the diffstat to `proposeCommitMessage`.
+
+The model output is a proposal, not authority. Close normalizes it after parsing: exactly one touched capability replaces the proposed scope; zero or several capabilities remove it; the change id is injected into the body. The deterministic fallback uses the normalized branch type, the same scope rule, and a type-appropriate imperative verb plus the normalized proposal title (`feat`/`perf` → `improve`, `fix` → `fix`, `refactor` → `refactor`, `docs` → `document`, `test` → `test`, all others → `update`). Its body begins with `change <change-id>` and then includes collapsed commit summaries.
+
+An explicit `--message` is authoritative and bypasses composition, normalization, and model startup.
+
+Alternatives: model-only (rejected — close must complete offline and during model outages), pure deterministic (rejected — slug-derived messages caused the current problem), reading context after archive (rejected — the live path has moved and archive layout naming is an implementation detail).
+
+### D2 — Default writer model: `openrouter/z-ai/glm-5.3-flash`
+
+`defaultCommitMessageModel` moves from `anthropic/claude-haiku-4-5` to `openrouter/z-ai/glm-5.3-flash`. The implementation verifies that the id passes the existing model parsing/resolution path; a runtime provider failure still degrades to D1's fallback. The id is pinned here rather than in the spec because model ids change faster than requirements. `finish` inherits the switch automatically; nothing else about its flow changes.
+
+### D3 — Observation and user decisions use separate interfaces
+
+`runClose` keeps the sequence logic and accepts two independent collaborators:
+
+- `onEvent(event): void` receives one-way state (`step-started`, `step-completed`, `step-skipped(reason)`, `step-failed(step, remediation)`, merge shape and final result) for either renderer.
+- `resolveMessage(proposal): Promise<message>` is the two-way gate before `applySquash`: TTY asks accept/edit; headless accepts the proposal unchanged; `--message` avoids the callback entirely.
+
+This keeps rendering observable without making an event subscriber responsible for controlling the sequence. The TTY checklist and headless formatter consume the same event stream, so narration has one source of truth.
+
+### D4 — Message editing reuses finish's editor flow
+
+The TTY resolver shows the normalized message and offers accept / edit. Edit delegates verbatim to `editMessageInEditor`: same GIT_EDITOR/VISUAL/EDITOR resolution, git comment-line stripping, and subject/body split already used and tested by finish. No second editor implementation is introduced.
+
+### D5 — Fast-forward stays, and merge shape is derived from git state
+
+The merge keeps today's semantics. Close records the base checkout SHA before merge and inspects the resulting commit: target-head equality without a new merge commit means fast-forward; a resulting commit with multiple parents means merge commit; unchanged means already up to date. Both renderers report that shape. This is narration, not policy.
+
+### D6 — Checklist shape
+
+Preflight renders as one line (`clean tree · 24/24 tasks · no live runs`). Sync, archive, squash, and merge each render running / completed / skipped-with-reason / failed-with-remediation. Skips are first-class (`sync skipped — main already an ancestor`). A stopped sequence leaves the final frame visible; resume emits detected completed/skipped states so they render checked before work continues.
+
+### D7 — Cleanup follows git's dependency graph
+
+Push is independent. Close resolves the base branch's configured upstream into remote plus remote branch and runs/prints an explicit refspec (`git push <remote> <local-base>:<remote-branch>`). Without an upstream, push is unavailable with a remediation instead of producing the invalid `git push main` shape.
+
+Worktree removal must succeed before branch deletion becomes available because git refuses to delete a checked-out branch. The completed TTY footer can show all actions, but branch delete is disabled until that dependency clears. An action is marked complete only after success; failure leaves it available with its error and retry. Headless output prints push (when configured), worktree removal, then branch deletion in safe execution order. None runs without an explicit choice.
+
+## Risks / Trade-offs
+
+- [Archive moves the message inputs] → D1 snapshots them before the first mutation and never discovers context from the archive layout.
+- [Model id is unavailable or the provider fails] → verify local resolution during implementation; runtime falls back without blocking close.
+- [Model ignores the capability rule] → scope and change-id body are normalized after parsing, outside the model.
+- [TUI and headless narration drift] → both render the same close event stream.
+- [A cleanup action fails halfway] → dependency state advances only after success; the action stays visible with retry/remediation.
+- [TUI holds a long git operation] → cancellation is honored at step boundaries only; a stop leaves the same resumable git state as today's `close --resume`.
+
+## Migration Plan
+
+None. The surface is additive; message changes affect only future closes; `--message` remains an exact override for scripted flows. Rollback restores the print-only driver and previous default model without data migration.

--- a/openspec/changes/close-ux/proposal.md
+++ b/openspec/changes/close-ux/proposal.md
@@ -1,0 +1,32 @@
+# Close UX
+
+## Why
+
+Closing a feature is the highest-stakes moment of the flow — it rewrites a branch, archives a change, and lands on main — yet today it remains opaque while those operations run and only explains the outcome afterward. A generic squashed message, an unreported merge shape, and cleanup commands that are printed rather than actionable leave the operator unsure what landed and what remains to clean up.
+
+## What Changes
+
+- Close composes a readable conventional commit through a model-backed writer with a deterministic fallback: capability-derived scope, meaningful subject, and the change id in the body.
+- The default commit-writer model moves to `openrouter/z-ai/glm-5.3-flash`; `convoy finish` inherits the same default.
+- In a TTY, close renders preflight, sync, archive, squash, and merge as a live checklist with skips, failures, resume state, and merge shape visible; headless runs remain non-interactive and print an equivalent factual summary.
+- The squash message is confirmed or edited before it lands; `--message` remains the non-interactive override.
+- Push, worktree removal, and branch deletion become deliberate interactive offers. Branch deletion is enabled only after the worktree has been removed; headless mode prints safe remote-aware commands. Nothing runs automatically.
+- Merge policy stays unchanged: fast-forward is used when possible and reported explicitly.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `feature-close`: the squash requirement gains a composed conventional message; cleanup becomes a safe sequence of deliberate offers; a new progress requirement covers the TTY checklist, headless summary, message confirmation, merge narration, and resume state.
+
+## Impact
+
+- `src/feature-close.ts` — snapshots the change context before archive, composes the message before squash, and reports progress and merge shape.
+- `src/feature-close-command.ts` — dual-mode surface: TUI progress in a TTY, stdout summary otherwise; follow-up offers.
+- `src/commit-message.ts` — default model switch; the writer prompt accepts scope candidates and a proposal excerpt as inputs.
+- `src/cli.ts` — the board's `close-change` handoff opens the interactive surface instead of the print-only driver.
+- `convoy finish` — inherits the new default writer model; no behavior change otherwise.

--- a/openspec/changes/close-ux/specs/feature-close/spec.md
+++ b/openspec/changes/close-ux/specs/feature-close/spec.md
@@ -1,0 +1,77 @@
+# feature-close Delta
+
+## MODIFIED Requirements
+
+### Requirement: Close squashes and merges into the base branch
+
+After archiving, close SHALL collapse the run's commits into one conventional commit under the operator's identity using the same authorship-anchored walk `convoy finish` uses, then merge the feature branch into the base branch from the main checkout. The merge SHALL be performed only when the squash left a single clean commit; the operator's own commits on the branch (for example the proposal commit) SHALL survive the squash. The merge SHALL be allowed to land as a fast-forward when the base branch has not moved, and which merge shape ran SHALL be reported to the operator. Once the merge completes, pushing the base ref to its configured remote, removing the worktree, and deleting the feature branch SHALL each be offered as separate, deliberate actions and SHALL never happen automatically. Branch deletion SHALL remain unavailable while the branch is checked out in its worktree; worktree removal SHALL succeed before branch deletion becomes available. Headless mode SHALL print commands with the configured remote and base ref named explicitly and in a safe execution order. When the base branch has no configured upstream, push SHALL be unavailable with a concrete remediation and headless mode SHALL print no invalid push command.
+
+#### Scenario: One conventional commit lands
+
+- **WHEN** close completes through the merge
+- **THEN** the base branch gains the squashed conventional commit plus any operator-authored commits, the canonical specs reflect the archived change, and the feature worktree still exists until the operator accepts its removal
+
+#### Scenario: Fast-forward is narrated, not hidden
+
+- **WHEN** the squash completes and the base branch has not moved since the branch forked
+- **THEN** the merge lands as a fast-forward and the close surface reports that shape explicitly
+
+#### Scenario: Cleanup respects git dependencies
+
+- **WHEN** close completes while the feature branch is still checked out in its worktree
+- **THEN** push and worktree removal are available, branch deletion stays unavailable until worktree removal succeeds, and no cleanup runs without confirmation
+
+#### Scenario: Missing upstream disables push
+
+- **WHEN** close completes and the base branch has no configured upstream
+- **THEN** push is unavailable with setup remediation and the headless summary prints no push command
+
+## ADDED Requirements
+
+### Requirement: The squashed commit carries a composed conventional message
+
+The squashed commit's message SHALL be composed, not templated from the branch name: a model-backed proposal seeded with the change's proposal document and the capability names from its delta specs, falling back deterministically when no model answers. Regardless of the writer's output, close SHALL normalize the scope to the single touched capability and SHALL omit it when the change touches zero or several capabilities. The subject SHALL be a readable imperative line derived from the change, not the change id slug; the deterministic fallback SHALL build it from a type-appropriate imperative verb plus the normalized proposal title. For composed messages, the change id SHALL be named in the body. An explicit `--message` override SHALL win verbatim and bypass composition.
+
+#### Scenario: Writer proposal lands
+
+- **WHEN** the commit writer answers for a change whose deltas touch one capability
+- **THEN** the squashed subject is a readable imperative line, the scope is that capability, and the body names the change id
+
+#### Scenario: Broad writer proposal loses its scope
+
+- **WHEN** the writer proposes a scope for a change whose deltas touch several capabilities
+- **THEN** close removes the scope before presenting the message and preserves the readable subject and change id body
+
+#### Scenario: Deterministic fallback without a model
+
+- **WHEN** no model is reachable when close composes the message
+- **THEN** the fallback message still carries the branch prefix as type, the single touched capability as scope (omitted for zero- or multi-capability changes), an imperative subject built from a type-appropriate verb and the normalized proposal title, and the change id in the body
+
+#### Scenario: Explicit override wins
+
+- **WHEN** close runs with an explicit message override
+- **THEN** the squashed commit uses it verbatim and no composition runs
+
+### Requirement: Close shows its progress as a checklist
+
+When running interactively, close SHALL render a live checklist of the sequence — preflight rendered as one line, then sync, archive, squash, and merge — with each step's completion, skip (with reason), or failure visible as it happens. The squash step SHALL present the composed message for confirmation or editing before the commit lands. A mid-sequence stop SHALL leave the checklist visible with the failed step and its remediation; resuming SHALL show previously completed steps already checked. When not running interactively, close SHALL print the same operational facts as a stdout summary without attempting any interactive offers.
+
+#### Scenario: Checklist completes in a terminal
+
+- **WHEN** close runs to completion in a TTY
+- **THEN** each step is visible as completed or skipped-with-reason, the merge shape is narrated, and the follow-up offers appear on the completed checklist
+
+#### Scenario: The message is confirmed before landing
+
+- **WHEN** the squash step reaches the composed message in a TTY
+- **THEN** the operator can accept it as-is or edit it, and the commit lands only after that choice
+
+#### Scenario: A stop keeps the state readable
+
+- **WHEN** a step fails mid-sequence in a TTY
+- **THEN** the checklist stays visible with the failed step marked and its remediation shown, and a later resume shows the completed steps already checked
+
+#### Scenario: Headless cleanup commands are executable
+
+- **WHEN** close runs without a TTY
+- **THEN** the outcome is printed as a stdout summary, the push command names the configured remote and base ref explicitly, worktree removal is printed before branch deletion, and nothing interactive is attempted

--- a/openspec/changes/close-ux/tasks.md
+++ b/openspec/changes/close-ux/tasks.md
@@ -2,28 +2,28 @@
 
 ## 1. Writer foundations
 
-- [ ] 1.1 Switch `defaultCommitMessageModel` to `openrouter/z-ai/glm-5.3-flash` in `src/commit-message.ts`; verify the id passes the existing model parsing/resolution path and a unit test proves `finish` inherits the default with no other flow change
-- [ ] 1.2 Extend `CommitMessageInput` with optional proposal excerpt and scope-candidate inputs, and include both plus the omit-scope-when-broad instruction in `commitMessagePrompt`; verify with unit tests over single-, multi-, and zero-capability prompt text
-- [ ] 1.3 Add post-writer normalization that replaces scope with the sole touched capability, removes it for zero/multiple capabilities, and injects `change <change-id>` into composed-message bodies; verify a writer that returns an invalid broad scope is corrected
-- [ ] 1.4 Add the deterministic close fallback (normalized branch type, the same scope rule, D1's type→verb mapping plus normalized proposal title, change-id body and collapsed summaries); verify single/multiple/no-capability, missing-proposal, and all verb-map branches
+- [x] 1.1 Switch `defaultCommitMessageModel` to `openrouter/z-ai/glm-5.3-flash` in `src/commit-message.ts`; verify the id passes the existing model parsing/resolution path and a unit test proves `finish` inherits the default with no other flow change
+- [x] 1.2 Extend `CommitMessageInput` with optional proposal excerpt and scope-candidate inputs, and include both plus the omit-scope-when-broad instruction in `commitMessagePrompt`; verify with unit tests over single-, multi-, and zero-capability prompt text
+- [x] 1.3 Add post-writer normalization that replaces scope with the sole touched capability, removes it for zero/multiple capabilities, and injects `change <change-id>` into composed-message bodies; verify a writer that returns an invalid broad scope is corrected
+- [x] 1.4 Add the deterministic close fallback (normalized branch type, the same scope rule, D1's type→verb mapping plus normalized proposal title, change-id body and collapsed summaries); verify single/multiple/no-capability, missing-proposal, and all verb-map branches
 
 ## 2. Close core
 
-- [ ] 2.1 Snapshot proposal excerpt, change id, touched capabilities, and collapsible commit subjects before `openspec archive` mutates the change path; verify with an integration test that archive moves the live change but later message composition still receives the captured inputs
-- [ ] 2.2 Define the one-way close event interface (`step-started`, `step-completed`, `step-skipped(reason)`, `step-failed(step, remediation)`, merge shape and final result) and thread an optional subscriber through `runClose`; verify exact event sequences for clean close, skipped sync, archive failure, and resume
-- [ ] 2.3 Add the separate async message resolver gate: compose via `proposeCommitMessage` after archive and before `applySquash`, then await the resolver; headless accepts unchanged and `--message` bypasses writer, normalization, and resolver; verify model, fallback, edited, and override paths with test doubles
-- [ ] 2.4 Record merge shape in `CloseResult` from the pre/post merge SHAs and resulting parent count (`fast-forward`, `merge-commit`, `already-up-to-date`); verify each shape in temporary-repo integration tests
+- [x] 2.1 Snapshot proposal excerpt, change id, touched capabilities, and collapsible commit subjects before `openspec archive` mutates the change path; verify with an integration test that archive moves the live change but later message composition still receives the captured inputs
+- [x] 2.2 Define the one-way close event interface (`step-started`, `step-completed`, `step-skipped(reason)`, `step-failed(step, remediation)`, merge shape and final result) and thread an optional subscriber through `runClose`; verify exact event sequences for clean close, skipped sync, archive failure, and resume
+- [x] 2.3 Add the separate async message resolver gate: compose via `proposeCommitMessage` after archive and before `applySquash`, then await the resolver; headless accepts unchanged and `--message` bypasses writer, normalization, and resolver; verify model, fallback, edited, and override paths with test doubles
+- [x] 2.4 Record merge shape in `CloseResult` from the pre/post merge SHAs and resulting parent count (`fast-forward`, `merge-commit`, `already-up-to-date`); verify each shape in temporary-repo integration tests
 
 ## 3. Surface and cleanup
 
-- [ ] 3.1 Build the headless formatter over the close event stream in `src/feature-close-command.ts`, including skips, failures, merge shape, and safe follow-up commands; verify captured stdout for success, mid-sequence stop, configured upstream, and missing upstream (no `git push main` or other invalid push command)
-- [ ] 3.2 Build the TTY checklist renderer: preflight as one line, sync/archive/squash/merge rows with running/completed/skipped/failed states, and the completed follow-up footer; verify frame tests for running, completed fast-forward, skipped sync, and stopped states
-- [ ] 3.3 Implement TTY message accept/edit through the resolver using `editMessageInEditor` verbatim; verify key-driver tests for accept, edit-then-accept, editor cancellation, and that no commit lands before resolution
-- [ ] 3.4 Implement cleanup follow-up state: resolve the base upstream to an explicit push refspec, disable push with remediation when absent, keep push independent, require successful worktree removal before enabling branch deletion, and retain failed actions for retry; verify success/failure/retry tests and that branch deletion never runs while its worktree exists
-- [ ] 3.5 Render resume state from detected close events so previously completed/skipped rows appear checked before work continues; verify stop → `--resume` → completion in a key-driver test
-- [ ] 3.6 Route the board's `close-change` handoff in `src/cli.ts` to the checklist when TTY and to the headless formatter otherwise; verify resolution-routing and mode-selection tests
+- [x] 3.1 Build the headless formatter over the close event stream in `src/feature-close-command.ts`, including skips, failures, merge shape, and safe follow-up commands; verify captured stdout for success, mid-sequence stop, configured upstream, and missing upstream (no `git push main` or other invalid push command)
+- [x] 3.2 Build the TTY checklist renderer: preflight as one line, sync/archive/squash/merge rows with running/completed/skipped/failed states, and the completed follow-up footer; verify frame tests for running, completed fast-forward, skipped sync, and stopped states
+- [x] 3.3 Implement TTY message accept/edit through the resolver using `editMessageInEditor` verbatim; verify key-driver tests for accept, edit-then-accept, editor cancellation, and that no commit lands before resolution
+- [x] 3.4 Implement cleanup follow-up state: resolve the base upstream to an explicit push refspec, disable push with remediation when absent, keep push independent, require successful worktree removal before enabling branch deletion, and retain failed actions for retry; verify success/failure/retry tests and that branch deletion never runs while its worktree exists
+- [x] 3.5 Render resume state from detected close events so previously completed/skipped rows appear checked before work continues; verify stop → `--resume` → completion in a key-driver test
+- [x] 3.6 Route the board's `close-change` handoff in `src/cli.ts` to the checklist when TTY and to the headless formatter otherwise; verify resolution-routing and mode-selection tests
 
 ## 4. Wrap-up
 
-- [ ] 4.1 Update `closeHelp()` and README.md for the checklist, message confirmation, merge-shape narration, upstream-aware push, and ordered cleanup offers; verify help-output tests contain the interactive and headless contracts
-- [ ] 4.2 Run `bun run test:coverage` with no coverage regression on touched modules, then run `openspec validate close-ux --strict` and fix any planning drift before apply
+- [x] 4.1 Update `closeHelp()` and README.md for the checklist, message confirmation, merge-shape narration, upstream-aware push, and ordered cleanup offers; verify help-output tests contain the interactive and headless contracts
+- [x] 4.2 Run `bun run test:coverage` with no coverage regression on touched modules, then run `openspec validate close-ux --strict` and fix any planning drift before apply

--- a/openspec/changes/close-ux/tasks.md
+++ b/openspec/changes/close-ux/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: close-ux
+
+## 1. Writer foundations
+
+- [ ] 1.1 Switch `defaultCommitMessageModel` to `openrouter/z-ai/glm-5.3-flash` in `src/commit-message.ts`; verify the id passes the existing model parsing/resolution path and a unit test proves `finish` inherits the default with no other flow change
+- [ ] 1.2 Extend `CommitMessageInput` with optional proposal excerpt and scope-candidate inputs, and include both plus the omit-scope-when-broad instruction in `commitMessagePrompt`; verify with unit tests over single-, multi-, and zero-capability prompt text
+- [ ] 1.3 Add post-writer normalization that replaces scope with the sole touched capability, removes it for zero/multiple capabilities, and injects `change <change-id>` into composed-message bodies; verify a writer that returns an invalid broad scope is corrected
+- [ ] 1.4 Add the deterministic close fallback (normalized branch type, the same scope rule, D1's type→verb mapping plus normalized proposal title, change-id body and collapsed summaries); verify single/multiple/no-capability, missing-proposal, and all verb-map branches
+
+## 2. Close core
+
+- [ ] 2.1 Snapshot proposal excerpt, change id, touched capabilities, and collapsible commit subjects before `openspec archive` mutates the change path; verify with an integration test that archive moves the live change but later message composition still receives the captured inputs
+- [ ] 2.2 Define the one-way close event interface (`step-started`, `step-completed`, `step-skipped(reason)`, `step-failed(step, remediation)`, merge shape and final result) and thread an optional subscriber through `runClose`; verify exact event sequences for clean close, skipped sync, archive failure, and resume
+- [ ] 2.3 Add the separate async message resolver gate: compose via `proposeCommitMessage` after archive and before `applySquash`, then await the resolver; headless accepts unchanged and `--message` bypasses writer, normalization, and resolver; verify model, fallback, edited, and override paths with test doubles
+- [ ] 2.4 Record merge shape in `CloseResult` from the pre/post merge SHAs and resulting parent count (`fast-forward`, `merge-commit`, `already-up-to-date`); verify each shape in temporary-repo integration tests
+
+## 3. Surface and cleanup
+
+- [ ] 3.1 Build the headless formatter over the close event stream in `src/feature-close-command.ts`, including skips, failures, merge shape, and safe follow-up commands; verify captured stdout for success, mid-sequence stop, configured upstream, and missing upstream (no `git push main` or other invalid push command)
+- [ ] 3.2 Build the TTY checklist renderer: preflight as one line, sync/archive/squash/merge rows with running/completed/skipped/failed states, and the completed follow-up footer; verify frame tests for running, completed fast-forward, skipped sync, and stopped states
+- [ ] 3.3 Implement TTY message accept/edit through the resolver using `editMessageInEditor` verbatim; verify key-driver tests for accept, edit-then-accept, editor cancellation, and that no commit lands before resolution
+- [ ] 3.4 Implement cleanup follow-up state: resolve the base upstream to an explicit push refspec, disable push with remediation when absent, keep push independent, require successful worktree removal before enabling branch deletion, and retain failed actions for retry; verify success/failure/retry tests and that branch deletion never runs while its worktree exists
+- [ ] 3.5 Render resume state from detected close events so previously completed/skipped rows appear checked before work continues; verify stop → `--resume` → completion in a key-driver test
+- [ ] 3.6 Route the board's `close-change` handoff in `src/cli.ts` to the checklist when TTY and to the headless formatter otherwise; verify resolution-routing and mode-selection tests
+
+## 4. Wrap-up
+
+- [ ] 4.1 Update `closeHelp()` and README.md for the checklist, message confirmation, merge-shape narration, upstream-aware push, and ordered cleanup offers; verify help-output tests contain the interactive and headless contracts
+- [ ] 4.2 Run `bun run test:coverage` with no coverage regression on touched modules, then run `openspec validate close-ux --strict` and fix any planning drift before apply

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -698,6 +698,9 @@ export async function openSpecsBrowser(targetDir: string): Promise<void> {
     return
   }
   if (resolution.type === "close-change") {
+    // The board's handoff goes through the dual-mode dispatcher: a TTY gets
+    // the live checklist (progress, message confirmation, cleanup offers),
+    // a pipe gets the headless stdout summary — same event stream either way.
     const { runCloseCommand } = await import("./feature-close-command")
     await runCloseCommand({
       targetDir,

--- a/src/commit-message.ts
+++ b/src/commit-message.ts
@@ -30,6 +30,10 @@ export type CommitMessageInput = {
   prompt?: string
   /** The run's concatenated step reports (SUMMARY.md). */
   summary?: string
+  /** The change's proposal document, snapshotted before archive moved it (close). */
+  proposalExcerpt?: string
+  /** The capability names the change's delta specs touch; the enforced scope rule's input (close). */
+  scopeCandidates?: readonly string[]
   /** Subjects of the convoy commits being replaced, newest first. */
   commits: readonly string[]
   diffStat?: string
@@ -45,8 +49,8 @@ export type CommitMessageProposal = {
   error?: string
 }
 
-/** Cheap, fast model used to write the squashed commit message. */
-export const defaultCommitMessageModel = "anthropic/claude-haiku-4-5"
+/** Cheap, fast model used to write the squashed commit message (`finish` and `close` share it). */
+export const defaultCommitMessageModel = "openrouter/z-ai/glm-5.3-flash"
 
 /** Registered so the writer replaces opencode's default coding agent instead of merely appending to it. */
 const writerAgentName = "convoy-commit-writer"
@@ -189,7 +193,16 @@ export async function askForCommitMessage(client: OpencodeClient, input: CommitM
 export function commitMessagePrompt(input: CommitMessageInput): string {
   const parts: string[] = [`Branch: ${input.branch}`]
   if (input.summary?.trim()) parts.push(`What the run reported doing:\n${excerpt(input.summary.trim())}`)
+  if (input.proposalExcerpt?.trim()) parts.push(`The change's proposal document:\n${excerpt(input.proposalExcerpt.trim())}`)
   if (input.prompt?.trim()) parts.push(`What the user originally asked for:\n${excerpt(input.prompt.trim())}`)
+  if (input.scopeCandidates && input.scopeCandidates.length > 0) {
+    parts.push(`Touched capabilities: ${input.scopeCandidates.join(", ")}`)
+    if (input.scopeCandidates.length === 1) {
+      parts.push(`Use "${input.scopeCandidates[0]}" as the scope — the change touches exactly one capability.`)
+    } else {
+      parts.push("The change touches several capabilities, so omit the scope entirely.")
+    }
+  }
   if (input.commits.length > 0) parts.push(`The step commits being squashed:\n${input.commits.map((subject) => `- ${subject}`).join("\n")}`)
   if (input.diffStat?.trim()) parts.push(`Diffstat:\n${excerpt(input.diffStat.trim())}`)
   return parts.join("\n\n")
@@ -276,6 +289,84 @@ export function templateCommitMessage(input: CommitMessageInput): ConventionalMe
     .filter(Boolean)
     .slice(0, maxBodyLines)
   return { type, subject: capSubject(type, undefined, subject), body }
+}
+
+/**
+ * Enforces the close capability's scope rule on a writer's proposal (design D1):
+ * exactly one touched capability becomes the scope, zero or several remove it.
+ * The change id is injected into the body of a composed message — the subject
+ * never carries the slug. The model proposes; this decides.
+ */
+export function normalizeComposedMessage(
+  message: ConventionalMessage,
+  opts: { scopeCandidates?: readonly string[]; changeID?: string } = {},
+): ConventionalMessage {
+  const candidates = opts.scopeCandidates ?? []
+  const scope = candidates.length === 1 ? cleanScope(candidates[0]!) || undefined : undefined
+  let body = message.body
+  // Skip only when the id is named the way this rule names it ("change <id>"),
+  // not when a collapsed commit subject merely happens to contain the id.
+  if (opts.changeID && !body.some((line) => line.includes(`change ${opts.changeID}`))) {
+    body = [`change ${opts.changeID}`, ...body]
+  }
+  body = body.slice(0, maxBodyLines)
+  return {
+    type: message.type,
+    ...(scope ? { scope } : {}),
+    subject: capSubject(message.type, scope, message.subject),
+    body,
+  }
+}
+
+/**
+ * Type-appropriate imperative verbs for the deterministic close fallback
+ * (design D1); anything not listed updates.
+ */
+const closeFallbackVerbs: Record<string, string> = {
+  feat: "improve",
+  perf: "improve",
+  fix: "fix",
+  refactor: "refactor",
+  docs: "document",
+  test: "test",
+}
+
+/**
+ * The deterministic close fallback: the branch prefix as type (`change/`
+ * branches keep their spin-specific prefix, like close's own branchPrefix),
+ * the same sole-capability scope rule, an imperative verb plus the normalized
+ * proposal title, the change id first in the body, then the collapsed step
+ * commits. Used when the writer model answers nothing usable.
+ */
+export function closeFallbackCommitMessage(input: {
+  branch: string
+  proposal?: string
+  changeID?: string
+  scopeCandidates?: readonly string[]
+  commits?: readonly string[]
+}): ConventionalMessage {
+  const { type, rest } = splitCloseBranch(input.branch)
+  const verb = closeFallbackVerbs[type] ?? "update"
+  const title = cleanSubject(firstMeaningfulLine(input.proposal ?? "")).toLowerCase()
+  const slug = cleanSubject(rest.replace(/-/g, " "))
+  const subject = title ? `${verb} ${title}` : slug ? `${verb} ${slug}` : "update"
+  const body = (input.commits ?? [])
+    .map((line) => line.replace(/^convoy\([^)]*\):\s*/, "").trim())
+    .filter(Boolean)
+    .slice(0, maxBodyLines)
+  return normalizeComposedMessage({ type, subject, body }, {
+    scopeCandidates: input.scopeCandidates,
+    ...(input.changeID ? { changeID: input.changeID } : {}),
+  })
+}
+
+/** Like splitBranch, but `change` (spin's all-modified prefix) is a valid close type. */
+function splitCloseBranch(branch: string): { type: string; rest: string } {
+  const match = /^([a-z]+)\/(.+)$/i.exec(branch.trim())
+  if (!match) return { type: defaultCommitType, rest: branch.trim() }
+  const prefix = match[1]!.toLowerCase()
+  const type = (commitTypes as readonly string[]).includes(prefix) || prefix === "change" ? prefix : defaultCommitType
+  return { type, rest: match[2]! }
 }
 
 /** Renders the message as git receives it: subject line, blank line, bullet body. */

--- a/src/commit-message.ts
+++ b/src/commit-message.ts
@@ -306,7 +306,7 @@ export function normalizeComposedMessage(
   let body = message.body
   // Skip only when the id is named the way this rule names it ("change <id>"),
   // not when a collapsed commit subject merely happens to contain the id.
-  if (opts.changeID && !body.some((line) => line.includes(`change ${opts.changeID}`))) {
+  if (opts.changeID && !body.some((line) => line === `change ${opts.changeID}`)) {
     body = [`change ${opts.changeID}`, ...body]
   }
   body = body.slice(0, maxBodyLines)
@@ -375,6 +375,20 @@ export function formatCommitMessage(message: ConventionalMessage): string {
   const subject = `${message.type}${scope}: ${message.subject}`
   if (message.body.length === 0) return subject
   return `${subject}\n\n${message.body.map((line) => `- ${line}`).join("\n")}`
+}
+
+/**
+ * Strips terminal-injection bytes from model- and git-derived text at the
+ * render and commit-composition boundaries (SC-4). Removes full ANSI CSI
+ * sequences (`\x1b[…m` and friends, so git-stderr color codes don't leave
+ * `[31m` garbage) plus the remaining C0 bytes except tab/newline/CR and DEL —
+ * escape bytes that could otherwise paint arbitrary terminal sequences.
+ * Newlines survive so multi-line bodies and error blocks stay readable.
+ */
+export function stripControlBytes(value: string): string {
+  return value
+    .replace(/\x1b\[[0-9;?]*[ -/]*[@-~]/g, "")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/g, "")
 }
 
 function splitBranch(branch: string): { type: string; rest: string } {

--- a/src/feature-close-command.ts
+++ b/src/feature-close-command.ts
@@ -1,15 +1,21 @@
-import { stdout } from "node:process"
+import { createInterface } from "node:readline/promises"
+import { stdin, stdout } from "node:process"
+import { stat } from "node:fs/promises"
 import { resolve } from "node:path"
+import type { Readable } from "node:stream"
 
-import { archiveChangeOnMain, runClose, type CloseInput } from "./feature-close"
+import { archiveChangeOnMain, runClose, type CloseEvent, type CloseInput, type CloseMessageProposal, type CloseResult, type CloseStep } from "./feature-close"
+import { editMessageInEditor } from "./finish"
+import { branchUpstream, execFile, mainWorktreeDir, pushRefspec, removeWorktree } from "./git"
 import { log } from "./log"
 
 /**
- * The `convoy close` command: the non-interactive driver of the closing
- * sequence. Resolves the feature (board handoff, `--branch`, or the current
- * worktree), runs preflight → sync → archive → squash → merge, and prints the
- * optional follow-ups — push, branch delete, worktree removal — as commands
- * the operator runs deliberately, never automatically.
+ * The `convoy close` command surface. One close sequence, two renderers
+ * (design D3/D6): in a TTY the sequence renders as a live checklist with the
+ * composed message confirmed before it lands and deliberate follow-up offers;
+ * headless, the same event stream prints as a factual stdout summary whose
+ * follow-up commands are executable and safe, and nothing interactive is
+ * attempted.
  */
 
 export type CloseOptions = {
@@ -40,21 +46,454 @@ export async function runCloseCommand(options: CloseOptions): Promise<void> {
     ...(options.resume ? { resume: true } : {}),
     ...(options.message ? { message: options.message } : {}),
   }
+  // The board's close-change handoff lands here too: a TTY gets the checklist,
+  // a pipe gets the stdout summary — one dispatcher, no second call site.
+  if (closeSurface() === "tty") await runCloseInteractive(input)
+  else await runCloseHeadless(input)
+}
+
+/** Which renderer the command surface uses; a seam so mode selection stays testable. */
+export function closeSurface(interactive: boolean = interactiveTerminal()): "tty" | "headless" {
+  return interactive ? "tty" : "headless"
+}
+
+function interactiveTerminal(): boolean {
+  return Boolean(stdin.isTTY && stdout.isTTY)
+}
+
+// ---------------------------------------------------------------------------
+// Headless: the event stream printed as a factual stdout summary
+// ---------------------------------------------------------------------------
+
+export async function runCloseHeadless(input: CloseInput): Promise<void> {
+  const events: CloseEvent[] = []
+  let result: CloseResult | undefined
+  let failure: string | undefined
   try {
-    const result = await runClose(input)
-    stdout.write(`closed ${result.changeID}\n`)
-    stdout.write(`  ${result.branch} → ${result.baseRef} (merged)\n`)
-    if (result.squashed) stdout.write(`  ${result.squashed.replaced} convoy commit${result.squashed.replaced === 1 ? "" : "s"} squashed into ${result.squashed.sha.slice(0, 8)}\n`)
-    stdout.write("\noptional follow-ups (never automatic):\n")
-    stdout.write(`  git push ${result.baseRef}\n`)
-    stdout.write(`  git branch -d ${result.branch}\n`)
-    stdout.write(`  git worktree remove ${result.worktreeDir}\n`)
+    result = await runClose({ ...input, onEvent: (event) => events.push(event) })
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    log.error(message)
+    failure = error instanceof Error ? error.message : String(error)
     process.exitCode = 1
   }
+  if (result) {
+    const followUps = await resolveCloseFollowUps({
+      targetDir: input.targetDir,
+      baseRef: result.baseRef,
+      branch: result.branch,
+      worktreeDir: result.worktreeDir,
+    })
+    stdout.write(formatCloseEvents(events, { followUps }))
+    return
+  }
+  stdout.write(formatCloseEvents(events, { failure }))
+  log.error(failure ?? "close failed")
 }
+
+/**
+ * The headless formatter over the close event stream (task 3.1): per-step
+ * final states, the merge shape, and — on success — the follow-up commands in
+ * safe execution order (push, worktree removal, branch deletion). Push prints
+ * its explicit remote and refspec, or a remediation when no upstream exists —
+ * never an invalid bare `git push main`.
+ */
+export function formatCloseEvents(events: readonly CloseEvent[], extra: { followUps?: CloseFollowUps; failure?: string } = {}): string {
+  const lines: string[] = []
+  const stepState = new Map<CloseStep, string>()
+
+  for (const event of events) {
+    switch (event.type) {
+      case "preflight":
+        lines.push(`preflight: ${event.summary}`)
+        break
+      case "preflight-failed":
+        lines.push("preflight failed:")
+        for (const blocker of event.blockers) lines.push(`  ${blocker.message}`)
+        break
+      case "step-started":
+        break
+      case "step-completed":
+        stepState.set(event.step, event.detail ? `${event.step}: ${event.detail}` : `${event.step}: completed`)
+        break
+      case "step-skipped":
+        stepState.set(event.step, `${event.step}: skipped — ${event.reason}`)
+        break
+      case "step-failed":
+        stepState.set(event.step, `${event.step}: failed — ${firstLine(event.message)}`)
+        break
+      case "merge-shape":
+        break
+      case "result":
+        lines.push(...stepState.values())
+        lines.push(`closed ${event.result.changeID}: ${event.result.branch} → ${event.result.baseRef}`)
+        if (extra.followUps) lines.push(...formatCloseFollowUps(extra.followUps))
+        break
+    }
+  }
+  // A stop never reaches the result event: the per-step states carry the story.
+  if (!events.some((event) => event.type === "result")) lines.push(...stepState.values())
+  if (extra.failure) lines.push(firstLine(extra.failure))
+  return `${lines.join("\n")}\n`
+}
+
+/** The follow-up cleanup, resolved from git state (design D7). */
+export type CloseFollowUps = {
+  /** Present only when the base branch has a configured upstream. */
+  push?: { remote: string; refspec: string; command: string }
+  /** The concrete setup step when push is unavailable; never an invalid push command. */
+  pushRemediation?: string
+  /** The worktree-removal command, present while the worktree still exists. */
+  worktreeRemoval?: string
+  branchDelete?: string
+}
+
+/**
+ * Resolves what cleanup is even possible: the base branch's configured
+ * upstream becomes an explicit push refspec; a worktree that still exists and
+ * isn't the main checkout gets a removal command; branch deletion follows the
+ * worktree's dependency.
+ */
+export async function resolveCloseFollowUps(args: {
+  targetDir: string
+  baseRef: string
+  branch: string
+  worktreeDir: string
+}): Promise<CloseFollowUps> {
+  const mainDir = (await mainWorktreeDir(args.targetDir).catch(() => undefined)) ?? args.targetDir
+
+  let push: CloseFollowUps["push"]
+  let pushRemediation: string | undefined
+  const upstream = await branchUpstream(args.baseRef, mainDir).catch(() => undefined)
+  const [remote, ...remoteRest] = (upstream ?? "").split("/")
+  const remoteBranch = remoteRest.join("/")
+  if (remote && remoteBranch) {
+    push = { remote, refspec: `${args.baseRef}:${remoteBranch}`, command: `git push ${remote} ${args.baseRef}:${remoteBranch}` }
+  } else {
+    pushRemediation = `${args.baseRef} has no configured upstream — set one first: git branch --set-upstream-to=<remote>/<branch> ${args.baseRef}`
+  }
+
+  let worktreeRemoval: string | undefined
+  const isMainCheckout = (await sameDir(mainDir, args.worktreeDir)) === true
+  const worktreeExists = await stat(args.worktreeDir).then(
+    () => true,
+    () => false,
+  )
+  if (!isMainCheckout && worktreeExists) worktreeRemoval = `git worktree remove ${args.worktreeDir}`
+
+  return {
+    ...(push ? { push } : {}),
+    ...(pushRemediation ? { pushRemediation } : {}),
+    ...(worktreeRemoval ? { worktreeRemoval } : {}),
+    branchDelete: `git branch -d ${args.branch}`,
+  }
+}
+
+/** The printed follow-up block, in the order a safe execution would run. */
+export function formatCloseFollowUps(followUps: CloseFollowUps): string[] {
+  const lines = ["", "optional follow-ups (never automatic):"]
+  if (followUps.push) lines.push(`  ${followUps.push.command}`)
+  else if (followUps.pushRemediation) lines.push(`  push unavailable — ${followUps.pushRemediation}`)
+  if (followUps.worktreeRemoval) lines.push(`  ${followUps.worktreeRemoval}`)
+  if (followUps.branchDelete) lines.push(`  ${followUps.branchDelete}`)
+  return lines
+}
+
+// ---------------------------------------------------------------------------
+// TTY: the live checklist, the message gate, and the deliberate cleanups
+// ---------------------------------------------------------------------------
+
+export async function runCloseInteractive(input: CloseInput, io: CloseIO = {}): Promise<void> {
+  const renderer = createCloseChecklistRenderer(frameWrite(io))
+  try {
+    const result = await runClose({
+      ...input,
+      onEvent: (event) => renderer.onEvent(event),
+      resolveMessage: (proposal) => confirmCloseMessage(proposal, { renderer, ...io }),
+    })
+    const followUps = await resolveCloseFollowUps({
+      targetDir: input.targetDir,
+      baseRef: result.baseRef,
+      branch: result.branch,
+      worktreeDir: result.worktreeDir,
+    })
+    await offerCloseFollowUps({ ...followUps, baseRef: result.baseRef, branch: result.branch, worktreeDir: result.worktreeDir, targetDir: input.targetDir }, io)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.exitCode = 1
+    // The checklist keeps its final frame (the failed step and its
+    // remediation stay visible); the full stop message goes below it.
+    renderer.break()
+    frameWrite(io)("\n")
+    log.error(message)
+  }
+}
+
+// -- checklist ----------------------------------------------------------------
+
+export type CloseChecklistRowStatus = "pending" | "running" | "completed" | "skipped" | "failed"
+
+export type CloseChecklistRow = {
+  step: CloseStep
+  status: CloseChecklistRowStatus
+  detail?: string
+}
+
+export type CloseChecklistState = {
+  preflight?: string
+  preflightFailed?: readonly string[]
+  rows: readonly CloseChecklistRow[]
+  /** The failed step's stop message; the failed row already carries its first line. */
+  failed?: string
+  result?: CloseResult
+}
+
+const closeSteps: readonly CloseStep[] = ["sync", "archive", "squash", "merge"]
+
+export function initialCloseChecklistState(): CloseChecklistState {
+  return { rows: closeSteps.map((step) => ({ step, status: "pending" as const })) }
+}
+
+/** The pure reducer from close events to checklist state — one source of narration. */
+export function applyCloseEvent(state: CloseChecklistState, event: CloseEvent): CloseChecklistState {
+  const withRow = (step: CloseStep, update: Partial<CloseChecklistRow>): CloseChecklistState => ({
+    ...state,
+    rows: state.rows.map((row) => (row.step === step ? { ...row, ...update, detail: update.detail ?? (update.status === "running" ? undefined : row.detail) } : row)),
+  })
+  switch (event.type) {
+    case "preflight":
+      return { ...state, preflight: event.summary }
+    case "preflight-failed":
+      return { ...state, preflightFailed: event.blockers.map((blocker) => blocker.message) }
+    case "step-started":
+      return withRow(event.step, { status: "running" })
+    case "step-completed":
+      return withRow(event.step, { status: "completed", detail: event.detail })
+    case "step-skipped":
+      return withRow(event.step, { status: "skipped", detail: event.reason })
+    case "step-failed": {
+      const line = firstLine(event.message)
+      const prefix = `${event.step}: `
+      const detail = line.startsWith(prefix) ? line.slice(prefix.length) : line
+      return { ...withRow(event.step, { status: "failed", detail }), failed: event.message }
+    }
+    case "merge-shape":
+      // The merge row's completed detail already narrates the shape.
+      return state
+    case "result":
+      return { ...state, result: event.result }
+  }
+}
+
+/** The pure frame renderer — the same lines the live driver rewrites in place. */
+export function renderCloseChecklist(state: CloseChecklistState): string[] {
+  const lines: string[] = []
+  if (state.preflightFailed) {
+    lines.push("close preflight failed:")
+    for (const message of state.preflightFailed) lines.push(`  ${message}`)
+    return lines
+  }
+  if (state.preflight) lines.push(`preflight: ${state.preflight}`)
+  for (const row of state.rows) {
+    if (row.status === "pending") {
+      lines.push(`  ○ ${row.step}`)
+    } else if (row.status === "running") {
+      lines.push(`  ▸ ${row.step}…`)
+    } else if (row.status === "completed") {
+      lines.push(`  ✓ ${row.step}${row.detail ? ` — ${row.detail}` : ""}`)
+    } else if (row.status === "skipped") {
+      lines.push(`  ⊘ ${row.step} — skipped: ${row.detail}`)
+    } else {
+      lines.push(`  ✗ ${row.step}${row.detail ? ` — ${row.detail}` : ""}`)
+    }
+  }
+  if (state.result) {
+    lines.push("")
+    lines.push(`closed ${state.result.changeID}: ${state.result.branch} → ${state.result.baseRef}`)
+  }
+  return lines
+}
+
+/**
+ * The live driver: rewrites the frame in place with cursor-up + clear. A
+ * `break()` releases the frame (before a prompt or an editor takes the
+ * terminal); the next event prints a fresh frame below instead of rewriting.
+ */
+export function createCloseChecklistRenderer(write: (text: string) => void = (text) => stdout.write(text)) {
+  let state = initialCloseChecklistState()
+  let drawn = 0
+  const redraw = () => {
+    const frame = renderCloseChecklist(state)
+    if (drawn > 0) write(`\x1b[${drawn}A\x1b[J`)
+    for (const line of frame) write(`${line}\n`)
+    drawn = frame.length
+  }
+  return {
+    onEvent(event: CloseEvent) {
+      state = applyCloseEvent(state, event)
+      redraw()
+    },
+    break() {
+      drawn = 0
+    },
+    state: () => state,
+  }
+}
+
+// -- message gate ---------------------------------------------------------------
+
+/** Injectable terminal I/O, so the interactive surfaces stay key-driver testable. */
+export type CloseIO = {
+  input?: Readable
+  output?: {
+    write(text: string): unknown
+  }
+}
+
+const frameWrite = (io: CloseIO) => (text: string) => (io.output ?? stdout).write(text)
+
+/**
+ * The TTY side of the resolver gate (design D4): show the composed message,
+ * accept or edit. Edit delegates verbatim to `editMessageInEditor` — the same
+ * GIT_EDITOR/VISUAL/EDITOR resolution and comment stripping `finish` uses. An
+ * emptied editor or a declined prompt returns undefined, which stops the
+ * sequence before the squash lands; nothing commits before the choice.
+ */
+export async function confirmCloseMessage(
+  proposal: CloseMessageProposal,
+  deps: { renderer?: ReturnType<typeof createCloseChecklistRenderer> } & CloseIO = {},
+): Promise<string | undefined> {
+  deps.renderer?.break()
+  const out = deps.output ?? stdout
+  for (;;) {
+    out.write("\n")
+    if (proposal.error) out.write("(the writing model failed, so this message is derived from the proposal and the step commits)\n")
+    out.write(`${indent(proposal.message)}\n\n`)
+    const answer = await ask("Commit with this message? [y/e/N] ", deps)
+    if (answer === "y") return proposal.message
+    if (answer === "e") {
+      const edited = await editMessageInEditor(proposal.message)
+      if (!edited) {
+        out.write("editor cancelled — nothing has landed\n")
+        continue
+      }
+      return edited.body.length === 0 ? edited.subject : `${edited.subject}\n\n${edited.body.map((line) => `- ${line}`).join("\n")}`
+    }
+    return undefined
+  }
+}
+
+// -- follow-up offers -------------------------------------------------------------
+
+type FollowUpOffers = CloseFollowUps & { baseRef: string; branch: string; worktreeDir: string; targetDir: string }
+
+/**
+ * Cleanup follows git's dependency graph (design D7): push is independent;
+ * worktree removal must succeed before branch deletion is offered. Every
+ * action is a deliberate choice, a failure keeps the action available for
+ * retry, and nothing runs without an explicit yes.
+ */
+export async function offerCloseFollowUps(followUps: FollowUpOffers, io: CloseIO = {}): Promise<void> {
+  const out = io.output ?? stdout
+  out.write("\n")
+  const mainDir = (await mainWorktreeDir(followUps.targetDir).catch(() => undefined)) ?? followUps.targetDir
+
+  if (followUps.push) {
+    const accepted = await offerAction(
+      "push",
+      `Push ${followUps.baseRef} to ${followUps.push.remote} (${followUps.push.refspec})? [y/N] `,
+      () => pushRefspec(followUps.push!.remote, followUps.push!.refspec, mainDir),
+      io,
+    )
+    if (!accepted) out.write(`next: ${followUps.push.command}\n`)
+  } else if (followUps.pushRemediation) {
+    out.write(`push unavailable — ${followUps.pushRemediation}\n`)
+  }
+
+  let worktreeRemoved = false
+  if (followUps.worktreeRemoval) {
+    if (processCwdInside(followUps.worktreeDir)) {
+      out.write(`to remove the worktree once you're out of it: ${followUps.worktreeRemoval}\n`)
+    } else {
+      worktreeRemoved = await offerAction(
+        "worktree removal",
+        `Remove the worktree at ${followUps.worktreeDir}? [y/N] `,
+        () => removeWorktree(followUps.worktreeDir, mainDir),
+        io,
+      )
+      if (worktreeRemoved) out.write("worktree removed\n")
+      else out.write(`next: ${followUps.worktreeRemoval}\n`)
+    }
+  }
+
+  // git refuses to delete a branch that is checked out in a worktree, so the
+  // offer only exists once that dependency cleared.
+  if (worktreeRemoved) {
+    const deleted = await offerAction(
+      "branch deletion",
+      `Delete the branch ${followUps.branch}? [y/N] `,
+      async () => {
+        const result = await execFile("git", ["branch", "-d", followUps.branch], { cwd: mainDir, allowFailure: true })
+        if (result.exitCode !== 0) throw new Error(result.stderr || `git branch -d ${followUps.branch} failed`)
+      },
+      io,
+    )
+    if (deleted) out.write(`branch ${followUps.branch} deleted\n`)
+    else out.write(`next: ${followUps.branchDelete}\n`)
+  } else if (!processCwdInside(followUps.worktreeDir)) {
+    out.write(`next (after the worktree is removed): ${followUps.branchDelete}\n`)
+  }
+}
+
+/** One deliberate action with retry: a failure keeps the offer alive; N prints the command instead. */
+async function offerAction(label: string, question: string, action: () => Promise<void>, io: CloseIO): Promise<boolean> {
+  for (;;) {
+    if ((await ask(question, io)) !== "y") return false
+    try {
+      await action()
+      return true
+    } catch (error) {
+      log.warn(`${label} failed: ${error instanceof Error ? error.message : String(error)} — answer y to retry, N to skip`)
+    }
+  }
+}
+
+/** Removing the directory the process sits in leaves the shell nowhere; print the command instead. */
+function processCwdInside(dir: string): boolean {
+  const cwd = resolve(process.cwd())
+  const target = resolve(dir)
+  return cwd === target || cwd.startsWith(`${target}/`)
+}
+
+/**
+ * Single-key confirmation in the style of `finish`'s prompt, including its
+ * raw-mode SIGINT handling and its EOF-must-resolve rule: a stdin that closes
+ * (a pipe, a closed terminal) resolves rather than leaving the close hanging.
+ */
+async function ask(question: string, io: CloseIO = {}): Promise<string> {
+  // Bun's readline types only accept the exact process streams; the injectable
+  // I/O is structurally compatible, so the cast stays at this one boundary.
+  const prompt = createInterface({ input: (io.input ?? stdin) as typeof stdin, output: (io.output ?? stdout) as typeof stdout })
+  const controller = new AbortController()
+  let interrupted = false
+  prompt.on("SIGINT", () => {
+    interrupted = true
+    controller.abort()
+  })
+  const closed = new Promise<string>((resolvePromise) => prompt.once("close", () => resolvePromise("")))
+  try {
+    const answer = await Promise.race([prompt.question(question, { signal: controller.signal }), closed])
+    return answer.trim().toLowerCase()
+  } catch (error) {
+    if (interrupted && error instanceof Error && error.name === "AbortError") {
+      ;(io.output ?? stdout).write("\n")
+      return ""
+    }
+    throw error
+  } finally {
+    prompt.close()
+  }
+}
+
+// ---------------------------------------------------------------------------
 
 /** Archive-on-main for probably-merged changes, routed from the board. */
 export async function runArchiveOnMain(input: { targetDir: string; changeID: string }): Promise<void> {
@@ -80,6 +519,22 @@ into the feature branch, archive the change through the OpenSpec CLI, squash
 convoy's commits into one conventional commit (your identity, your signature),
 and merge the feature branch into the base branch from the main checkout.
 
+In a terminal the sequence renders as a live checklist — each step's
+completion, skip (with reason), or failure visible as it happens, and the
+merge's shape (fast-forward or merge commit) narrated. The squashed commit's
+message is composed from the change's proposal and touched capabilities, with
+a deterministic fallback when no model answers; the scope is always the single
+touched capability, and the change id is named in the body. You confirm or
+edit the message before it lands.
+
+Once merged, push, worktree removal, and branch deletion are offered as
+separate, deliberate actions — never automatic. Push names the configured
+remote and refspec explicitly, and is unavailable (with the setup step) when
+the base branch has no upstream; branch deletion is only offered after the
+worktree has been removed, because git refuses to delete a checked-out branch.
+Headless (piped) runs print the same facts as a stdout summary plus executable
+commands, and attempt nothing interactive.
+
 The feature is resolved from the current worktree, or pass --branch <name> to
 target another feature's worktree.
 
@@ -90,7 +545,8 @@ Options:
   --branch <name>    Close the feature worktree carrying this branch
   --change <id>      Pin the OpenSpec change id (default: the branch's id)
   --resume           Continue a stopped sequence from the first incomplete step
-  --message <text>   Subject for the squashed conventional commit
+  --message <text>   Exact message for the squashed commit; skips composition
+                     and confirmation
   --dry-run          Print the sequence without touching anything
 `
 }
@@ -116,4 +572,35 @@ export function parseCloseArgs(argv: string[]): CloseOptions {
     else throw new Error(`usage: convoy close [--branch <name>] [--change <id>] [--resume] [--message <subject>] (unexpected argument: ${arg})`)
   }
   return options
+}
+
+// -- shared helpers -------------------------------------------------------------
+
+function firstLine(value: string): string {
+  return value.split("\n")[0]?.trim() ?? value
+}
+
+function indent(value: string): string {
+  return value
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n")
+}
+
+async function sameDir(a: string, b: string): Promise<boolean | undefined> {
+  const aExists = await stat(a).then(
+    () => true,
+    () => false,
+  )
+  const bExists = await stat(b).then(
+    () => true,
+    () => false,
+  )
+  if (!aExists || !bExists) return undefined
+  const { realpath } = await import("node:fs/promises")
+  try {
+    return (await realpath(a)) === (await realpath(b))
+  } catch {
+    return a === b
+  }
 }

--- a/src/feature-close-command.ts
+++ b/src/feature-close-command.ts
@@ -1,13 +1,14 @@
-import { createInterface } from "node:readline/promises"
-import { stdin, stdout } from "node:process"
+import { stdout } from "node:process"
 import { stat } from "node:fs/promises"
 import { resolve } from "node:path"
 import type { Readable } from "node:stream"
 
 import { archiveChangeOnMain, runClose, type CloseEvent, type CloseInput, type CloseMessageProposal, type CloseResult, type CloseStep } from "./feature-close"
+import { stripControlBytes } from "./commit-message"
 import { editMessageInEditor } from "./finish"
 import { branchUpstream, execFile, mainWorktreeDir, pushRefspec, removeWorktree } from "./git"
 import { log } from "./log"
+import { ask, isInteractiveTerminal } from "./terminal-input"
 
 /**
  * The `convoy close` command surface. One close sequence, two renderers
@@ -44,7 +45,7 @@ export async function runCloseCommand(options: CloseOptions): Promise<void> {
     ...(options.branch ? { branch: options.branch } : {}),
     ...(options.changeID ? { changeID: options.changeID } : {}),
     ...(options.resume ? { resume: true } : {}),
-    ...(options.message ? { message: options.message } : {}),
+    ...(options.message !== undefined ? { message: options.message } : {}),
   }
   // The board's close-change handoff lands here too: a TTY gets the checklist,
   // a pipe gets the stdout summary — one dispatcher, no second call site.
@@ -53,12 +54,8 @@ export async function runCloseCommand(options: CloseOptions): Promise<void> {
 }
 
 /** Which renderer the command surface uses; a seam so mode selection stays testable. */
-export function closeSurface(interactive: boolean = interactiveTerminal()): "tty" | "headless" {
+export function closeSurface(interactive: boolean = isInteractiveTerminal()): "tty" | "headless" {
   return interactive ? "tty" : "headless"
-}
-
-function interactiveTerminal(): boolean {
-  return Boolean(stdin.isTTY && stdout.isTTY)
 }
 
 // ---------------------------------------------------------------------------
@@ -112,13 +109,13 @@ export function formatCloseEvents(events: readonly CloseEvent[], extra: { follow
       case "step-started":
         break
       case "step-completed":
-        stepState.set(event.step, event.detail ? `${event.step}: ${event.detail}` : `${event.step}: completed`)
+        stepState.set(event.step, event.detail ? `${event.step}: ${strip(event.detail)}` : `${event.step}: completed`)
         break
       case "step-skipped":
-        stepState.set(event.step, `${event.step}: skipped — ${event.reason}`)
+        stepState.set(event.step, `${event.step}: skipped — ${strip(event.reason)}`)
         break
       case "step-failed":
-        stepState.set(event.step, `${event.step}: failed — ${firstLine(event.message)}`)
+        stepState.set(event.step, `${event.step}: failed — ${strip(firstLine(event.message))}`)
         break
       case "merge-shape":
         break
@@ -159,6 +156,10 @@ export async function resolveCloseFollowUps(args: {
   worktreeDir: string
 }): Promise<CloseFollowUps> {
   const mainDir = (await mainWorktreeDir(args.targetDir).catch(() => undefined)) ?? args.targetDir
+  // Every printed command is prefixed `git -C <mainDir>` and quotes only the
+  // path tokens, so it is executable from inside the feature worktree (the
+  // natural close cwd) and survives paths with spaces (SC-2).
+  const gitC = `git -C ${shq(mainDir)}`
 
   let push: CloseFollowUps["push"]
   let pushRemediation: string | undefined
@@ -166,9 +167,9 @@ export async function resolveCloseFollowUps(args: {
   const [remote, ...remoteRest] = (upstream ?? "").split("/")
   const remoteBranch = remoteRest.join("/")
   if (remote && remoteBranch) {
-    push = { remote, refspec: `${args.baseRef}:${remoteBranch}`, command: `git push ${remote} ${args.baseRef}:${remoteBranch}` }
+    push = { remote, refspec: `${args.baseRef}:${remoteBranch}`, command: `${gitC} push ${remote} ${args.baseRef}:${remoteBranch}` }
   } else {
-    pushRemediation = `${args.baseRef} has no configured upstream — set one first: git branch --set-upstream-to=<remote>/<branch> ${args.baseRef}`
+    pushRemediation = `${args.baseRef} has no configured upstream — set one first: ${gitC} branch --set-upstream-to=<remote>/<branch> ${args.baseRef}`
   }
 
   let worktreeRemoval: string | undefined
@@ -177,13 +178,13 @@ export async function resolveCloseFollowUps(args: {
     () => true,
     () => false,
   )
-  if (!isMainCheckout && worktreeExists) worktreeRemoval = `git worktree remove ${args.worktreeDir}`
+  if (!isMainCheckout && worktreeExists) worktreeRemoval = `${gitC} worktree remove ${shq(args.worktreeDir)}`
 
   return {
     ...(push ? { push } : {}),
     ...(pushRemediation ? { pushRemediation } : {}),
     ...(worktreeRemoval ? { worktreeRemoval } : {}),
-    branchDelete: `git branch -d ${args.branch}`,
+    branchDelete: `${gitC} branch -d ${args.branch}`,
   }
 }
 
@@ -241,8 +242,6 @@ export type CloseChecklistState = {
   preflight?: string
   preflightFailed?: readonly string[]
   rows: readonly CloseChecklistRow[]
-  /** The failed step's stop message; the failed row already carries its first line. */
-  failed?: string
   result?: CloseResult
 }
 
@@ -266,14 +265,14 @@ export function applyCloseEvent(state: CloseChecklistState, event: CloseEvent): 
     case "step-started":
       return withRow(event.step, { status: "running" })
     case "step-completed":
-      return withRow(event.step, { status: "completed", detail: event.detail })
+      return withRow(event.step, { status: "completed", detail: strip(event.detail) })
     case "step-skipped":
-      return withRow(event.step, { status: "skipped", detail: event.reason })
+      return withRow(event.step, { status: "skipped", detail: strip(event.reason) })
     case "step-failed": {
-      const line = firstLine(event.message)
+      const line = firstLine(strip(event.message))
       const prefix = `${event.step}: `
       const detail = line.startsWith(prefix) ? line.slice(prefix.length) : line
-      return { ...withRow(event.step, { status: "failed", detail }), failed: event.message }
+      return withRow(event.step, { status: "failed", detail })
     }
     case "merge-shape":
       // The merge row's completed detail already narrates the shape.
@@ -366,7 +365,7 @@ export async function confirmCloseMessage(
   for (;;) {
     out.write("\n")
     if (proposal.error) out.write("(the writing model failed, so this message is derived from the proposal and the step commits)\n")
-    out.write(`${indent(proposal.message)}\n\n`)
+    out.write(`${indent(strip(proposal.message))}\n\n`)
     const answer = await ask("Commit with this message? [y/e/N] ", deps)
     if (answer === "y") return proposal.message
     if (answer === "e") {
@@ -425,7 +424,13 @@ export async function offerCloseFollowUps(followUps: FollowUpOffers, io: CloseIO
   }
 
   // git refuses to delete a branch that is checked out in a worktree, so the
-  // offer only exists once that dependency cleared.
+  // offer only exists once that dependency cleared. The worktree may be gone
+  // already (removed between runs or by hand) — then the branch is deletable
+  // now and the immediate command is printed, not a wait (SC-9).
+  const worktreeStillExists = await stat(followUps.worktreeDir).then(
+    () => true,
+    () => false,
+  )
   if (worktreeRemoved) {
     const deleted = await offerAction(
       "branch deletion",
@@ -438,7 +443,9 @@ export async function offerCloseFollowUps(followUps: FollowUpOffers, io: CloseIO
     )
     if (deleted) out.write(`branch ${followUps.branch} deleted\n`)
     else out.write(`next: ${followUps.branchDelete}\n`)
-  } else if (!processCwdInside(followUps.worktreeDir)) {
+  } else if (!worktreeStillExists && !processCwdInside(followUps.worktreeDir)) {
+    out.write(`next: ${followUps.branchDelete}\n`)
+  } else if (worktreeStillExists && !processCwdInside(followUps.worktreeDir)) {
     out.write(`next (after the worktree is removed): ${followUps.branchDelete}\n`)
   }
 }
@@ -463,35 +470,9 @@ function processCwdInside(dir: string): boolean {
   return cwd === target || cwd.startsWith(`${target}/`)
 }
 
-/**
- * Single-key confirmation in the style of `finish`'s prompt, including its
- * raw-mode SIGINT handling and its EOF-must-resolve rule: a stdin that closes
- * (a pipe, a closed terminal) resolves rather than leaving the close hanging.
- */
-async function ask(question: string, io: CloseIO = {}): Promise<string> {
-  // Bun's readline types only accept the exact process streams; the injectable
-  // I/O is structurally compatible, so the cast stays at this one boundary.
-  const prompt = createInterface({ input: (io.input ?? stdin) as typeof stdin, output: (io.output ?? stdout) as typeof stdout })
-  const controller = new AbortController()
-  let interrupted = false
-  prompt.on("SIGINT", () => {
-    interrupted = true
-    controller.abort()
-  })
-  const closed = new Promise<string>((resolvePromise) => prompt.once("close", () => resolvePromise("")))
-  try {
-    const answer = await Promise.race([prompt.question(question, { signal: controller.signal }), closed])
-    return answer.trim().toLowerCase()
-  } catch (error) {
-    if (interrupted && error instanceof Error && error.name === "AbortError") {
-      ;(io.output ?? stdout).write("\n")
-      return ""
-    }
-    throw error
-  } finally {
-    prompt.close()
-  }
-}
+// The single-key `ask` confirmation and the interactive-terminal check live in
+// `terminal-input.ts`, shared with `finish` so their SIGINT/EOF semantics stay
+// identical (SC-3).
 
 // ---------------------------------------------------------------------------
 
@@ -578,6 +559,16 @@ export function parseCloseArgs(argv: string[]): CloseOptions {
 
 function firstLine(value: string): string {
   return value.split("\n")[0]?.trim() ?? value
+}
+
+/** The display/commit boundary sanitizer for model- and git-derived text (SC-4). */
+function strip(value: string | undefined): string {
+  return stripControlBytes(value ?? "")
+}
+
+/** Quotes a token for the shell only when it would otherwise break out of a bare word. */
+function shq(value: string): string {
+  return /^[A-Za-z0-9_./:=@-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`
 }
 
 function indent(value: string): string {

--- a/src/feature-close.ts
+++ b/src/feature-close.ts
@@ -23,6 +23,7 @@ import {
   formatCommitMessage,
   normalizeComposedMessage,
   proposeCommitMessage,
+  stripControlBytes,
   type CommitMessageProposal,
 } from "./commit-message"
 import { listRuns } from "./runs"
@@ -277,6 +278,12 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
   let syncMergeSha: string | undefined
   if (await isAncestor(baseRef, target.branch, target.worktreeDir)) {
     emit({ type: "step-skipped", step: "sync", reason: `${baseRef} is already an ancestor of ${target.branch}` })
+    // A resume arrives here after the sync merge already landed, so this step
+    // is detected as done rather than redone. That merge is an operator-identity
+    // commit the squash below must fold (design D5); it isn't persisted, so
+    // re-discover it — without it the plain walk would leave the sync merge and
+    // the raw convoy commits to leak onto the base branch (SC-1).
+    if (input.resume) syncMergeSha = await detectPendingSyncMerge(target.worktreeDir)
   } else {
     emit({ type: "step-started", step: "sync" })
     const merge = await execFile("git", ["merge", "--no-edit", baseRef], { cwd: target.worktreeDir, allowFailure: true })
@@ -335,9 +342,17 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
       emit({ type: "step-failed", step: "squash", message: stop })
       throw new Error(stop)
     }
-    const result = await applySquash({ cwd: target.worktreeDir, plan: range, message })
-    squashed = { sha: result.sha, replaced: result.replaced }
-    emit({ type: "step-completed", step: "squash", detail: `${result.replaced} commit${result.replaced === 1 ? "" : "s"} → ${result.sha.slice(0, 8)}` })
+    try {
+      const result = await applySquash({ cwd: target.worktreeDir, plan: range, message })
+      squashed = { sha: result.sha, replaced: result.replaced }
+      emit({ type: "step-completed", step: "squash", detail: `${result.replaced} commit${result.replaced === 1 ? "" : "s"} → ${result.sha.slice(0, 8)}` })
+    } catch (error) {
+      // A failed rewrite (declined signature, rejected hook) must still mark
+      // the squash row failed; the failed event carries the remediation (SC-5).
+      const detail = error instanceof Error ? error.message : String(error)
+      emit({ type: "step-failed", step: "squash", message: `squash: ${detail}` })
+      throw error
+    }
   } else if (range.reason === "no-commits") {
     emit({ type: "step-skipped", step: "squash", reason: "no convoy commits to squash" })
   } else {
@@ -406,7 +421,9 @@ async function resolveSquashMessage(
   input: CloseInput,
   context: { target: CloseTarget; snapshot: CloseContextSnapshot; diffStat: string },
 ): Promise<string | undefined> {
-  if (input.message) return input.message
+  // `--message ""` is still an explicit override and must win verbatim, so
+  // presence is `!== undefined`, never truthiness (SC-8).
+  if (input.message !== undefined) return input.message
   const proposal = await composeCloseMessage(context, input.writer)
   if (input.resolveMessage) return await input.resolveMessage(proposal)
   return proposal.message
@@ -439,13 +456,13 @@ async function composeCloseMessage(
       scopeCandidates: context.snapshot.scopeCandidates,
       commits: context.snapshot.commitSubjects,
     })
-    return { message: formatCommitMessage(message), source: "fallback", ...(proposal.error ? { error: proposal.error } : {}) }
+    return { message: stripControlBytes(formatCommitMessage(message)), source: "fallback", ...(proposal.error ? { error: proposal.error } : {}) }
   }
   const normalized = normalizeComposedMessage(proposal.message, {
     scopeCandidates: context.snapshot.scopeCandidates,
     changeID: context.target.changeID,
   })
-  return { message: formatCommitMessage(normalized), source: "model" }
+  return { message: stripControlBytes(formatCommitMessage(normalized)), source: "model" }
 }
 
 /** The message inputs, captured before archive moves the live change (task 2.1, design D1). */
@@ -644,6 +661,27 @@ async function firstParentLog(head: string, cwd: string): Promise<CommitInfo[]> 
       return { sha, authorEmail, subject: rest.join("\x1f") }
     })
     .filter((commit) => commit.sha !== "")
+}
+
+/**
+ * Re-discovers close's sync merge after a resume (SC-1). The sync step creates
+ * exactly one operator-identity merge commit; nothing close added above it
+ * (the archive commit) is a merge, so the newest first-parent merge is that
+ * merge. The branch's own first-parent line descends into the base's history,
+ * so a merge there — which the squash never reaches (the walk anchors below
+ * the operator's surviving commit) — wouldn't fold anyway; returning one is
+ * harmless. Returns undefined when no first-parent merge exists at all.
+ */
+async function detectPendingSyncMerge(cwd: string): Promise<string | undefined> {
+  const head = (await resolveCommit("HEAD", cwd)) ?? ""
+  if (!head) return undefined
+  const result = await execFile("git", ["log", "--first-parent", "--format=%H %P", head], { cwd, allowFailure: true })
+  if (result.exitCode !== 0) return undefined
+  for (const line of result.stdout.split("\n")) {
+    const [sha = "", ...parents] = line.trim().split(/\s+/)
+    if (sha && parents.length > 1) return sha
+  }
+  return undefined
 }
 
 async function exists(path: string): Promise<boolean> {

--- a/src/feature-close.ts
+++ b/src/feature-close.ts
@@ -1,4 +1,4 @@
-import { stat } from "node:fs/promises"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { join } from "node:path"
 
 import {
@@ -18,6 +18,13 @@ import {
 } from "./git"
 import { branchIdFromBranch, isOpenSpecChangeId, openspecDirName } from "./openspec"
 import { applySquash, resolveSquashRange, type SquashRange } from "./finish"
+import {
+  closeFallbackCommitMessage,
+  formatCommitMessage,
+  normalizeComposedMessage,
+  proposeCommitMessage,
+  type CommitMessageProposal,
+} from "./commit-message"
 import { listRuns } from "./runs"
 
 /**
@@ -30,7 +37,34 @@ import { listRuns } from "./runs"
  * conflicting sync, a manual archive — continues from the first incomplete
  * step without redoing completed ones. Push, branch delete, and worktree
  * removal are offered separately and never happen automatically.
+ *
+ * The sequence narrates itself through one-way `CloseEvent`s (design D3) and
+ * gates the squashed commit behind a separate `resolveMessage` resolver, so
+ * the TTY checklist and the headless formatter consume the same stream.
  */
+
+export type CloseStep = "sync" | "archive" | "squash" | "merge"
+
+/** How the feature branch landed on the base branch (design D5: derived from git state, narrated). */
+export type CloseMergeShape = "fast-forward" | "merge-commit" | "already-up-to-date"
+
+export type CloseEvent =
+  | { type: "preflight"; summary: string }
+  | { type: "preflight-failed"; blockers: readonly ClosePreflightBlocker[] }
+  | { type: "step-started"; step: CloseStep }
+  | { type: "step-completed"; step: CloseStep; detail?: string }
+  | { type: "step-skipped"; step: CloseStep; reason: string }
+  | { type: "step-failed"; step: CloseStep; message: string }
+  | { type: "merge-shape"; shape: CloseMergeShape }
+  | { type: "result"; result: CloseResult }
+
+/** What the message gate hands the operator: the normalized proposal, and where it came from. */
+export type CloseMessageProposal = {
+  message: string
+  source: "model" | "fallback"
+  /** Set when the writing model failed and the message is the deterministic fallback. */
+  error?: string
+}
 
 export type CloseInput = {
   /** The repo (used to detect the base branch and reach the main checkout). */
@@ -43,8 +77,19 @@ export type CloseInput = {
   changeID?: string
   /** Continue a previously stopped sequence: completed steps are detected, not repeated. */
   resume?: boolean
-  /** Override for the squashed conventional commit's subject. */
+  /** Override for the squashed conventional commit's message; wins verbatim and bypasses composition. */
   message?: string
+  /** One-way narration of the sequence (design D3); safe to ignore for scripted calls. */
+  onEvent?: (event: CloseEvent) => void
+  /**
+   * The two-way gate before the squash lands: receives the composed message and
+   * returns the message to commit, or undefined to stop the sequence before the
+   * squash. Headless callers omit it (the proposal is accepted unchanged);
+   * `--message` never reaches it.
+   */
+  resolveMessage?: (proposal: CloseMessageProposal) => Promise<string | undefined>
+  /** Test seam: the commit writer behind composition. Defaults to `proposeCommitMessage`. */
+  writer?: (input: Parameters<typeof proposeCommitMessage>[0]) => Promise<CommitMessageProposal>
 }
 
 export type ClosePreflightBlocker = {
@@ -66,6 +111,8 @@ export type CloseResult = {
   /** The squash outcome; skipped when the branch carried no convoy commits. */
   squashed?: { sha: string; replaced: number }
   merged: boolean
+  /** How the merge landed (design D5); "already-up-to-date" when nothing moved. */
+  mergeShape: CloseMergeShape
 }
 
 export type CloseTarget = {
@@ -120,21 +167,37 @@ async function resolveSame(a: string, b: string): Promise<boolean> {
 }
 
 /**
+ * The preflight state: the blocking conditions (each with its concrete
+ * remediation) plus the one-line summary the checklist renders (design D6:
+ * `clean tree · 24/24 tasks · no live runs`).
+ */
+export type ClosePreflightState = {
+  blockers: ClosePreflightBlocker[]
+  summary: string
+}
+
+/**
  * The three blocking preflight conditions, each with its concrete remediation.
  * Returned (not thrown) so the caller can print them all at once; an empty
  * list means the sequence may start.
  */
 export async function closePreflight(input: CloseInput, target: CloseTarget): Promise<ClosePreflightBlocker[]> {
+  return (await closePreflightState(input, target)).blockers
+}
+
+export async function closePreflightState(input: CloseInput, target: CloseTarget): Promise<ClosePreflightState> {
   const blockers: ClosePreflightBlocker[] = []
 
   // Fail closed: a git status that cannot be read must not be read as "clean",
   // because the sequence that follows rewrites history (squash) and merges it
   // onto the base. If we cannot verify the tree, we refuse (SC-6).
   let porcelain: string
+  let treeVerifiable = true
   try {
     porcelain = await statusPorcelain(target.worktreeDir)
   } catch (error) {
     porcelain = ""
+    treeVerifiable = false
     blockers.push({
       check: "clean-tree",
       message: `couldn't verify the worktree at ${target.worktreeDir} is clean (${error instanceof Error ? error.message : error}) — refusing to rewrite history under an unverifiable tree`,
@@ -148,12 +211,17 @@ export async function closePreflight(input: CloseInput, target: CloseTarget): Pr
   // An already-archived change (a resumed sequence) has no task list to
   // check — its precondition was satisfied and archived away with the change.
   const changeStillPresent = await exists(join(target.worktreeDir, openspecDirName, "changes", target.changeID))
+  let taskSummary: string | undefined
   if (changeStillPresent) {
     const tasks = (await openspecTaskCounts(target.worktreeDir)).get(target.changeID)
     if (!tasks || tasks.total === 0) {
       blockers.push({ check: "tasks", message: `no task list found for change ${target.changeID}; finish the tasks before closing` })
+      taskSummary = "no task list"
     } else if (tasks.done < tasks.total) {
       blockers.push({ check: "tasks", message: `${tasks.total - tasks.done} of ${tasks.total} tasks are incomplete — finish them before closing` })
+      taskSummary = `${tasks.done}/${tasks.total} tasks`
+    } else {
+      taskSummary = `${tasks.done}/${tasks.total} tasks`
     }
   }
 
@@ -177,55 +245,77 @@ export async function closePreflight(input: CloseInput, target: CloseTarget): Pr
     blockers.push({ check: "live-run", message: `${liveCount} live run${liveCount === 1 ? " is" : "s are"} attached to ${target.branch} — wait for or stop ${liveCount === 1 ? "it" : "them"} first` })
   }
 
-  return blockers
+  const parts: string[] = [treeVerifiable ? "clean tree" : "tree unverifiable"]
+  if (taskSummary) parts.push(taskSummary)
+  parts.push(liveCount === 0 ? "no live runs" : `${liveCount} live run${liveCount === 1 ? "" : "s"}`)
+  return { blockers, summary: parts.join(" · ") }
 }
 
 /**
  * The full closing sequence. Throws `Error` on every stop (preflight
- * blockers, sync conflict, archive failure, merge conflict); the error
- * message names the step and the remediation, and `close --resume` picks up
- * from the first incomplete step.
+ * blockers, sync conflict, archive failure, declined message, merge conflict);
+ * the error message names the step and the remediation, and `close --resume`
+ * picks up from the first incomplete step. Every state change the renderers
+ * need travels through `input.onEvent` (design D3) — the TTY checklist and the
+ * headless formatter consume the same stream, so narration has one source.
  */
 export async function runClose(input: CloseInput): Promise<CloseResult> {
+  const emit = (event: CloseEvent) => input.onEvent?.(event)
   const target = await resolveCloseTarget(input)
   const baseRef = await closeBaseRef(input.targetDir)
 
   // Preflight: refuse to touch anything until the feature is ready to close.
-  const blockers = await closePreflight(input, target)
-  if (blockers.length > 0) {
-    throw new Error(`close preflight failed:\n  ${blockers.map((blocker) => blocker.message).join("\n  ")}`)
+  const preflight = await closePreflightState(input, target)
+  if (preflight.blockers.length > 0) {
+    emit({ type: "preflight-failed", blockers: preflight.blockers })
+    throw new Error(`close preflight failed:\n  ${preflight.blockers.map((blocker) => blocker.message).join("\n  ")}`)
   }
+  emit({ type: "preflight", summary: preflight.summary })
 
   // Sync: bring the base branch's tip in before archiving, so the canonical
   // specs the archive produces land against a fresh base.
   let syncMergeSha: string | undefined
-  if (!(await isAncestor(baseRef, target.branch, target.worktreeDir))) {
+  if (await isAncestor(baseRef, target.branch, target.worktreeDir)) {
+    emit({ type: "step-skipped", step: "sync", reason: `${baseRef} is already an ancestor of ${target.branch}` })
+  } else {
+    emit({ type: "step-started", step: "sync" })
     const merge = await execFile("git", ["merge", "--no-edit", baseRef], { cwd: target.worktreeDir, allowFailure: true })
     if (merge.exitCode !== 0) {
-      throw new Error(
-        `sync: merging ${baseRef} into ${target.branch} conflicted — resolve the conflicts and commit inside the worktree, then run \`convoy close --resume\`\n${merge.stderr || merge.stdout}`,
-      )
+      const message = `sync: merging ${baseRef} into ${target.branch} conflicted — resolve the conflicts and commit inside the worktree, then run \`convoy close --resume\`\n${merge.stderr || merge.stdout}`
+      emit({ type: "step-failed", step: "sync", message })
+      throw new Error(message)
     }
     // The clean sync just wrote an operator-identity merge commit. The squash
     // below must fold it (plus the convoy commits beneath it) into the one
     // conventional commit, or the raw `convoy(...)` steps leak onto the base
     // branch unchanged.
     syncMergeSha = (await resolveCommit("HEAD", target.worktreeDir)) ?? undefined
+    emit({ type: "step-completed", step: "sync", detail: `merged ${baseRef} into ${target.branch}` })
   }
+
+  // Snapshot the message inputs before the first archive mutation (design D1):
+  // the archive moves the live change, and the archive layout's naming is an
+  // implementation detail the message must never discover.
+  const archiveSubject = `chore(openspec): archive ${target.changeID}`
+  const snapshot = await snapshotCloseContext(target, baseRef, { syncMergeSha, archiveSubject })
 
   // Archive: through the OpenSpec CLI only — convoy never edits openspec/.
   const changeDir = join(target.worktreeDir, openspecDirName, "changes", target.changeID)
   if (await exists(changeDir)) {
+    emit({ type: "step-started", step: "archive" })
     const archive = await execFile("openspec", ["archive", target.changeID, "--yes"], { cwd: target.worktreeDir, allowFailure: true })
     if (archive.exitCode !== 0) {
-      throw new Error(
-        `archive: openspec archive ${target.changeID} failed — the sequence stops before any squash or merge\n${archive.stderr || archive.stdout}`,
-      )
+      const message = `archive: openspec archive ${target.changeID} failed — the sequence stops before any squash or merge\n${archive.stderr || archive.stdout}`
+      emit({ type: "step-failed", step: "archive", message })
+      throw new Error(message)
     }
     // The archive result is committed on the feature branch under the
     // operator's identity (staged explicitly; commitAsUser adds nothing).
     await execFile("git", ["add", openspecDirName], { cwd: target.worktreeDir })
-    await commitAsUser(`chore(openspec): archive ${target.changeID}`, target.worktreeDir)
+    await commitAsUser(archiveSubject, target.worktreeDir)
+    emit({ type: "step-completed", step: "archive", detail: `archived ${target.changeID}` })
+  } else {
+    emit({ type: "step-skipped", step: "archive", reason: `change ${target.changeID} is already archived` })
   }
 
   // Squash: the same authorship-anchored walk `convoy finish` uses, so the
@@ -233,35 +323,27 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
   // close's own archive commit, made under the operator identity — collapse
   // into one conventional commit. A branch with no convoy commits skips the
   // squash and merges as-is.
-  const archiveSubject = `chore(openspec): archive ${target.changeID}`
   let squashed: CloseResult["squashed"]
-  if (syncMergeSha) {
-    // A clean sync left a merge commit on the branch that resolveSquashRange's
-    // authorship-anchored walk would stop dead at (it's operator-identity and
-    // never extraSquashable), farming the merge *and* the raw convoy commits
-    // onto the base. Walk the first-parent line instead — the base side of
-    // the merge lives on the second parent and never enters it — folding the
-    // sync merge, the archive commit, and every convoy commit down to the
-    // operator's own proposal commit, which survives.
-    const range = await closeSyncSquashRange(target.worktreeDir, baseRef, { syncMergeSha, archiveSubject })
-    if (range.ok) {
-      const message = input.message ?? `${branchPrefix(target.branch)}: ${target.changeID}`
-      const result = await applySquash({ cwd: target.worktreeDir, plan: range, message })
-      squashed = { sha: result.sha, replaced: result.replaced }
-    } else if (range.reason !== "no-commits") {
-      throw new Error(`squash: ${range.message}`)
+  const range = syncMergeSha
+    ? await closeSyncSquashRange(target.worktreeDir, baseRef, { syncMergeSha, archiveSubject })
+    : await resolveSquashRange(target.worktreeDir, baseRef, { extraSquashable: (commit) => commit.subject === archiveSubject })
+  if (range.ok) {
+    emit({ type: "step-started", step: "squash" })
+    const message = await resolveSquashMessage(input, { target, snapshot, diffStat: range.diffStat })
+    if (message === undefined) {
+      const stop = "close stopped: the squashed commit message wasn't confirmed — rerun `convoy close --resume` to retry the squash"
+      emit({ type: "step-failed", step: "squash", message: stop })
+      throw new Error(stop)
     }
+    const result = await applySquash({ cwd: target.worktreeDir, plan: range, message })
+    squashed = { sha: result.sha, replaced: result.replaced }
+    emit({ type: "step-completed", step: "squash", detail: `${result.replaced} commit${result.replaced === 1 ? "" : "s"} → ${result.sha.slice(0, 8)}` })
+  } else if (range.reason === "no-commits") {
+    emit({ type: "step-skipped", step: "squash", reason: "no convoy commits to squash" })
   } else {
-    const range = await resolveSquashRange(target.worktreeDir, baseRef, {
-      extraSquashable: (commit) => commit.subject === archiveSubject,
-    })
-    if (range.ok) {
-      const message = input.message ?? `${branchPrefix(target.branch)}: ${target.changeID}`
-      const result = await applySquash({ cwd: target.worktreeDir, plan: range, message })
-      squashed = { sha: result.sha, replaced: result.replaced }
-    } else if (range.reason !== "no-commits") {
-      throw new Error(`squash: ${range.message}`)
-    }
+    const message = `squash: ${range.message}`
+    emit({ type: "step-failed", step: "squash", message })
+    throw new Error(message)
   }
 
   // Merge: into the base branch from the main checkout. The main checkout
@@ -270,25 +352,183 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
   const mainDir = (await mainWorktreeDir(input.targetDir)) ?? input.targetDir
   const mainBranch = await currentBranch(mainDir)
   if (mainBranch !== baseRef) {
-    throw new Error(`merge: the main checkout is on ${mainBranch ?? "a detached HEAD"}, not ${baseRef} — check out ${baseRef} there, then run \`convoy close --resume\``)
+    const message = `merge: the main checkout is on ${mainBranch ?? "a detached HEAD"}, not ${baseRef} — check out ${baseRef} there, then run \`convoy close --resume\``
+    emit({ type: "step-failed", step: "merge", message })
+    throw new Error(message)
   }
   const mainStatus = await statusPorcelain(mainDir).catch(() => "dirty")
   if (mainStatus.trim() !== "") {
-    throw new Error(`merge: the main checkout has uncommitted changes — commit or stash them first, then run \`convoy close --resume\``)
-  }
-  const merge = await execFile("git", ["merge", "--no-edit", target.branch], { cwd: mainDir, allowFailure: true })
-  if (merge.exitCode !== 0) {
-    throw new Error(`merge: merging ${target.branch} into ${baseRef} failed — resolve in the main checkout, then run \`convoy close --resume\`\n${merge.stderr || merge.stdout}`)
+    const message = "merge: the main checkout has uncommitted changes — commit or stash them first, then run `convoy close --resume`"
+    emit({ type: "step-failed", step: "merge", message })
+    throw new Error(message)
   }
 
-  return {
+  let mergeShape: CloseMergeShape
+  if (await isAncestor(target.branch, baseRef, mainDir)) {
+    emit({ type: "step-skipped", step: "merge", reason: `${target.branch} is already contained in ${baseRef}` })
+    mergeShape = "already-up-to-date"
+    emit({ type: "merge-shape", shape: mergeShape })
+  } else {
+    emit({ type: "step-started", step: "merge" })
+    const baseBefore = (await resolveCommit(baseRef, mainDir)) ?? ""
+    const merge = await execFile("git", ["merge", "--no-edit", target.branch], { cwd: mainDir, allowFailure: true })
+    if (merge.exitCode !== 0) {
+      const message = `merge: merging ${target.branch} into ${baseRef} failed — resolve in the main checkout, then run \`convoy close --resume\`\n${merge.stderr || merge.stdout}`
+      emit({ type: "step-failed", step: "merge", message })
+      throw new Error(message)
+    }
+    mergeShape = await deriveMergeShape(baseBefore, baseRef, mainDir)
+    emit({ type: "merge-shape", shape: mergeShape })
+    emit({ type: "step-completed", step: "merge", detail: mergeShapeDetail(mergeShape) })
+  }
+
+  const result: CloseResult = {
     changeID: target.changeID,
     branch: target.branch,
     worktreeDir: target.worktreeDir,
     baseRef,
     ...(squashed ? { squashed } : {}),
     merged: true,
+    mergeShape,
   }
+  emit({ type: "result", result })
+  return result
+}
+
+/**
+ * The message gate before `applySquash` (design D3): `--message` wins verbatim
+ * and bypasses the writer, normalization, and resolver entirely; otherwise the
+ * composed proposal goes to the resolver, whose undefined answer stops the
+ * sequence before anything lands; headless callers without a resolver accept
+ * the proposal unchanged.
+ */
+async function resolveSquashMessage(
+  input: CloseInput,
+  context: { target: CloseTarget; snapshot: CloseContextSnapshot; diffStat: string },
+): Promise<string | undefined> {
+  if (input.message) return input.message
+  const proposal = await composeCloseMessage(context, input.writer)
+  if (input.resolveMessage) return await input.resolveMessage(proposal)
+  return proposal.message
+}
+
+/**
+ * Snapshot + final diffstat → normalized message proposal (design D1). The
+ * writer's answer is a proposal, not authority: the scope rule is enforced
+ * here, and a writer that answered nothing usable degrades to the
+ * deterministic close fallback without blocking the sequence.
+ */
+async function composeCloseMessage(
+  context: { target: CloseTarget; snapshot: CloseContextSnapshot; diffStat: string },
+  writer?: CloseInput["writer"],
+): Promise<CloseMessageProposal> {
+  const writerInput = {
+    targetDir: context.target.worktreeDir,
+    branch: context.target.branch,
+    commits: context.snapshot.commitSubjects,
+    ...(context.diffStat.trim() ? { diffStat: context.diffStat } : {}),
+    ...(context.snapshot.proposalExcerpt ? { proposalExcerpt: context.snapshot.proposalExcerpt } : {}),
+    ...(context.snapshot.scopeCandidates.length > 0 ? { scopeCandidates: context.snapshot.scopeCandidates } : {}),
+  }
+  const proposal = await (writer ?? proposeCommitMessage)(writerInput)
+  if (proposal.source === "template") {
+    const message = closeFallbackCommitMessage({
+      branch: context.target.branch,
+      proposal: context.snapshot.proposalExcerpt,
+      changeID: context.target.changeID,
+      scopeCandidates: context.snapshot.scopeCandidates,
+      commits: context.snapshot.commitSubjects,
+    })
+    return { message: formatCommitMessage(message), source: "fallback", ...(proposal.error ? { error: proposal.error } : {}) }
+  }
+  const normalized = normalizeComposedMessage(proposal.message, {
+    scopeCandidates: context.snapshot.scopeCandidates,
+    changeID: context.target.changeID,
+  })
+  return { message: formatCommitMessage(normalized), source: "model" }
+}
+
+/** The message inputs, captured before archive moves the live change (task 2.1, design D1). */
+export type CloseContextSnapshot = {
+  changeID: string
+  /** The proposal document's content, read while the live path still existed. */
+  proposalExcerpt?: string
+  /** The capability names under the change's delta specs — the scope rule's candidates. */
+  scopeCandidates: string[]
+  /** The collapsible commit subjects, captured before the archive commit exists. */
+  commitSubjects: string[]
+}
+
+async function snapshotCloseContext(
+  target: CloseTarget,
+  baseRef: string,
+  opts: { syncMergeSha?: string; archiveSubject: string },
+): Promise<CloseContextSnapshot> {
+  const changeDir = join(target.worktreeDir, openspecDirName, "changes", target.changeID)
+  let proposalExcerpt: string | undefined
+  try {
+    proposalExcerpt = await readFile(join(changeDir, "proposal.md"), "utf8")
+  } catch {
+    // A change without a readable proposal still closes; the message just
+    // loses that seed.
+  }
+  return {
+    changeID: target.changeID,
+    ...(proposalExcerpt ? { proposalExcerpt } : {}),
+    scopeCandidates: await listChangeCapabilities(changeDir),
+    commitSubjects: await collapsibleCommitSubjects(target, baseRef, opts),
+  }
+}
+
+/** The capability directories of the change's delta specs, sorted. */
+async function listChangeCapabilities(changeDir: string): Promise<string[]> {
+  try {
+    const entries = await readdir(join(changeDir, "specs"), { withFileTypes: true })
+    return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name).sort()
+  } catch {
+    return []
+  }
+}
+
+/**
+ * The pre-archive walk of what will collapse. The archive commit doesn't exist
+ * yet, so the plain authorship-anchored walk already lists every convoy commit;
+ * the sync-aware first-parent walk covers a branch that just synced. A failure
+ * here only costs the message its commit summaries.
+ */
+async function collapsibleCommitSubjects(
+  target: CloseTarget,
+  baseRef: string,
+  opts: { syncMergeSha?: string; archiveSubject: string },
+): Promise<string[]> {
+  try {
+    const range = opts.syncMergeSha
+      ? await closeSyncSquashRange(target.worktreeDir, baseRef, { syncMergeSha: opts.syncMergeSha, archiveSubject: opts.archiveSubject })
+      : await resolveSquashRange(target.worktreeDir, baseRef)
+    return range.ok ? range.commits.map((commit) => commit.subject) : []
+  } catch {
+    return []
+  }
+}
+
+/** The merge shape from git state alone (design D5): SHA movement plus parent count. */
+async function deriveMergeShape(baseBefore: string, baseRef: string, cwd: string): Promise<CloseMergeShape> {
+  const baseAfter = (await resolveCommit(baseRef, cwd)) ?? ""
+  if (!baseBefore || !baseAfter || baseAfter === baseBefore) return "already-up-to-date"
+  const parents = await commitParentCount(baseAfter, cwd)
+  return parents > 1 ? "merge-commit" : "fast-forward"
+}
+
+async function commitParentCount(sha: string, cwd: string): Promise<number> {
+  const result = await execFile("git", ["rev-list", "--parents", "-n", "1", sha], { cwd, allowFailure: true })
+  if (result.exitCode !== 0) return 1
+  return Math.max(1, result.stdout.trim().split(/\s+/).length - 1)
+}
+
+function mergeShapeDetail(shape: CloseMergeShape): string {
+  if (shape === "fast-forward") return "merged (fast-forward)"
+  if (shape === "merge-commit") return "merged (merge commit)"
+  return "already up to date"
 }
 
 /**
@@ -333,13 +573,6 @@ export async function closeBaseRef(targetDir: string): Promise<string> {
   const mainDir = (await mainWorktreeDir(targetDir).catch(() => undefined)) ?? targetDir
   const detected = await detectBaseRef(mainDir).catch(() => undefined)
   return detected?.ref ?? "HEAD"
-}
-
-/** The conventional type the squash commit inherits from the branch's own prefix. */
-function branchPrefix(branch: string): string {
-  const slash = branch.indexOf("/")
-  const prefix = slash === -1 ? "" : branch.slice(0, slash)
-  return /^(feat|fix|refactor|perf|docs|test|chore|build|ci|change)$/.test(prefix) ? prefix : "feat"
 }
 
 /**

--- a/src/finish-command.ts
+++ b/src/finish-command.ts
@@ -1,5 +1,4 @@
-import { createInterface } from "node:readline/promises"
-import { stdin, stdout } from "node:process"
+import { stdout } from "node:process"
 import { resolve } from "node:path"
 
 import { formatCommitMessage } from "./commit-message"
@@ -7,6 +6,7 @@ import { loadMergedConvoyConfig } from "./config"
 import { applySquash, canOpenPullRequest, defaultRemote, describeSquashPlan, openPullRequest, prepareFinish, resolveFinishBase } from "./finish"
 import { mainWorktreeDir, pushBranch, removeWorktree } from "./git"
 import { log } from "./log"
+import { ask, isInteractiveTerminal } from "./terminal-input"
 
 export type FinishOptions = {
   /** Repo or worktree holding the run's branch. */
@@ -64,7 +64,7 @@ export async function runFinishCommand(options: FinishOptions, deps: FinishComma
     return
   }
 
-  if (!options.yes && !interactive()) {
+  if (!options.yes && !isInteractiveTerminal()) {
     // Rewriting history is not something to do because nobody was there to say no.
     stdout.write("not an interactive terminal; re-run with --yes to squash without confirmation\n")
     return
@@ -133,7 +133,7 @@ async function offerFollowUps(input: FollowUpInput) {
   // --yes covers the squash only. Pushing and opening a PR are outward-facing,
   // so they always ask — and where there is nobody to ask, they simply don't
   // happen and the commands are printed instead.
-  if (input.yes || !interactive()) {
+  if (input.yes || !isInteractiveTerminal()) {
     stdout.write(`\nnext: git push -u ${defaultRemote} ${input.branch}\n`)
     await describeWorktreeRemoval(input)
     return
@@ -208,39 +208,9 @@ async function worktreeRemoval(input: FollowUpInput): Promise<{ mainDir: string;
   }
 }
 
-/**
- * Single-key confirmation in the style of confirmRunPlan, including its raw-mode
- * SIGINT handling. Every question opens its own readline interface, so a stdin
- * that reaches EOF (a pipe, a closed terminal) must resolve rather than leave
- * the promise pending forever and let the process exit mid-flow.
- */
-async function ask(question: string): Promise<string> {
-  const prompt = createInterface({ input: stdin, output: stdout })
-  const controller = new AbortController()
-  let interrupted = false
-  prompt.on("SIGINT", () => {
-    interrupted = true
-    controller.abort()
-  })
-  const closed = new Promise<string>((resolve) => prompt.once("close", () => resolve("")))
-  try {
-    const answer = await Promise.race([prompt.question(question, { signal: controller.signal }), closed])
-    return answer.trim().toLowerCase()
-  } catch (error) {
-    if (interrupted && error instanceof Error && error.name === "AbortError") {
-      stdout.write("\n")
-      return ""
-    }
-    throw error
-  } finally {
-    prompt.close()
-  }
-}
-
-/** Whether convoy can still ask the user anything, or should only print what it would have offered. */
-function interactive(): boolean {
-  return Boolean(stdin.isTTY && stdout.isTTY)
-}
+// Single-key confirmation (`ask`) and the interactive-terminal check live in
+// `terminal-input.ts`, shared with `close` so their SIGINT/EOF semantics stay
+// identical (SC-3).
 
 function indent(value: string) {
   return value

--- a/src/git.ts
+++ b/src/git.ts
@@ -406,6 +406,16 @@ export async function pushBranch(branch: string, remote: string, cwd: string) {
   if (exitCode !== 0) throw new Error(`git push exited with code ${exitCode}`)
 }
 
+/**
+ * Pushes an explicit refspec (`<local>:<remote>`) without touching upstream
+ * config — the shape close uses for the base branch, whose remote mapping is
+ * resolved from its configured upstream rather than guessed.
+ */
+export async function pushRefspec(remote: string, refspec: string, cwd: string) {
+  const exitCode = await execFileInherited(["push", remote, refspec], cwd)
+  if (exitCode !== 0) throw new Error(`git push exited with code ${exitCode}`)
+}
+
 export async function removeWorktree(dir: string, cwd: string) {
   await execFile("git", ["worktree", "remove", "--", dir], { cwd })
 }
@@ -534,6 +544,13 @@ export async function isAncestor(ancestor: string, descendant: string, cwd: stri
 /** The upstream of the current branch (e.g. "origin/feat/x"), or undefined when it has none. */
 export async function upstreamRef(cwd: string): Promise<string | undefined> {
   const result = await execFile("git", ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], { cwd, allowFailure: true })
+  if (result.exitCode !== 0) return undefined
+  return result.stdout.trim() || undefined
+}
+
+/** The configured upstream of any branch (e.g. "origin/main"), or undefined when it has none. */
+export async function branchUpstream(branch: string, cwd: string): Promise<string | undefined> {
+  const result = await execFile("git", ["rev-parse", "--abbrev-ref", "--symbolic-full-name", `${branch}@{upstream}`], { cwd, allowFailure: true })
   if (result.exitCode !== 0) return undefined
   return result.stdout.trim() || undefined
 }

--- a/src/terminal-input.ts
+++ b/src/terminal-input.ts
@@ -3,6 +3,54 @@ import { createInterface } from "node:readline/promises"
 
 import { log } from "./log"
 
+/** The injectable terminal I/O a single-key confirmation can target, kept
+ * structurally compatible with the process streams so key-driver tests can
+ * feed answers and capture prompts (shared by `convoy finish` and `close`). */
+export type AskIo = {
+  input?: NodeJS.ReadableStream
+  output?: {
+    write(text: string): unknown
+  }
+}
+
+/**
+ * Single-key confirmation in the style finish originally owned: raw-mode
+ * SIGINT handling (Ctrl+C resolves the prompt) and an EOF-must-resolve rule —
+ * a stdin that reaches EOF (a pipe, a closed terminal) resolves rather than
+ * leaving the close/finish hanging. Code, not prose: one prompt implementation
+ * shared by `finish` and `close`, so their SIGINT/EOF semantics cannot drift
+ * (SC-3).
+ */
+export async function ask(question: string, io: AskIo = {}): Promise<string> {
+  // Bun's readline types only accept the exact process streams; the injectable
+  // I/O is structurally compatible, so the cast stays at this one boundary.
+  const prompt = createInterface({ input: (io.input ?? stdin) as typeof stdin, output: (io.output ?? stdout) as typeof stdout })
+  const controller = new AbortController()
+  let interrupted = false
+  prompt.on("SIGINT", () => {
+    interrupted = true
+    controller.abort()
+  })
+  const closed = new Promise<string>((resolve) => prompt.once("close", () => resolve("")))
+  try {
+    const answer = await Promise.race([prompt.question(question, { signal: controller.signal }), closed])
+    return answer.trim().toLowerCase()
+  } catch (error) {
+    if (interrupted && error instanceof Error && error.name === "AbortError") {
+      ;(io.output ?? stdout).write("\n")
+      return ""
+    }
+    throw error
+  } finally {
+    prompt.close()
+  }
+}
+
+/** Whether convoy can still ask the user anything in this invocation. */
+export function isInteractiveTerminal(): boolean {
+  return Boolean(stdin.isTTY && stdout.isTTY)
+}
+
 /** A single question asked on the terminal under the current input lock. */
 export type TerminalPrompt = {
   ask(question: string, options?: { signal?: AbortSignal }): Promise<string>

--- a/test/commit-message.test.ts
+++ b/test/commit-message.test.ts
@@ -2,13 +2,17 @@ import { describe, expect, test } from "bun:test"
 import type { Config, OpencodeClient } from "@opencode-ai/sdk/v2"
 
 import {
+  closeFallbackCommitMessage,
   commitMessagePrompt,
+  defaultCommitMessageModel,
   formatCommitMessage,
+  normalizeComposedMessage,
   proposeCommitMessage,
   readCommitMessage,
   templateCommitMessage,
   type CommitMessageInput,
 } from "../src/commit-message"
+import { parseModel } from "../src/runner"
 
 type ProposalDeps = NonNullable<Parameters<typeof proposeCommitMessage>[1]>
 
@@ -89,7 +93,7 @@ describe("proposeCommitMessage", () => {
     expect(calls.prompts[0]).toMatchObject({
       sessionID: "session-1",
       directory: "/repo",
-      model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+      model: { providerID: "openrouter", modelID: "z-ai/glm-5.3-flash" },
       agent: "convoy-commit-writer",
       tools: { read: true, list: true, glob: true, grep: true, webfetch: false, write: false, edit: false, bash: false },
     })
@@ -548,5 +552,126 @@ describe("templateCommitMessage edge cases", () => {
   test("scope is omitted when not set", () => {
     const msg = templateCommitMessage({ targetDir: "/repo", branch: "feat/feature", commits: [] })
     expect(msg.scope).toBeUndefined()
+  })
+})
+
+describe("defaultCommitMessageModel", () => {
+  // Task 1.1: the id must survive the same parsing/resolution path any run
+  // model takes, so `finish` (and close) inherit it without a special case.
+  test("the pinned writer model parses through the run model path", () => {
+    expect(defaultCommitMessageModel).toBe("openrouter/z-ai/glm-5.3-flash")
+    expect(parseModel(defaultCommitMessageModel)).toEqual({ providerID: "openrouter", modelID: "z-ai/glm-5.3-flash" })
+  })
+})
+
+describe("commitMessagePrompt scope guidance", () => {
+  const base = { targetDir: "/repo", branch: "feat/widget", commits: [] } satisfies CommitMessageInput
+
+  test("a single capability is named as the scope to use", () => {
+    const prompt = commitMessagePrompt({ ...base, scopeCandidates: ["cli"] })
+    expect(prompt).toContain("Touched capabilities: cli")
+    expect(prompt).toContain('Use "cli" as the scope')
+    expect(prompt).not.toContain("omit the scope")
+  })
+
+  test("several capabilities get the omit-scope instruction", () => {
+    const prompt = commitMessagePrompt({ ...base, scopeCandidates: ["cli", "ui"] })
+    expect(prompt).toContain("Touched capabilities: cli, ui")
+    expect(prompt).toContain("omit the scope entirely")
+  })
+
+  test("zero capabilities carry no scope section at all", () => {
+    const prompt = commitMessagePrompt({ ...base, scopeCandidates: [] })
+    expect(prompt).not.toContain("Touched capabilities")
+    expect(prompt).not.toContain("scope")
+  })
+
+  test("the proposal document is seeded into the prompt", () => {
+    const prompt = commitMessagePrompt({ ...base, proposalExcerpt: "# Add widget\n\nWhy: the board needs it." })
+    expect(prompt).toContain("The change's proposal document:")
+    expect(prompt).toContain("Add widget")
+  })
+})
+
+describe("normalizeComposedMessage", () => {
+  test("a sole touched capability replaces whatever scope the writer proposed", () => {
+    const normalized = normalizeComposedMessage({ type: "feat", scope: "everything", subject: "improve the board", body: [] }, {
+      scopeCandidates: ["control-board"],
+      changeID: "close-ux",
+    })
+    expect(normalized.scope).toBe("control-board")
+  })
+
+  test("an invalid scope candidate cannot survive cleaning into a wrong scope", () => {
+    const normalized = normalizeComposedMessage({ type: "feat", subject: "improve", body: [] }, { scopeCandidates: ["!!!"] })
+    expect(normalized.scope).toBeUndefined()
+  })
+
+  test("zero or several capabilities remove the scope", () => {
+    const none = normalizeComposedMessage({ type: "feat", scope: "x", subject: "do it", body: [] }, { scopeCandidates: [] })
+    expect(none.scope).toBeUndefined()
+    const many = normalizeComposedMessage({ type: "feat", scope: "x", subject: "do it", body: [] }, { scopeCandidates: ["a", "b"] })
+    expect(many.scope).toBeUndefined()
+  })
+
+  test("the change id is injected first in the body and never duplicated", () => {
+    const injected = normalizeComposedMessage({ type: "feat", subject: "do it", body: ["one"] }, { changeID: "close-ux" })
+    expect(injected.body[0]).toBe("change close-ux")
+    const already = normalizeComposedMessage({ type: "feat", subject: "do it", body: ["change close-ux", "one"] }, { changeID: "close-ux" })
+    expect(already.body).toEqual(["change close-ux", "one"])
+  })
+})
+
+describe("closeFallbackCommitMessage", () => {
+  test("carries the branch prefix as type, the sole capability as scope, verb + proposal title as subject, and the change id in the body", () => {
+    const message = closeFallbackCommitMessage({
+      branch: "feat/close-ux",
+      proposal: "# Close UX\n\nBetter commits and a visible close.",
+      changeID: "close-ux",
+      scopeCandidates: ["feature-close"],
+      commits: ["convoy(implementer): Implementer report"],
+    })
+    expect(message.type).toBe("feat")
+    expect(message.scope).toBe("feature-close")
+    expect(message.subject).toBe("improve close ux")
+    expect(message.body[0]).toBe("change close-ux")
+    expect(message.body).toContain("Implementer report")
+  })
+
+  test("several or zero capabilities omit the scope", () => {
+    const many = closeFallbackCommitMessage({ branch: "feat/x", proposal: "# X", changeID: "x", scopeCandidates: ["a", "b"], commits: [] })
+    expect(many.scope).toBeUndefined()
+    const none = closeFallbackCommitMessage({ branch: "feat/x", proposal: "# X", changeID: "x", commits: [] })
+    expect(none.scope).toBeUndefined()
+  })
+
+  test("a missing proposal falls back to the branch slug for the subject", () => {
+    const message = closeFallbackCommitMessage({ branch: "fix/broken-thing", changeID: "broken-thing", commits: [] })
+    expect(message.type).toBe("fix")
+    expect(message.subject).toBe("fix broken thing")
+  })
+
+  test("every verb-map branch picks its type-appropriate imperative", () => {
+    const verbOf = (branch: string, proposal: string) =>
+      closeFallbackCommitMessage({ branch, proposal, changeID: "x", commits: [] }).subject.split(" ")[0]
+    expect(verbOf("feat/x", "# X")).toBe("improve")
+    expect(verbOf("perf/x", "# X")).toBe("improve")
+    expect(verbOf("fix/x", "# X")).toBe("fix")
+    expect(verbOf("refactor/x", "# X")).toBe("refactor")
+    expect(verbOf("docs/x", "# X")).toBe("document")
+    expect(verbOf("test/x", "# X")).toBe("test")
+    expect(verbOf("chore/x", "# X")).toBe("update")
+    expect(verbOf("ci/x", "# X")).toBe("update")
+  })
+
+  test("spin's change/ prefix survives as the type", () => {
+    const message = closeFallbackCommitMessage({ branch: "change/rename-flow", proposal: "# Rename", changeID: "rename-flow", commits: [] })
+    expect(message.type).toBe("change")
+    expect(message.subject).toBe("update rename")
+  })
+
+  test("an unknown prefix defaults to feat", () => {
+    const message = closeFallbackCommitMessage({ branch: "operator/x", proposal: "# X", changeID: "x", commits: [] })
+    expect(message.type).toBe("feat")
   })
 })

--- a/test/commit-message.test.ts
+++ b/test/commit-message.test.ts
@@ -620,6 +620,15 @@ describe("normalizeComposedMessage", () => {
     const already = normalizeComposedMessage({ type: "feat", subject: "do it", body: ["change close-ux", "one"] }, { changeID: "close-ux" })
     expect(already.body).toEqual(["change close-ux", "one"])
   })
+
+  test("a collapsed subject merely containing the id does not suppress the required body line (SC-7)", () => {
+    // A collapsed commit subject like "convoy(openspec): change close-ux plan"
+    // contains the substring but is not the rule's own body line; the required
+    // `change close-ux` line must still be injected.
+    const normalized = normalizeComposedMessage({ type: "feat", subject: "improve", body: ["change close-ux plan gets archived"] }, { changeID: "close-ux" })
+    expect(normalized.body[0]).toBe("change close-ux")
+    expect(normalized.body).toContain("change close-ux plan gets archived")
+  })
 })
 
 describe("closeFallbackCommitMessage", () => {

--- a/test/feature-close-command.test.ts
+++ b/test/feature-close-command.test.ts
@@ -1,0 +1,414 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { PassThrough } from "node:stream"
+
+import {
+  applyCloseEvent,
+  closeHelp,
+  closeSurface,
+  confirmCloseMessage,
+  createCloseChecklistRenderer,
+  formatCloseEvents,
+  formatCloseFollowUps,
+  initialCloseChecklistState,
+  offerCloseFollowUps,
+  renderCloseChecklist,
+  resolveCloseFollowUps,
+  type CloseChecklistState,
+  type CloseIO,
+} from "../src/feature-close-command"
+import type { CloseEvent, ClosePreflightBlocker } from "../src/feature-close"
+
+const dirs: string[] = []
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" })
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+  if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed`)
+  return stdout.trim()
+}
+
+/** A repo with a worktree on `feat/add-widget`, no upstream, and a clean tree. */
+async function makeFixture(): Promise<{ mainDir: string; worktreeDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), "convoy-close-cmd-"))
+  dirs.push(root)
+  const mainDir = join(root, "main")
+  const worktreeDir = join(root, "wt")
+  await mkdir(mainDir, { recursive: true })
+  const user = { GIT_AUTHOR_NAME: "Operator", GIT_AUTHOR_EMAIL: "operator@example.com", GIT_COMMITTER_NAME: "Operator", GIT_COMMITTER_EMAIL: "operator@example.com" }
+  await git(mainDir, "init", "-b", "main")
+  await git(mainDir, "config", "user.email", "operator@example.com")
+  await git(mainDir, "config", "user.name", "Operator")
+  await writeFile(join(mainDir, "README.md"), "# repo\n")
+  await git(mainDir, "add", ".")
+  await git(mainDir, "commit", "-m", "chore: init")
+  await git(mainDir, "worktree", "add", "-b", "feat/add-widget", worktreeDir, "main")
+  return { mainDir, worktreeDir }
+}
+
+/** A stdout capture and a stdin that feeds the next answer the moment a
+ * question appears — readline interfaces swallow pre-buffered input, so the
+ * answers must arrive after their question is printed. */
+function createIO(answers: string[]): CloseIO & { chunks: string[]; input: PassThrough } {
+  const chunks: string[] = []
+  const input = new PassThrough()
+  let next = 0
+  const output = {
+    write: (text: string) => {
+      chunks.push(text)
+      if (next < answers.length && text.includes("[y")) input.write(`${answers[next++]!}\n`)
+      // After the last buffered answer, EOF: any further ask resolves
+      // immediately (the same path a closed terminal takes).
+      if (next >= answers.length) setImmediate(() => input.end())
+      return true
+    },
+  }
+  return { chunks, input, output }
+}
+
+const cleaned = (chunks: string[]) => chunks.join("")
+
+// -- task 3.6: mode selection ---------------------------------------------------
+
+describe("closeSurface", () => {
+  test("a TTY gets the checklist; a pipe gets the headless formatter", () => {
+    expect(closeSurface(true)).toBe("tty")
+    expect(closeSurface(false)).toBe("headless")
+  })
+})
+
+// -- task 4.1: the help contract ---------------------------------------------------
+
+describe("closeHelp", () => {
+  const help = closeHelp()
+
+  test("documents the interactive and headless contracts", () => {
+    expect(help).toContain("live checklist")
+    expect(help).toContain("confirm or")
+    expect(help).toContain("fast-forward")
+    expect(help).toContain("upstream")
+    expect(help).toContain("Headless")
+    expect(help).toContain("--resume")
+    expect(help).toContain("--message")
+  })
+})
+
+// -- task 3.2: the checklist frames ----------------------------------------------
+
+describe("renderCloseChecklist", () => {
+  const preflight: CloseEvent = { type: "preflight", summary: "clean tree · 2/2 tasks · no live runs" }
+
+  const stateThrough = (events: CloseEvent[]): CloseChecklistState => events.reduce(applyCloseEvent, initialCloseChecklistState())
+
+  test("a running frame shows the preflight line, checked skips, and the running step", () => {
+    const frame = renderCloseChecklist(
+      stateThrough([
+        preflight,
+        { type: "step-skipped", step: "sync", reason: "main is already an ancestor of feat/add-widget" },
+        { type: "step-started", step: "archive" },
+      ]),
+    )
+    expect(frame).toEqual([
+      "preflight: clean tree · 2/2 tasks · no live runs",
+      "  ⊘ sync — skipped: main is already an ancestor of feat/add-widget",
+      "  ▸ archive…",
+      "  ○ squash",
+      "  ○ merge",
+    ])
+  })
+
+  test("a completed fast-forward frame narrates the shape and the close", () => {
+    const frame = renderCloseChecklist(
+      stateThrough([
+        preflight,
+        { type: "step-skipped", step: "sync", reason: "main is already an ancestor" },
+        { type: "step-completed", step: "archive", detail: "archived add-widget" },
+        { type: "step-completed", step: "squash", detail: "2 commits → abcd1234" },
+        { type: "merge-shape", shape: "fast-forward" },
+        { type: "step-completed", step: "merge", detail: "merged (fast-forward)" },
+        {
+          type: "result",
+          result: { changeID: "add-widget", branch: "feat/add-widget", worktreeDir: "/wt", baseRef: "main", squashed: { sha: "abcd1234", replaced: 2 }, merged: true, mergeShape: "fast-forward" },
+        },
+      ]),
+    )
+    expect(frame.at(-3)).toContain("✓ merge — merged (fast-forward)")
+    expect(frame.at(-2)).toBe("")
+    expect(frame.at(-1)).toBe("closed add-widget: feat/add-widget → main")
+    expect(frame.some((line) => line.includes("⊘ sync — skipped:"))).toBe(true)
+  })
+
+  test("a stopped frame keeps the failed step and its remediation visible", () => {
+    const frame = renderCloseChecklist(
+      stateThrough([
+        preflight,
+        { type: "step-started", step: "archive" },
+        { type: "step-failed", step: "archive", message: "archive: openspec archive add-widget failed\nstderr detail" },
+      ]),
+    )
+    expect(frame).toContain("  ✗ archive — openspec archive add-widget failed")
+    expect(frame.some((line) => line.includes("stopped"))).toBe(false)
+    expect(frame.some((line) => line.includes("▸"))).toBe(false)
+  })
+
+  test("a preflight failure renders the blockers instead of a checklist", () => {
+    const blockers: ClosePreflightBlocker[] = [{ check: "tasks", message: "2 of 3 tasks are incomplete — finish them before closing" }]
+    const frame = renderCloseChecklist(stateThrough([{ type: "preflight-failed", blockers }]))
+    expect(frame).toEqual(["close preflight failed:", "  2 of 3 tasks are incomplete — finish them before closing"])
+  })
+})
+
+describe("createCloseChecklistRenderer", () => {
+  test("redraws in place with cursor-up, and break() makes the next event print fresh", () => {
+    const chunks: string[] = []
+    const renderer = createCloseChecklistRenderer((text) => chunks.push(text))
+    renderer.onEvent({ type: "preflight", summary: "clean tree" })
+    const firstFrame = chunks.join("")
+    expect(firstFrame).toContain("preflight: clean tree")
+    expect(firstFrame).not.toContain("\x1b[")
+
+    const afterFirstFrame = chunks.length
+    renderer.onEvent({ type: "step-started", step: "sync" })
+    const redraw = chunks.slice(afterFirstFrame).join("")
+    expect(redraw.startsWith("\x1b[5A\x1b[J")).toBe(true)
+
+    renderer.break()
+    const afterSecondFrame = chunks.length
+    renderer.onEvent({ type: "step-completed", step: "sync", detail: "done" })
+    expect(chunks.slice(afterSecondFrame).join("")).not.toContain("\x1b[")
+  })
+})
+
+// -- task 3.1: the headless formatter ---------------------------------------------
+
+describe("formatCloseEvents", () => {
+  const successEvents: CloseEvent[] = [
+    { type: "preflight", summary: "clean tree · 2/2 tasks · no live runs" },
+    { type: "step-skipped", step: "sync", reason: "main is already an ancestor of feat/add-widget" },
+    { type: "step-completed", step: "archive", detail: "archived add-widget" },
+    { type: "step-completed", step: "squash", detail: "2 commits → abcd1234" },
+    { type: "merge-shape", shape: "fast-forward" },
+    { type: "step-completed", step: "merge", detail: "merged (fast-forward)" },
+    {
+      type: "result",
+      result: { changeID: "add-widget", branch: "feat/add-widget", worktreeDir: "/wt", baseRef: "main", merged: true, mergeShape: "fast-forward" },
+    },
+  ]
+
+  test("a successful close prints per-step facts and executable follow-ups in safe order", () => {
+    const followUps = {
+      push: { remote: "origin", refspec: "main:main", command: "git push origin main:main" },
+      worktreeRemoval: "git worktree remove /wt",
+      branchDelete: "git branch -d feat/add-widget",
+    }
+    const text = formatCloseEvents(successEvents, { followUps })
+    expect(text).toContain("preflight: clean tree · 2/2 tasks · no live runs")
+    expect(text).toContain("sync: skipped — main is already an ancestor of feat/add-widget")
+    expect(text).toContain("merge: merged (fast-forward)")
+    expect(text).toContain("closed add-widget: feat/add-widget → main")
+    // Push names remote and refspec explicitly, and worktree removal is
+    // printed before branch deletion (design D7's safe execution order).
+    const pushAt = text.indexOf("git push origin main:main")
+    const worktreeAt = text.indexOf("git worktree remove /wt")
+    const deleteAt = text.indexOf("git branch -d feat/add-widget")
+    expect(pushAt).toBeGreaterThan(-1)
+    expect(worktreeAt).toBeGreaterThan(pushAt)
+    expect(deleteAt).toBeGreaterThan(worktreeAt)
+  })
+
+  test("a missing upstream prints the remediation and never an invalid push command", () => {
+    const followUps = {
+      pushRemediation: "main has no configured upstream — set one first: git branch --set-upstream-to=<remote>/<branch> main",
+      worktreeRemoval: "git worktree remove /wt",
+      branchDelete: "git branch -d feat/add-widget",
+    }
+    const text = formatCloseEvents(successEvents, { followUps })
+    expect(text).toContain("push unavailable — main has no configured upstream")
+    expect(text).not.toMatch(/git push\s+main\s*$/m)
+    expect(text).not.toContain("git push main\n")
+  })
+
+  test("a mid-sequence stop prints the failed step and never a close line", () => {
+    const text = formatCloseEvents(
+      [
+        { type: "preflight", summary: "clean tree" },
+        { type: "step-started", step: "archive" },
+        { type: "step-failed", step: "archive", message: "archive: openspec archive add-widget failed\nthe stderr" },
+      ],
+      { failure: "archive: openspec archive add-widget failed\nthe stderr" },
+    )
+    expect(text).toContain("archive: failed — archive: openspec archive add-widget failed")
+    expect(text).not.toContain("closed ")
+    expect(text).not.toContain("optional follow-ups")
+  })
+})
+
+// -- task 3.4: upstream-aware follow-ups -------------------------------------------
+
+describe("resolveCloseFollowUps", () => {
+  test("a configured upstream becomes an explicit remote + refspec push", async () => {
+    const fixture = await makeFixture()
+    // Configure main's upstream without a real remote: git resolves the
+    // symbolic name from the remote config plus the tracking ref alone.
+    await git(fixture.mainDir, "config", "remote.origin.url", "/tmp/fake-origin.git")
+    await git(fixture.mainDir, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
+    await git(fixture.mainDir, "config", "branch.main.remote", "origin")
+    await git(fixture.mainDir, "config", "branch.main.merge", "refs/heads/main")
+    await git(fixture.mainDir, "update-ref", "refs/remotes/origin/main", "HEAD")
+    const followUps = await resolveCloseFollowUps({ targetDir: fixture.mainDir, baseRef: "main", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir })
+    expect(followUps.push).toEqual({ remote: "origin", refspec: "main:main", command: "git push origin main:main" })
+    expect(followUps.pushRemediation).toBeUndefined()
+    expect(followUps.worktreeRemoval).toBe(`git worktree remove ${fixture.worktreeDir}`)
+    expect(followUps.branchDelete).toBe("git branch -d feat/add-widget")
+  })
+
+  test("a missing upstream yields the remediation and no push", async () => {
+    const fixture = await makeFixture()
+    const followUps = await resolveCloseFollowUps({ targetDir: fixture.mainDir, baseRef: "main", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir })
+    expect(followUps.push).toBeUndefined()
+    expect(followUps.pushRemediation).toContain("no configured upstream")
+    expect(followUps.pushRemediation).toContain("git branch --set-upstream-to=")
+  })
+
+  test("a worktree that is the main checkout offers no removal", async () => {
+    const fixture = await makeFixture()
+    const followUps = await resolveCloseFollowUps({ targetDir: fixture.mainDir, baseRef: "main", branch: "main", worktreeDir: fixture.mainDir })
+    expect(followUps.worktreeRemoval).toBeUndefined()
+  })
+
+  test("formatCloseFollowUps keeps push, worktree removal, then branch deletion in order", () => {
+    const lines = formatCloseFollowUps({
+      push: { remote: "origin", refspec: "main:main", command: "git push origin main:main" },
+      worktreeRemoval: "git worktree remove /wt",
+      branchDelete: "git branch -d feat/x",
+    })
+    const at = (needle: string) => lines.findIndex((line) => line.includes(needle))
+    expect(at("git push origin main:main")).toBeGreaterThan(-1)
+    expect(at("git worktree remove /wt")).toBeGreaterThan(at("git push origin main:main"))
+    expect(at("git branch -d feat/x")).toBeGreaterThan(at("git worktree remove /wt"))
+  })
+})
+
+// -- task 3.3: the message gate key-driver ------------------------------------------
+
+describe("confirmCloseMessage", () => {
+  const proposal = { message: "feat(cli): improve the close flow\n\n- change add-widget", source: "model" as const }
+
+  test("accept returns the proposal unchanged and no commit ran before it", async () => {
+    const io = createIO(["y"])
+    const result = await confirmCloseMessage(proposal, { ...io })
+    expect(result).toBe(proposal.message)
+    expect(cleaned(io.chunks)).toContain("feat(cli): improve the close flow")
+  })
+
+  test("edit-then-accept lands the edited message", async () => {
+    const binDir = await mkdtemp(join(tmpdir(), "convoy-close-editor-"))
+    dirs.push(binDir)
+    const editor = join(binDir, "replace-editor")
+    await writeFile(editor, "#!/bin/sh\nprintf 'edited subject\\n\\n- edited body\\n' > \"$1\"\n")
+    await chmod(editor, 0o755)
+    const saved = process.env.GIT_EDITOR
+    process.env.GIT_EDITOR = editor
+    try {
+      const io = createIO(["e"])
+      const result = await confirmCloseMessage(proposal, { ...io })
+      expect(result).toBe("edited subject\n\n- edited body")
+    } finally {
+      if (saved === undefined) delete process.env.GIT_EDITOR
+      else process.env.GIT_EDITOR = saved
+    }
+  })
+
+  test("an editor cancellation re-asks; a declined prompt returns undefined", async () => {
+    const binDir = await mkdtemp(join(tmpdir(), "convoy-close-editor-"))
+    dirs.push(binDir)
+    const editor = join(binDir, "failing-editor")
+    await writeFile(editor, "#!/bin/sh\nexit 1\n")
+    await chmod(editor, 0o755)
+    const saved = process.env.GIT_EDITOR
+    process.env.GIT_EDITOR = editor
+    try {
+      // e → editor dies → re-ask → EOF resolves as "" → declined.
+      const io = createIO(["e"])
+      const result = await confirmCloseMessage(proposal, { ...io })
+      expect(result).toBeUndefined()
+      expect(cleaned(io.chunks)).toContain("editor cancelled — nothing has landed")
+    } finally {
+      if (saved === undefined) delete process.env.GIT_EDITOR
+      else process.env.GIT_EDITOR = saved
+    }
+  })
+})
+
+// -- task 3.4: the cleanup dependency graph ------------------------------------------
+
+describe("offerCloseFollowUps", () => {
+  test("declined worktree removal keeps branch deletion unavailable and prints both commands", async () => {
+    const fixture = await makeFixture()
+    const io = createIO(["n"])
+    await offerCloseFollowUps(
+      {
+        branchDelete: "git branch -d feat/add-widget",
+        worktreeRemoval: `git worktree remove ${fixture.worktreeDir}`,
+        baseRef: "main",
+        branch: "feat/add-widget",
+        worktreeDir: fixture.worktreeDir,
+        targetDir: fixture.mainDir,
+      },
+      io,
+    )
+    const text = cleaned(io.chunks)
+    expect(text).toContain(`next: git worktree remove ${fixture.worktreeDir}`)
+    expect(text).toContain("next (after the worktree is removed): git branch -d feat/add-widget")
+    // The branch still exists and still has its worktree.
+    expect((await stat(fixture.worktreeDir)).isDirectory()).toBe(true)
+    expect(await git(fixture.mainDir, "rev-parse", "--verify", "feat/add-widget")).toBeTruthy()
+  })
+
+  test("an accepted worktree removal is what enables the branch deletion offer", async () => {
+    const fixture = await makeFixture()
+    const io = createIO(["y", "n"])
+    await offerCloseFollowUps(
+      {
+        branchDelete: "git branch -d feat/add-widget",
+        worktreeRemoval: `git worktree remove ${fixture.worktreeDir}`,
+        baseRef: "main",
+        branch: "feat/add-widget",
+        worktreeDir: fixture.worktreeDir,
+        targetDir: fixture.mainDir,
+      },
+      io,
+    )
+    const text = cleaned(io.chunks)
+    expect(text).toContain("worktree removed")
+    // The worktree is gone, so the branch-delete offer appeared (declined here).
+    await expect(stat(fixture.worktreeDir)).rejects.toThrow()
+    expect(text).toContain("next: git branch -d feat/add-widget")
+    expect(await git(fixture.mainDir, "rev-parse", "--verify", "feat/add-widget")).toBeTruthy()
+  })
+
+  test("branch deletion runs only after the worktree removal succeeded", async () => {
+    const fixture = await makeFixture()
+    const io = createIO(["y", "y"])
+    await offerCloseFollowUps(
+      {
+        branchDelete: "git branch -d feat/add-widget",
+        worktreeRemoval: `git worktree remove ${fixture.worktreeDir}`,
+        baseRef: "main",
+        branch: "feat/add-widget",
+        worktreeDir: fixture.worktreeDir,
+        targetDir: fixture.mainDir,
+      },
+      io,
+    )
+    expect(cleaned(io.chunks)).toContain("branch feat/add-widget deleted")
+    await expect(stat(fixture.worktreeDir)).rejects.toThrow()
+    await expect(git(fixture.mainDir, "rev-parse", "--verify", "feat/add-widget")).rejects.toThrow()
+  })
+})
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})

--- a/test/feature-close-command.test.ts
+++ b/test/feature-close-command.test.ts
@@ -23,6 +23,12 @@ import type { CloseEvent, ClosePreflightBlocker } from "../src/feature-close"
 
 const dirs: string[] = []
 
+/** git reports repo paths in the kernel's canonical form (/private/var on macOS). */
+async function realPath(path: string): Promise<string> {
+  const { realpath } = await import("node:fs/promises")
+  return realpath(path)
+}
+
 async function git(cwd: string, ...args: string[]): Promise<string> {
   const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" })
   const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
@@ -258,10 +264,13 @@ describe("resolveCloseFollowUps", () => {
     await git(fixture.mainDir, "config", "branch.main.merge", "refs/heads/main")
     await git(fixture.mainDir, "update-ref", "refs/remotes/origin/main", "HEAD")
     const followUps = await resolveCloseFollowUps({ targetDir: fixture.mainDir, baseRef: "main", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir })
-    expect(followUps.push).toEqual({ remote: "origin", refspec: "main:main", command: "git push origin main:main" })
+    // The printed commands carry git -C <main-repo> and only quote unsafe paths,
+    // so they stay executable from inside the feature worktree (SC-2).
+    const main = await realPath(fixture.mainDir)
+    expect(followUps.push).toEqual({ remote: "origin", refspec: "main:main", command: `git -C ${main} push origin main:main` })
     expect(followUps.pushRemediation).toBeUndefined()
-    expect(followUps.worktreeRemoval).toBe(`git worktree remove ${fixture.worktreeDir}`)
-    expect(followUps.branchDelete).toBe("git branch -d feat/add-widget")
+    expect(followUps.worktreeRemoval).toBe(`git -C ${main} worktree remove ${fixture.worktreeDir}`)
+    expect(followUps.branchDelete).toBe(`git -C ${main} branch -d feat/add-widget`)
   })
 
   test("a missing upstream yields the remediation and no push", async () => {
@@ -269,7 +278,7 @@ describe("resolveCloseFollowUps", () => {
     const followUps = await resolveCloseFollowUps({ targetDir: fixture.mainDir, baseRef: "main", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir })
     expect(followUps.push).toBeUndefined()
     expect(followUps.pushRemediation).toContain("no configured upstream")
-    expect(followUps.pushRemediation).toContain("git branch --set-upstream-to=")
+    expect(followUps.pushRemediation).toContain("branch --set-upstream-to=")
   })
 
   test("a worktree that is the main checkout offers no removal", async () => {
@@ -406,6 +415,29 @@ describe("offerCloseFollowUps", () => {
     expect(cleaned(io.chunks)).toContain("branch feat/add-widget deleted")
     await expect(stat(fixture.worktreeDir)).rejects.toThrow()
     await expect(git(fixture.mainDir, "rev-parse", "--verify", "feat/add-widget")).rejects.toThrow()
+  })
+
+  test("an already-removed worktree makes branch deletion immediately available (SC-9)", async () => {
+    const fixture = await makeFixture()
+    // Remove the worktree out from under close (by hand / a prior run), so
+    // resolveCloseFollowUps returns no removal command.
+    await git(fixture.mainDir, "worktree", "remove", fixture.worktreeDir)
+    await expect(stat(fixture.worktreeDir)).rejects.toThrow()
+    const io = createIO([])
+    await offerCloseFollowUps(
+      {
+        branchDelete: "git branch -d feat/add-widget",
+        baseRef: "main",
+        branch: "feat/add-widget",
+        worktreeDir: fixture.worktreeDir,
+        targetDir: fixture.mainDir,
+      },
+      io,
+    )
+    const text = cleaned(io.chunks)
+    // The branch is deletable now — the immediate command, not a wait.
+    expect(text).toContain("next: git branch -d feat/add-widget")
+    expect(text).not.toContain("after the worktree is removed")
   })
 })
 

--- a/test/feature-close.test.ts
+++ b/test/feature-close.test.ts
@@ -461,6 +461,60 @@ describe("runClose", () => {
     expect(subject).toBe("feat(cli): exact override")
   })
 
+  test("an empty --message still bypasses composition (SC-8)", async () => {
+    const fixture = await makeFixture()
+    // Presence, not truthiness: `--message ""` must not fall through to the
+    // writer. (git rejects an empty message, which is the failure here — but
+    // neither the writer nor the resolver may even be reached.)
+    let writerRan = false
+    let resolverRan = false
+    await expect(
+      runTestClose(fixture, {
+        message: "",
+        writer: async () => {
+          writerRan = true
+          return { message: templateCommitMessage({ targetDir: "", branch: "", commits: [] }), source: "template", error: "n/a" }
+        },
+        resolveMessage: async () => {
+          resolverRan = true
+          return ""
+        },
+      }),
+    ).rejects.toThrow()
+    expect(writerRan).toBe(false)
+    expect(resolverRan).toBe(false)
+  })
+
+  test("control bytes from a model message are stripped before the commit lands (SC-4)", async () => {
+    const fixture = await makeFixture()
+    await runTestClose(fixture, {
+      writer: async () => ({
+        message: { type: "feat", scope: "hack", subject: "improve \u001b[31mred\u001b[0m", body: ["a line\u001b[K"] },
+        source: "model",
+      }),
+    })
+    const subject = await git(fixture.mainDir, undefined, "log", "--format=%s", "-n", "1", "main")
+    // The sole capability still wins the scope; the escape sequences are gone.
+    expect(subject).toBe("feat(cli): improve red")
+    const body = await git(fixture.mainDir, undefined, "log", "--format=%B", "-n", "1", "main")
+    expect(body).not.toContain("\u001b")
+  })
+
+  test("an applySquash failure emits a step-failed squash event (SC-5)", async () => {
+    const fixture = await makeFixture()
+    const finish = await import("../src/finish")
+    const spy = spyOn(finish, "applySquash")
+    spy.mockRejectedValue(new Error("signature declined"))
+    try {
+      const events: CloseEvent[] = []
+      await expect(runTestClose(fixture, { onEvent: (event) => events.push(event) })).rejects.toThrow(/signature declined/)
+      expect(events[events.length - 1]).toMatchObject({ type: "step-failed", step: "squash" })
+      expect(events.some((event) => event.type === "result")).toBe(false)
+    } finally {
+      spy.mockRestore()
+    }
+  })
+
   test("a declined message stops before the squash and nothing lands", async () => {
     const fixture = await makeFixture()
     const branchBefore = await git(fixture.worktreeDir, undefined, "rev-parse", "HEAD")
@@ -471,6 +525,35 @@ describe("runClose", () => {
     expect(branchAfter).not.toBe(branchBefore)
     const mainLog = await git(fixture.mainDir, undefined, "log", "--format=%s", "main")
     expect(mainLog).not.toContain("improve add widget")
+  })
+
+  test("a resumed close after a declined message on a synced branch leaks no raw convoy commit onto the base (SC-1)", async () => {
+    const fixture = await makeFixture()
+    // Advance main so the first attempt's sync step creates an
+    // operator-identity merge commit the resumed squash must fold.
+    await writeFile(join(fixture.mainDir, "main-advance.txt"), "advance\n")
+    await git(fixture.mainDir, undefined, "add", ".")
+    await git(fixture.mainDir, undefined, "commit", "-m", "chore: advance main in parallel")
+
+    // First attempt: sync runs, archive runs, the message is declined at the
+    // squash gate — the sequence stops with the sync merge and archive commit
+    // already on the feature branch.
+    await expect(runTestClose(fixture, { resolveMessage: async () => undefined })).rejects.toThrow(/wasn't confirmed[\s\S]*--resume/)
+
+    // Resume accepts. The resumed squash must re-discover the sync merge and
+    // fold it (plus the archive and convoy commits) instead of leaking them.
+    const result = await runTestClose(fixture, {
+      resume: true,
+      resolveMessage: async (proposal) => proposal.message,
+    })
+    expect(result.merged).toBe(true)
+    expect(result.mergeShape).toBe("merge-commit")
+
+    const log = await git(fixture.mainDir, undefined, "log", "--format=%s", "main")
+    expect(log).not.toContain("convoy(implement): implement add-widget")
+    expect(log).not.toContain("chore(openspec): archive add-widget")
+    // The operator's proposal commit survives the walk.
+    expect(log).toContain("feat(openspec): propose add-widget")
   })
 
   // -- task 2.4: merge shapes --------------------------------------------------

--- a/test/feature-close.test.ts
+++ b/test/feature-close.test.ts
@@ -3,9 +3,25 @@ import { chmod, mkdir, mkdtemp, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { archiveChangeOnMain, closePreflight, resolveCloseTarget, runClose } from "../src/feature-close"
+import { archiveChangeOnMain, closePreflight, resolveCloseTarget, runClose, type CloseEvent, type CloseInput } from "../src/feature-close"
+import { templateCommitMessage, type CommitMessageProposal } from "../src/commit-message"
 
 const dirs: string[] = []
+
+/** A writer double that always fails, so close degrades to its deterministic
+ * fallback exactly as it would during a model outage — fast and hermetically. */
+const writerFails: CloseInput["writer"] = async () =>
+  ({ message: templateCommitMessage({ targetDir: "", branch: "", commits: [] }), source: "template", error: "writer unavailable (test double)" }) satisfies CommitMessageProposal
+
+/** Runs the close sequence with the failing writer double unless a test brings its own. */
+const runTestClose = (fixture: Fixture, extra: Partial<CloseInput> = {}) => runClose({ ...closeInput(fixture), writer: writerFails, ...extra })
+
+/** Collects the event stream of a close run. */
+const collectEvents = async (fixture: Fixture, extra: Partial<CloseInput> = {}): Promise<CloseEvent[]> => {
+  const events: CloseEvent[] = []
+  await runTestClose(fixture, { ...extra, onEvent: (event) => events.push(event) })
+  return events
+}
 
 /** git reports worktree paths through the kernel's canonical form
  * (`/private/var/...` on macOS); tests compare against the same form. */
@@ -72,6 +88,11 @@ async function writeOpenspecDouble(binDir: string): Promise<void> {
   const path = join(binDir, "openspec")
   await writeFile(path, script)
   await chmod(path, 0o755)
+  // An `opencode` double that dies instantly: any code path that reaches for
+  // the real commit-writer server fails fast instead of hanging a test on a
+  // live model (the tests below bring their own writer doubles instead).
+  await writeFile(join(binDir, "opencode"), "#!/bin/sh\nexit 1\n")
+  await chmod(join(binDir, "opencode"), 0o755)
 }
 
 type Fixture = {
@@ -125,6 +146,8 @@ const closeInput = (fixture: Fixture) => ({
   changeID: "add-widget",
 })
 
+const originalPath = process.env.PATH
+
 beforeAll(async () => {
   // The OpenSpec CLI double leads PATH so `runClose` never shells out to the
   // real tool (whose validation needs full OpenSpec-authoring rigor).
@@ -142,6 +165,8 @@ beforeAll(async () => {
 
 afterAll(async () => {
   delete process.env.CONVOY_HOME
+  // The fake bin dir must not leak into other test files sharing this process.
+  if (originalPath !== undefined) process.env.PATH = originalPath
   await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
@@ -192,9 +217,14 @@ describe("closePreflight", () => {
 })
 
 describe("runClose", () => {
+  // The deterministic fallback for this fixture: branch prefix `feat`, the
+  // sole touched capability `cli` as scope, the proposal title behind the
+  // type-appropriate verb, and the change id first in the body.
+  const fallbackSubject = "feat(cli): improve add widget"
+
   test("the full sequence: archive via the CLI, one conventional commit, operator commit survives, merged", async () => {
     const fixture = await makeFixture()
-    const result = await runClose(closeInput(fixture))
+    const result = await runTestClose(fixture)
 
     expect(result.merged).toBe(true)
     // The archive commit and the convoy implement commit collapse into one;
@@ -205,20 +235,23 @@ describe("runClose", () => {
     expect((await stat(join(fixture.worktreeDir, "openspec", "changes", "archive", "add-widget"))).isDirectory()).toBe(true)
     // The base branch gained the squashed conventional commit and the operator's proposal commit.
     const log = await git(fixture.mainDir, undefined, "log", "--format=%s", "main")
-    expect(log).toContain("feat: add-widget")
+    expect(log).toContain(fallbackSubject)
     expect(log).toContain("feat(openspec): propose add-widget")
+    const body = await git(fixture.mainDir, undefined, "log", "--format=%B", "-n", "1", "main")
+    expect(body).toContain("change add-widget")
     // The worktree still exists until the operator accepts its removal.
     expect((await stat(fixture.worktreeDir)).isDirectory()).toBe(true)
   })
 
   test("the sequence is resumable: completed steps are not redone", async () => {
     const fixture = await makeFixture()
-    await runClose(closeInput(fixture))
+    await runTestClose(fixture)
     // A resume finds nothing left to do: the change dir is gone (archive done)
     // and the branch is contained in the base (merge done).
-    const result = await runClose({ ...closeInput(fixture), resume: true })
+    const result = await runTestClose(fixture, { resume: true })
     expect(result.merged).toBe(true)
     expect(result.squashed).toBeUndefined()
+    expect(result.mergeShape).toBe("already-up-to-date")
   })
 
   test("a clean sync folds the sync merge and convoy commits into one conventional commit (SC-2)", async () => {
@@ -230,14 +263,14 @@ describe("runClose", () => {
     await git(fixture.mainDir, undefined, "add", ".")
     await git(fixture.mainDir, undefined, "commit", "-m", "chore: advance main in parallel")
 
-    const result = await runClose(closeInput(fixture))
+    const result = await runTestClose(fixture)
     expect(result.merged).toBe(true)
 
     const log = await git(fixture.mainDir, undefined, "log", "--format=%s", "main")
     // The operator's proposal commit survives, and the feature lands as the
     // one conventional commit — the base's own advance is also present.
     expect(log).toContain("feat(openspec): propose add-widget")
-    expect(log).toContain("feat: add-widget")
+    expect(log).toContain(fallbackSubject)
     expect(log).toContain("chore: advance main in parallel")
     // ...and none of the raw convoy step commits or the archive commit leak
     // through the squash.
@@ -253,19 +286,19 @@ describe("runClose", () => {
     await git(fixture.mainDir, undefined, "commit", "-m", "chore: main moves shared.txt")
     await writeFile(join(fixture.worktreeDir, "shared.txt"), "from feature\n")
     await git(fixture.worktreeDir, undefined, "add", ".")
-    await git(fixture.worktreeDir, { GIT_AUTHOR_NAME: "Operator", GIT_AUTHOR_EMAIL: "operator@example.com", GIT_COMMITTER_NAME: "Operator", GIT_COMMITTER_EMAIL: "operator@example.com" }, "commit", "-m", "feat: feature moves shared.txt")
+    await git(fixture.worktreeDir, undefined, "commit", "-m", "feat: feature moves shared.txt")
 
-    await expect(runClose(closeInput(fixture))).rejects.toThrow(/sync.*conflicted[\s\S]*--resume/)
+    await expect(runTestClose(fixture)).rejects.toThrow(/sync.*conflicted[\s\S]*--resume/)
     // Nothing was archived or merged.
     expect((await stat(join(fixture.worktreeDir, "openspec", "changes", "add-widget"))).isDirectory()).toBe(true)
     const mainLog = await git(fixture.mainDir, undefined, "log", "--format=%s", "main")
-    expect(mainLog).not.toContain("feat: add-widget")
+    expect(mainLog).not.toContain("add-widget")
   })
 
   test("preflight failure changes nothing on any branch", async () => {
     const fixture = await makeFixture({ tasksDone: false })
     const before = await git(fixture.mainDir, undefined, "rev-parse", "HEAD")
-    await expect(runClose(closeInput(fixture))).rejects.toThrow(/preflight failed/)
+    await expect(runTestClose(fixture)).rejects.toThrow(/preflight failed/)
     expect(await git(fixture.mainDir, undefined, "rev-parse", "HEAD")).toBe(before)
   })
 
@@ -273,16 +306,182 @@ describe("runClose", () => {
     const fixture = await makeFixture()
     process.env.CONVOY_OPENSPEC_ARCHIVE_FAIL = "1"
     try {
-      await expect(runClose(closeInput(fixture))).rejects.toThrow(/archive.*failed[\s\S]*before any squash or merge/)
+      await expect(runTestClose(fixture)).rejects.toThrow(/archive.*failed[\s\S]*before any squash or merge/)
       // The change was not archived (the CLI failed before moving it)...
       expect((await stat(join(fixture.worktreeDir, "openspec", "changes", "add-widget"))).isDirectory()).toBe(true)
       await expect(stat(join(fixture.worktreeDir, "openspec", "changes", "archive", "add-widget"))).rejects.toThrow()
       // ...and nothing landed on the base branch (no squash, no merge).
       const mainLog = await git(fixture.mainDir, undefined, "log", "--format=%s", "main")
-      expect(mainLog).not.toContain("feat: add-widget")
+      expect(mainLog).not.toContain("add-widget")
     } finally {
       delete process.env.CONVOY_OPENSPEC_ARCHIVE_FAIL
     }
+  })
+
+  // -- task 2.2: the one-way event stream -----------------------------------
+
+  test("a clean close narrates preflight, skipped sync, and each step as it happens", async () => {
+    const fixture = await makeFixture()
+    const events = await collectEvents(fixture)
+
+    expect(events[0]).toEqual({ type: "preflight", summary: "clean tree · 2/2 tasks · no live runs" })
+    // The base hasn't moved, so the sync is a detected skip, not a merge.
+    expect(events[1]).toMatchObject({ type: "step-skipped", step: "sync" })
+    const steps = events.map((event) =>
+      event.type === "step-started" || event.type === "step-completed" || event.type === "step-skipped" || event.type === "step-failed"
+        ? `${event.type}:${event.step}`
+        : event.type,
+    )
+    expect(steps).toEqual([
+      "preflight",
+      "step-skipped:sync",
+      "step-started:archive",
+      "step-completed:archive",
+      "step-started:squash",
+      "step-completed:squash",
+      "step-started:merge",
+      "merge-shape",
+      "step-completed:merge",
+      "result",
+    ])
+    // The base never moved, so the merge narrates its fast-forward shape.
+    expect(events).toContainEqual({ type: "merge-shape", shape: "fast-forward" })
+    const result = events.find((event) => event.type === "result")
+    expect(result && result.type === "result" ? result.result.mergeShape : undefined).toBe("fast-forward")
+  })
+
+  test("a mid-sequence archive stop emits the failed step and its remediation", async () => {
+    const fixture = await makeFixture()
+    process.env.CONVOY_OPENSPEC_ARCHIVE_FAIL = "1"
+    try {
+      const events: CloseEvent[] = []
+      await expect(runTestClose(fixture, { onEvent: (event) => events.push(event) })).rejects.toThrow(/before any squash or merge/)
+      expect(events[events.length - 1]).toMatchObject({ type: "step-failed", step: "archive" })
+      expect(events.some((event) => event.type === "result")).toBe(false)
+    } finally {
+      delete process.env.CONVOY_OPENSPEC_ARCHIVE_FAIL
+    }
+  })
+
+  test("a resume shows the previously completed sequence as detected skips", async () => {
+    const fixture = await makeFixture()
+    await runTestClose(fixture)
+    const events = await collectEvents(fixture, { resume: true })
+    const skips = events.filter((event) => event.type === "step-skipped")
+    expect(skips).toHaveLength(4)
+    for (const skip of skips) {
+      if (skip.type !== "step-skipped") continue
+      expect(["sync", "archive", "squash", "merge"]).toContain(skip.step)
+      expect(skip.reason.length).toBeGreaterThan(0)
+    }
+    expect(events).toContainEqual({ type: "merge-shape", shape: "already-up-to-date" })
+  })
+
+  // -- task 2.1: the message snapshot survives the archive's move ------------
+
+  test("the writer receives the pre-archive snapshot even though archive moved the live change", async () => {
+    const fixture = await makeFixture()
+    const seen: Parameters<NonNullable<CloseInput["writer"]>>[0][] = []
+    await runTestClose(fixture, {
+      writer: async (input) => {
+        seen.push(input)
+        return writerFails(input)
+      },
+    })
+    expect(seen).toHaveLength(1)
+    // The change dir is long gone by composition time...
+    await expect(stat(join(fixture.worktreeDir, "openspec", "changes", "add-widget", "proposal.md"))).rejects.toThrow()
+    // ...yet the writer was seeded with the captured proposal, capabilities, and commits.
+    expect(seen[0]!.proposalExcerpt).toContain("Add widget")
+    expect(seen[0]!.scopeCandidates).toEqual(["cli"])
+    expect(seen[0]!.commits).toContain("convoy(implement): implement add-widget")
+  })
+
+  // -- task 2.3: the resolver gate -------------------------------------------
+
+  test("a model proposal is normalized (scope enforced, change id in body) and lands after the resolver accepts", async () => {
+    const fixture = await makeFixture()
+    const seenProposals: Array<{ message: string; source: string; error?: string }> = []
+    const result = await runTestClose(fixture, {
+      writer: async () => ({
+        message: { type: "feat", scope: "everything", subject: "improve the close flow", body: ["one change"] },
+        source: "model",
+      }),
+      resolveMessage: async (proposal) => {
+        seenProposals.push(proposal)
+        return proposal.message
+      },
+    })
+    expect(result.squashed).toBeDefined()
+    // The writer's broad scope was corrected to the sole touched capability,
+    // and the change id was injected into the body.
+    expect(seenProposals).toHaveLength(1)
+    expect(seenProposals[0]!.source).toBe("model")
+    expect(seenProposals[0]!.message).toBe("feat(cli): improve the close flow\n\n- change add-widget\n- one change")
+    const subject = await git(fixture.mainDir, undefined, "log", "--format=%s", "-n", "1", "main")
+    expect(subject).toBe("feat(cli): improve the close flow")
+  })
+
+  test("the fallback proposal names its writer failure and still closes", async () => {
+    const fixture = await makeFixture()
+    const seenProposals: Array<{ source: string; error?: string }> = []
+    const result = await runTestClose(fixture, {
+      resolveMessage: async (proposal) => {
+        seenProposals.push(proposal)
+        return proposal.message
+      },
+    })
+    expect(result.squashed).toBeDefined()
+    expect(seenProposals[0]!.source).toBe("fallback")
+    expect(seenProposals[0]!.error).toContain("test double")
+  })
+
+  test("an edited message lands verbatim", async () => {
+    const fixture = await makeFixture()
+    await runTestClose(fixture, {
+      resolveMessage: async () => "feat(cli): hand polished subject\n\n- change add-widget",
+    })
+    const body = await git(fixture.mainDir, undefined, "log", "--format=%B", "-n", "1", "main")
+    expect(body).toContain("hand polished subject")
+    expect(body).toContain("change add-widget")
+  })
+
+  test("an explicit --message wins verbatim and bypasses writer and resolver entirely", async () => {
+    const fixture = await makeFixture()
+    await runTestClose(fixture, {
+      message: "feat(cli): exact override",
+      resolveMessage: async () => {
+        throw new Error("the resolver must never be reached with an explicit --message")
+      },
+      writer: async () => {
+        throw new Error("the writer must never run under an explicit --message")
+      },
+    })
+    const subject = await git(fixture.mainDir, undefined, "log", "--format=%s", "-n", "1", "main")
+    expect(subject).toBe("feat(cli): exact override")
+  })
+
+  test("a declined message stops before the squash and nothing lands", async () => {
+    const fixture = await makeFixture()
+    const branchBefore = await git(fixture.worktreeDir, undefined, "rev-parse", "HEAD")
+    await expect(runTestClose(fixture, { resolveMessage: async () => undefined })).rejects.toThrow(/wasn't confirmed[\s\S]*--resume/)
+    // The archive happened, but the squash didn't: the branch tip moved to the
+    // archive commit, not to a squashed rewrite, and nothing reached the base.
+    const branchAfter = await git(fixture.worktreeDir, undefined, "rev-parse", "HEAD")
+    expect(branchAfter).not.toBe(branchBefore)
+    const mainLog = await git(fixture.mainDir, undefined, "log", "--format=%s", "main")
+    expect(mainLog).not.toContain("improve add widget")
+  })
+
+  // -- task 2.4: merge shapes --------------------------------------------------
+
+  test("a moved base narrates a merge-commit shape", async () => {
+    const fixture = await makeFixture()
+    await writeFile(join(fixture.mainDir, "main-advance.txt"), "advance\n")
+    await git(fixture.mainDir, undefined, "add", ".")
+    await git(fixture.mainDir, undefined, "commit", "-m", "chore: advance main in parallel")
+    const result = await runTestClose(fixture)
+    expect(result.mergeShape).toBe("merge-commit")
   })
 })
 


### PR DESCRIPTION
- squash and merge feature changes into the base branch
- compose conventional commit messages with model and deterministic fallback support
- make pushes upstream-aware and protect worktree removal before branch deletion
- sanitize model and git text before terminal rendering and commit composition
- add close, resume, sync, and commit-message regression coverage