### PR TITLE
feat(home): shorten masthead commit hash

### DIFF
--- a/openspec/changes/shorten-masthead-commit-hash/.openspec.yaml
+++ b/openspec/changes/shorten-masthead-commit-hash/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-31

--- a/openspec/changes/shorten-masthead-commit-hash/design.md
+++ b/openspec/changes/shorten-masthead-commit-hash/design.md
@@ -1,0 +1,37 @@
+## Context
+
+The masthead line comes from `versionDetails()` in `src/version.ts`, which today derives from `formatVersion()` by stripping the `convoy ` prefix: both read `<version> (commit <full 40-char SHA>, <platform>)`. `formatVersion()` also backs the `convoy --version` CLI output. `src/home-tui.ts` renders `versionDetails()` in both masthead layouts and uses `displayWidth(versionDetails())` to decide whether the three-row block wordmark fits, so every masthead consumer goes through the one function. See proposal.md — Why.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Masthead build line reads `<version> (<7-char commit fragment>, <platform>)` with no `commit` label, in both wide and compact layouts.
+- Keep the full SHA on the `convoy --version` diagnostic surface.
+
+**Non-Goals:**
+
+- Changing `formatVersion()` / `--version` output or its tests' expectations.
+- Changing the build-time version metadata scheme in `scripts/build.ts` (`0.6.0-local+a475995`).
+- Any masthead layout work beyond what falls out of the shorter string automatically.
+
+## Decisions
+
+**1. Shorten in `versionDetails()`, not in `formatVersion()`.**
+`versionDetails()` stops deriving from `formatVersion()` and formats its own line: `${info.version} (${shortCommit}, ${info.platform})`. Alternative: shortening `formatVersion()` itself would also change `--version` — rejected, the full hash there is the copy-paste identity for bug reports. This split also makes the two functions' difference intentional instead of a regex away from identical.
+
+**2. The fragment is the first 7 characters of the SHA, via a small pure helper in `version.ts`.**
+`scripts/build.ts` already shortens the same way (`commit.slice(0, 7)` for local build metadata), and 7-char prefixes are what git accepts for `git show`/`git log`, so the fragment is usable, not just short. The user's wording was "últimos dígitos" (last digits) — recorded as a deliberate deviation: a suffix fragment can't be fed to git tooling, defeating the point of showing a hash at all. The helper handles the `"unknown"` sentinel for free (`"unknown".slice(0, 7)` is `"unknown"`). `scripts/build.ts` keeps its own slice rather than importing runtime code into the build script.
+
+**3. No layout edits.**
+`wordmarkGlyphRows()` measures `displayWidth(versionDetails())`, so the ~33-column saving automatically lets the block wordmark appear at narrower widths. That is the desired effect; touching layout constants would fight it.
+
+## Risks / Trade-offs
+
+- [Two local builds sharing 7 leading chars would render identically] → Acceptable: the fragment is glanceable chrome, not identity; `--version` keeps the full SHA.
+- [Local builds show the fragment twice (`0.6.0-local+a475995 (a475995, …)`)] → Pre-existing shape (full hash already repeated the metadata's fragment); special-casing local builds adds branching for no diagnostic value.
+- [Hidden consumers of the long line] → Verified by search: `versionDetails()` is used only by `home-tui.ts` and the tests; `formatVersion()` only by `cli.ts` and tests.
+
+## Migration Plan
+
+None — a pure display change with no persisted formats, flags, or protocol. Rollback is a plain revert.

--- a/openspec/changes/shorten-masthead-commit-hash/proposal.md
+++ b/openspec/changes/shorten-masthead-commit-hash/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The home launcher's masthead right-aligns the build line next to the wordmark, e.g. `0.6.0 (commit 4f2a9b8c1d3e5f7a9b0c1d2e3f4a5b6c7d8e9f0a, darwin-arm64)`. The word "commit" plus the full 40-character SHA is noise in a header that has room for a tag, not a build line: it consumes ~50 columns that the wordmark layout must work around, and no identification beyond a short hash fragment is ever needed at a glance.
+
+## What Changes
+
+- The masthead build line drops the `commit` label and the full 40-character hash, and instead shows a short commit fragment: `0.6.0 (a475995, darwin-arm64)`.
+- The short fragment is the first 7 characters of the commit SHA — git's `--short` convention, and the same shortening `scripts/build.ts` already applies for local build metadata (`0.6.0-local+a475995`). The user asked for "the last digits"; a short fragment is the intent, and the 7-character prefix is what git tooling accepts, so that convention is used.
+- The `convoy --version` CLI diagnostic output is unchanged: it keeps the full hash because it is a copy-paste surface for bug reports, not chrome.
+- Both masthead layouts (wide block wordmark and compact text wordmark) pick up the new line automatically, as will the glyph-row width calculation that reserves space for it.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `home-launcher`: the "Home presents a unified masthead" requirement changes the build line shown right-aligned on the first masthead row from the full build line (version, full commit with `commit` label, platform) to version, short commit fragment (no label), platform.
+
+## Impact
+
+- `src/version.ts`: `versionDetails()` (the masthead's build line) stops deriving from `formatVersion()` and formats the shortened line; `formatVersion()` (CLI `--version`) keeps the full hash.
+- `src/home-tui.ts`: no behavior edits expected — it renders `versionDetails()` and measures its width by calling the same function.
+- Tests: `test/version.test.ts` gains coverage for the shortened masthead line; `test/home-tui.test.ts` asserts against `versionDetails()` itself and adapts automatically.
+- No config, CLI flags, or persisted formats change; the full SHA remains available via `convoy --version`.

--- a/openspec/changes/shorten-masthead-commit-hash/specs/home-launcher/spec.md
+++ b/openspec/changes/shorten-masthead-commit-hash/specs/home-launcher/spec.md
@@ -1,0 +1,20 @@
+## MODIFIED Requirements
+
+### Requirement: Home presents a unified masthead
+The Home launcher SHALL display a left-aligned three-line `CONVOY` wordmark in one uniform neutral tone. To its right, the masthead SHALL show the build line (version, short commit fragment, platform) right-aligned on the first row and the project path right-aligned on the second row. The build line SHALL read `<version> (<commit-fragment>, <platform>)`, where `<commit-fragment>` is the first 7 characters of the build's commit SHA (or `unknown` when no commit is known); it SHALL NOT include a `commit` label or a full-length hash. The launcher SHALL reserve one blank row above the wordmark and one blank row between the masthead and the body content. Compact widths SHALL fall back to a text wordmark with the build line right-aligned and a labeled project row below, without overflowing the terminal width. The launcher MUST NOT render a footer.
+
+#### Scenario: Wide masthead
+- **WHEN** Home opens with enough width for the full wordmark, build line, and project path
+- **THEN** the wordmark is left-aligned, the build line is right-aligned on the first masthead row, and the project path is right-aligned on the second masthead row
+
+#### Scenario: Commit fragment instead of the full hash
+- **WHEN** the masthead renders with a known build commit
+- **THEN** the first masthead row ends with `<version> (<first 7 characters of the commit SHA>, <platform>)`, and neither the word `commit` nor a commit hash longer than 7 characters appears anywhere in the masthead
+
+#### Scenario: Compact masthead
+- **WHEN** the terminal cannot fit the block wordmark beside the build line
+- **THEN** Home shows a text `CONVOY` wordmark with the build line right-aligned and a labeled `project  <path>` row below it
+
+#### Scenario: No footer
+- **WHEN** Home renders in any width or graphics mode
+- **THEN** no selection counter and no key hints appear anywhere on screen, one blank row pads the top of the screen, and two blank rows pad the bottom below the content

--- a/openspec/changes/shorten-masthead-commit-hash/tasks.md
+++ b/openspec/changes/shorten-masthead-commit-hash/tasks.md
@@ -1,0 +1,9 @@
+## 1. Version line
+
+- [ ] 1.1 In `src/version.ts`, add a pure helper that returns the first 7 characters of a commit SHA (passing `"unknown"` through unchanged) and rework `versionDetails()` to format `<version> (<fragment>, <platform>)` without the `commit` label or full hash; leave `formatVersion()` untouched. Verify with `bun test test/version.test.ts` — existing cases stay green.
+- [ ] 1.2 Extend `test/version.test.ts` with `versionDetails()` cases: a release info with a 40-char commit renders `0.1.1 (aaaaaaa, darwin-arm64)`, an unknown commit renders the `unknown` fragment, and no rendering contains the word `commit`. Verify with `bun test test/version.test.ts`.
+
+## 2. Masthead and verification
+
+- [ ] 2.1 Confirm `src/home-tui.ts` needs no edits: both masthead layouts render `versionDetails()` and `wordmarkGlyphRows()` measures it, so the shortened line and the wider block-wordmark threshold apply automatically. Verify with `bun test test/home-tui.test.ts`.
+- [ ] 2.2 Run the full suite and typecheck (`bun test && bun run typecheck`) and confirm the only behavior change is the masthead build line; `--version` output still carries the full hash.

--- a/openspec/changes/shorten-masthead-commit-hash/tasks.md
+++ b/openspec/changes/shorten-masthead-commit-hash/tasks.md
@@ -1,9 +1,9 @@
 ## 1. Version line
 
-- [ ] 1.1 In `src/version.ts`, add a pure helper that returns the first 7 characters of a commit SHA (passing `"unknown"` through unchanged) and rework `versionDetails()` to format `<version> (<fragment>, <platform>)` without the `commit` label or full hash; leave `formatVersion()` untouched. Verify with `bun test test/version.test.ts` — existing cases stay green.
-- [ ] 1.2 Extend `test/version.test.ts` with `versionDetails()` cases: a release info with a 40-char commit renders `0.1.1 (aaaaaaa, darwin-arm64)`, an unknown commit renders the `unknown` fragment, and no rendering contains the word `commit`. Verify with `bun test test/version.test.ts`.
+- [x] 1.1 In `src/version.ts`, add a pure helper that returns the first 7 characters of a commit SHA (passing `"unknown"` through unchanged) and rework `versionDetails()` to format `<version> (<fragment>, <platform>)` without the `commit` label or full hash; leave `formatVersion()` untouched. Verify with `bun test test/version.test.ts` — existing cases stay green.
+- [x] 1.2 Extend `test/version.test.ts` with `versionDetails()` cases: a release info with a 40-char commit renders `0.1.1 (aaaaaaa, darwin-arm64)`, an unknown commit renders the `unknown` fragment, and no rendering contains the word `commit`. Verify with `bun test test/version.test.ts`.
 
 ## 2. Masthead and verification
 
-- [ ] 2.1 Confirm `src/home-tui.ts` needs no edits: both masthead layouts render `versionDetails()` and `wordmarkGlyphRows()` measures it, so the shortened line and the wider block-wordmark threshold apply automatically. Verify with `bun test test/home-tui.test.ts`.
-- [ ] 2.2 Run the full suite and typecheck (`bun test && bun run typecheck`) and confirm the only behavior change is the masthead build line; `--version` output still carries the full hash.
+- [x] 2.1 Confirm `src/home-tui.ts` needs no edits: both masthead layouts render `versionDetails()` and `wordmarkGlyphRows()` measures it, so the shortened line and the wider block-wordmark threshold apply automatically. Verify with `bun test test/home-tui.test.ts`.
+- [x] 2.2 Run the full suite and typecheck (`bun test && bun run typecheck`) and confirm the only behavior change is the masthead build line; `--version` output still carries the full hash.

--- a/src/version.ts
+++ b/src/version.ts
@@ -49,7 +49,15 @@ export function majorMinorVersion(info: VersionInfo = versionInfo) {
   return match ? `v${match[1]}.${match[2]}` : version
 }
 
-/** The full build line (version + commit + platform), brand prefix dropped. */
+// The masthead has room for a tag, not a build line: git's short-hash
+// convention (`git log --oneline`, `scripts/build.ts`'s local build metadata)
+// is what stays glanceable while remaining feedable to git tooling. A suffix
+// fragment would defeat that, so the fragment is the SHA's leading characters.
+function shortCommit(commit: string) {
+  return commit.slice(0, 7)
+}
+
+/** The masthead build line (version + short commit + platform), brand prefix dropped. */
 export function versionDetails(info: VersionInfo = versionInfo) {
-  return formatVersion(info).replace(/^convoy\s+/, "")
+  return `${info.version} (${shortCommit(info.commit)}, ${info.platform})`
 }

--- a/test/home-tui.test.ts
+++ b/test/home-tui.test.ts
@@ -284,8 +284,10 @@ test("image selection and resize delete the old placement before drawing the nex
     const resized = writes.join("")
     expect(resized.indexOf("\x1b_Ga=d,d=i,i=101")).toBeGreaterThanOrEqual(0)
     expect(resized.indexOf("\x1b_Ga=p,i=101")).toBeGreaterThan(resized.indexOf("\x1b_Ga=d,d=i,i=101"))
-    expect(resized).toContain("\x1b[5;2H")
-    expect(resized).toMatch(/\x1b_Ga=p,i=101[^;]*c=78,r=13/)
+    // The shortened masthead build line lets the block wordmark fit at 80
+    // columns too, so the image keeps its row and only loses one row of height.
+    expect(resized).toContain("\x1b[6;2H")
+    expect(resized).toMatch(/\x1b_Ga=p,i=101[^;]*c=78,r=12/)
   } finally {
     session.press("q")
     await session.home.result

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
 import { compareSemVer, parseSemVer } from "../src/update"
-import { formatVersion, majorMinorVersion, shortVersion, versionInfo } from "../src/version"
+import { formatVersion, majorMinorVersion, shortVersion, versionDetails, versionInfo } from "../src/version"
 
 const released = { version: "0.1.1", commit: "a".repeat(40), platform: "darwin-arm64", release: true }
 
@@ -53,6 +53,24 @@ describe("version formatting", () => {
     // A numeric-only short hash with a leading zero stays valid as build
     // metadata (it would be invalid as a prerelease identifier).
     expect(parseSemVer("0.1.1-local+0123456")).toBeDefined()
+  })
+
+  // The masthead shows a glanceable short fragment, not the diagnostic hash:
+  // git's short-hash convention, matching what scripts/build.ts embeds as
+  // local build metadata. A suffix fragment can't be fed to git tooling.
+  describe("versionDetails", () => {
+    test("the masthead build line keeps a short commit fragment, not the full hash", () => {
+      expect(versionDetails(released)).toBe("0.1.1 (aaaaaaa, darwin-arm64)")
+    })
+
+    test("an unknown commit renders the unknown fragment", () => {
+      expect(versionDetails({ ...released, commit: "unknown" })).toBe("0.1.1 (unknown, darwin-arm64)")
+    })
+
+    test("no masthead rendering carries the commit label or a long hash", () => {
+      expect(versionDetails(released)).not.toContain("commit")
+      expect(versionDetails(released)).not.toMatch(/[0-9a-f]{8,}/)
+    })
   })
 
   test("a source checkout still reports a usable version triple", () => {


### PR DESCRIPTION
- Show a seven-character commit fragment without the commit label
- Preserve full commit details in CLI version output
- Add version formatting tests for shortened and unknown hashes