### PR TITLE
feat: fold custom pipelines into built-ins and default to full-cycle

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -310,8 +310,8 @@ async function buildReviewedPlan(input: BuildRunPlanInput): Promise<RunPlan> {
   if (input.change && (!openspec || openspec.changeIds.length === 0)) {
     throw new Error(`--change "${input.change}" matched no active change under openspec/changes/ (archived or absent; run without --change to auto-resolve)`)
   }
-  // Selection rule 5: in an OpenSpec repo, implement needs a change contract;
-  // review keeps today's diff-inference fallback.
+  // Selection rule 5: in an OpenSpec repo, the default implementation pipeline
+  // (full-cycle) needs a change contract; review keeps today's diff-inference fallback.
   if (openspec && openspec.changeIds.length === 0 && input.pipeline.name === defaultPipelineName) {
     throw new Error("no change; run /opsx:propose first (or pass --change <id>)")
   }
@@ -1424,9 +1424,9 @@ Flags:
   --version, -V            Print Convoy's version, commit, and build platform
   --prompt-file <path>     Read the PRD/prompt from a file
   --file, -f <path>        Attach a file or directory to all steps (repeatable)
-   --pipeline, -p <name>    Pipeline to run (default: "implement"), which runs
-                            implementer,patterns,security,design,tests,adversarial,
-                            then distills every report into reports/run-report.md
+   --pipeline, -p <name>    Pipeline to run (default: "full-cycle"), which writes,
+                            audits, then measures and iterates on a terminal goal
+                            step until the score clears 90
   --only <steps>           Run only these pipeline steps
   --skip <steps>           Skip these pipeline steps
   --resume <id>            Resume a previous run by its ID (steps with an existing report are

--- a/src/config.ts
+++ b/src/config.ts
@@ -1162,16 +1162,16 @@ export async function writeConvoyConfig(path: string, config: ConvoyConfig, targ
 
 /**
  * Boilerplate written by the config TUI's "initialize" action: the current
- * effective defaults plus the built-in `implement` pipeline expanded so it stays
- * editable. Agent model preferences that differ from defaults.model are inlined
- * on their steps, because defaults.model would otherwise shadow them.
+ * effective defaults plus the default pipeline expanded so it stays editable.
+ * Agent model preferences that differ from defaults.model are inlined on their
+ * steps, because defaults.model would otherwise shadow them.
  */
 export function defaultConfigTemplate(): ConvoyConfig {
   const globalModel = `${defaultGptModel}#${defaultGptVariant}`
   return {
     defaults: { model: globalModel },
     agents: {},
-    pipelines: { implement: materializePipelineSpec(builtInPipelines[defaultPipelineName]!, globalModel) },
+    pipelines: { [defaultPipelineName]: materializePipelineSpec(builtInPipelines[defaultPipelineName]!, globalModel) },
     permissions: { allow: [], deny: [] },
     hooks: emptyHooksConfig(),
     attachments: [],

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -24,6 +24,10 @@ const deepseekHighModel = `${deepseekModel}#high`
 /** GPT 5.6 Sol: the advisor `implement` consults, and at xhigh the consensus reporter for the review/ship/hunter pipelines. */
 const solModel = "openai/gpt-5.6-sol"
 const solXhighModel = `${solModel}#xhigh`
+/** GLM 5.3 Flash with reasoning raised: the low-cost code-writer for `implement-lite` and the design/fixer legs of the goal pipelines. */
+const glm53FlashHighModel = "openrouter/z-ai/glm-5.3-flash#high"
+/** GPT 6 Astra at extra high: the advisor the goal pipelines (full-cycle/astra) and the fixer consult where Grok or Sol used to advise. */
+const astraXhighModel = "openai/gpt-6-astra#xhigh"
 
 // Per-step models the built-in `implement` pipeline pins. Exported so `convoy init`'s
 // inlined copy of that pipeline stays in sync with the built-in it claims to mirror.
@@ -455,7 +459,7 @@ export const readOnlyAgentSuffix = "__ro"
 export const verifyAgentSuffix = "__verify"
 
 /** The pipeline run when none is selected (no -p flag and no defaults.pipeline). */
-export const defaultPipelineName = "implement"
+export const defaultPipelineName = "full-cycle"
 
 export const builtInPipelines: Record<string, PipelineSpec> = {
   // The audits are pinned to GLM 5.3 high rather than left to inherit the run's
@@ -493,15 +497,114 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
   // drop. DeepSeek V4 Flash (OpenRouter) writes instead of GLM, and Grok advises
   // rather than a second GLM: the cross-vendor disagreement costs no new provider.
   "implement-lite": {
-    description: "Like implement, but drops every code-writing phase to DeepSeek V4 Flash 0731 and GLM 5.3 to reduce cost; Grok 4.6 advises the implementer and polishes design, and adversarial runs on GLM 5.3",
+    description:
+      "Advised lite: GLM 5.3 Flash implements consulting Grok 4.6; patterns, security and tests audit on DeepSeek V4 Flash advised by GLM 5.3 high. Design stays on Grok 4.6 unadvised and adversarial on GLM 5.3. Closes with an extractive one-page run recap (run-report).",
     steps: [
-      { agent: "implementer", model: deepseekHighModel, advisor: grokModel, reports: "none" },
-      { agent: "patterns", model: glm53HighModel, advisor: false },
-      { agent: "security", model: glm53HighModel, advisor: false },
+      { agent: "implementer", model: glm53FlashHighModel, advisor: grokModel, reports: "none" },
+      { agent: "patterns", model: deepseekHighModel, advisor: glm53HighModel },
+      { agent: "security", model: deepseekHighModel, advisor: glm53HighModel },
       { agent: "design", model: grokModel, advisor: false },
-      { agent: "tests", model: glm53HighModel, advisor: false, reports: "none" },
+      { agent: "tests", model: deepseekHighModel, advisor: glm53HighModel, reports: "none" },
       { agent: "adversarial", model: glm53HighModel, advisor: false, reports: "all" },
-      { agent: "run-report", model: defaultRunReportModel, advisor: false, reports: "all", diff: false },
+      { agent: "run-report", model: deepseekHighModel, advisor: false, reports: "all", diff: false },
+    ],
+  },
+  // Full Cycle: implement-lite's writing phases (implementer, patterns, security,
+  // design, tests), closed by the terminal goal step that owns the whole loop:
+  // it measures FIRST (two independent quality-scorers + a verified consensus),
+  // and only under 90 does it iterate — the fixer applies exactly the reported
+  // gaps, re-scores, and stops at 90, after 3 fix iterations, or on a 3-round
+  // score plateau. All scoring lives inside the goal step's measure fragment, so
+  // the initial score and every re-score run through the same declared panel.
+  "full-cycle": {
+    description:
+      "Full Cycle: implement-lite's writing phases, then a terminal goal step that measures with two independent quality-scorers and a verified consensus, and drives fix iterations until the score clears 90.",
+    steps: [
+      { agent: "implementer", model: glm53FlashHighModel, advisor: grokModel, reports: "none" },
+      { agent: "patterns", model: deepseekHighModel, advisor: glm53HighModel },
+      { agent: "security", model: deepseekHighModel, advisor: glm53HighModel },
+      { agent: "design", model: grokModel, advisor: false },
+      { agent: "tests", model: deepseekHighModel, advisor: glm53HighModel, reports: "none" },
+      {
+        goal: {
+          target: 90,
+          improve: {
+            briefStep: "fix",
+            steps: [
+              // The directed fixer: applies exactly the gaps the previous
+              // scoring round reported, which arrive as its per-step brief.
+              { agent: "goal-fixer", name: "fix", model: deepseekHighModel, advisor: grokModel, reports: "none", diff: true, prdHistory: true },
+            ],
+          },
+          measure: {
+            steps: [
+              {
+                parallel: [
+                  // The re-scorers stay blind to the previous score: no reports
+                  // at all (they grade the artifact, not the run's history), but
+                  // they still get the original PRD via prdHistory and the
+                  // current diff for the rubric's `prd` dimension.
+                  { agent: "quality-scorer", name: "score", models: [grokModel, glm53HighModel], reports: "none", diff: true, prdHistory: true },
+                ],
+              },
+              // The consensus sees only the fresh scorer reports, never the
+              // fixer's, so its measurement cannot anchor on the number it is
+              // reconciling; the original PRD is attached so disagreements on
+              // the `prd` dimension can be judged against the requirements.
+              { agent: "quality-score-report", name: "score-report", model: glm53HighModel, reports: ["score"], verify: true, diff: true, prdHistory: true },
+            ],
+          },
+        },
+      },
+    ],
+  },
+  // Astra: full-cycle's shape, but the advisor is Astra 6 (GPT-6) in extra-high
+  // mode wherever full-cycle used Grok 4.6 (implementer and goal fixer), and the
+  // design phase joins the advised set on GLM 5.3 Flash. The fixer runs on GLM
+  // 5.3 Flash (instead of DeepSeek) advised by Astra 6, with up to 5 fix rounds.
+  // Scoring (measure fragment) is unchanged.
+  astra: {
+    description:
+      "Astra: full-cycle's writing phases, then a terminal goal step that measures with two independent quality-scorers and a verified consensus, and drives fix iterations until the score clears 90. Advisor is Astra 6 (extra high) wherever full-cycle used Grok 4.6; design is advised on GLM 5.3 Flash; the fixer runs on GLM 5.3 Flash advised by Astra 6 with up to 5 fix rounds.",
+    steps: [
+      { agent: "implementer", model: glm53FlashHighModel, advisor: astraXhighModel, reports: "none" },
+      { agent: "patterns", model: deepseekHighModel, advisor: glm53HighModel },
+      { agent: "security", model: deepseekHighModel, advisor: glm53HighModel },
+      { agent: "design", model: glm53FlashHighModel, advisor: astraXhighModel },
+      { agent: "tests", model: deepseekHighModel, advisor: glm53HighModel, reports: "none" },
+      {
+        goal: {
+          target: 90,
+          maxIterations: 5,
+          improve: {
+            briefStep: "fix",
+            steps: [
+              // The directed fixer, on GLM 5.3 Flash advised by Astra 6 (extra
+              // high). It alone receives the score brief (by step name). diff:
+              // true is load-bearing: as the fragment's first step it would
+              // otherwise default to no diff.
+              { agent: "goal-fixer", name: "fix", model: glm53FlashHighModel, advisor: astraXhighModel, reports: "none", diff: true, prdHistory: true },
+            ],
+          },
+          measure: {
+            steps: [
+              {
+                parallel: [
+                  // The scorers stay blind to any previous round: no reports at
+                  // all, but the original PRD via prdHistory and the current
+                  // diff for the rubric's `prd` dimension. Kept as-is (Grok 4.6
+                  // + GLM 5.3 high).
+                  { agent: "quality-scorer", name: "score", models: [grokModel, glm53HighModel], reports: "none", diff: true, prdHistory: true },
+                ],
+              },
+              // The consensus sees only the fresh scorer reports, never the
+              // fixer's, so its measurement cannot anchor on the number it is
+              // reconciling.
+              { agent: "quality-score-report", name: "score-report", model: glm53HighModel, reports: ["score"], verify: true, diff: true, prdHistory: true },
+            ],
+          },
+        },
+      },
     ],
   },
   // Report-only review + the measurement layer: after the parallel audits, two
@@ -539,16 +642,16 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
   // writes the report, and the fan-outs pair GLM 5.3 with Grok 4.6.
   "review-lite": {
     description:
-      "Like review, but every phase runs on a low-cost model: GLM 5.3 scopes and reconciles the score, DeepSeek V4 Flash 0731 writes the report, and the audit and scorer fan-outs pair GLM 5.3 with Grok 4.6 instead of Opus.",
+      "Report-only PR review on ultra-cheap models: scope, parallel audits (DeepSeek V4 Flash + GLM 5.3 Flash) and report on flash models; the scoring uses GLM 5.3 high + Grok 4.6 high and the score consensus stays on GLM 5.3 high. Makes no changes.",
     defaultPrompt: "Review the current branch against its base and report prioritized findings with a verified quality score.",
     suggestedPrompts: ["Review the open PR for this branch", "Review only the last commit's diff"],
     steps: [
-      { agent: "review-scope", name: "scope", model: glm53HighModel, reports: "none", diff: true, verify: true, prdHistory: true },
+      { agent: "review-scope", name: "scope", model: deepseekHighModel, reports: "none", diff: true, verify: true, prdHistory: true },
       {
         parallel: [
-          { agent: "clean-code-auditor", name: "clean-code", models: [glm53HighModel, grokModel], reports: ["scope"] },
-          { agent: "security-reviewer", name: "security", models: [glm53HighModel, grokModel], reports: ["scope"] },
-          { agent: "bug-auditor", name: "bugs", models: [glm53HighModel, grokModel], reports: ["scope"] },
+          { agent: "clean-code-auditor", name: "clean-code", models: [deepseekHighModel, glm53FlashHighModel], reports: ["scope"] },
+          { agent: "security-reviewer", name: "security", models: [deepseekHighModel, glm53FlashHighModel], reports: ["scope"] },
+          { agent: "bug-auditor", name: "bugs", models: [deepseekHighModel, glm53FlashHighModel], reports: ["scope"] },
         ],
       },
       { agent: "review-report", name: "report", model: deepseekHighModel, reports: "all" },
@@ -635,8 +738,8 @@ export const builtInPipelines: Record<string, PipelineSpec> = {
   fixer: {
     description: "Turn supplied findings into proven regression tests, targeted fixes, and an independently rerun final report",
     steps: [
-      { agent: "fixer-test-author", name: "reproduction", model: fallbackModel, advisor: solXhighModel, reports: "none", diff: true },
-      { agent: "fixer-implementer", name: "fixes", model: fallbackModel, advisor: solXhighModel, reports: ["reproduction"] },
+      { agent: "fixer-test-author", name: "reproduction", model: fallbackModel, advisor: astraXhighModel, reports: "none", diff: true },
+      { agent: "fixer-implementer", name: "fixes", model: fallbackModel, advisor: astraXhighModel, reports: ["reproduction"] },
       { agent: "fixer-validator", name: "validation", model: fallbackModel, reports: ["reproduction", "fixes"], verify: true },
     ],
   },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -498,7 +498,7 @@ describe("pipeline selection", () => {
     expect(selectPipelineSpec(config, "implement").steps).toEqual(["tests"])
     expect(selectPipelineSpec(undefined, "implement").steps.length).toBeGreaterThan(1)
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(
-      'unknown pipeline "ghost" (available: fixer, hunter, hunter-max, implement, implement-lite, quick, review, review-cc, review-lite, ship)',
+      'unknown pipeline "ghost" (available: astra, fixer, full-cycle, hunter, hunter-max, implement, implement-lite, quick, review, review-cc, review-lite, ship)',
     )
     expect(() => selectPipelineSpec(config, "ghost")).toThrow(ConfigError)
   })
@@ -1022,12 +1022,12 @@ describe("serialization", () => {
     expect(reparsed.hooks).toEqual(config.hooks)
   })
 
-  test("defaultConfigTemplate preserves implement step model overrides and round-trips", () => {
+  test("defaultConfigTemplate materializes the default pipeline's step model overrides and round-trips", () => {
     const template = defaultConfigTemplate()
     expect(template.defaults.model).toBe(`${defaultGptModel}#${defaultGptVariant}`)
-    const steps = template.pipelines.implement!.steps
+    const steps = template.pipelines["full-cycle"]!.steps
     expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && !isHumanStepSpec(step) && !isGoalStepSpec(step) && step.agent === "design")).toEqual({ agent: "design", model: defaultImplementReviewModel, advisor: false })
-    expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && !isHumanStepSpec(step) && !isGoalStepSpec(step) && step.agent === "adversarial")).toEqual({ agent: "adversarial", model: defaultAdversarialModel, advisor: false, reports: "all" })
+    expect(steps.find((step) => typeof step !== "string" && !isParallelSpec(step) && !isHumanStepSpec(step) && !isGoalStepSpec(step) && step.agent === "implementer")).toEqual({ agent: "implementer", model: "openrouter/z-ai/glm-5.3-flash#high", advisor: "openrouter/x-ai/grok-4.6#high", reports: "none" })
     const reparsed = parse(serializeConvoyConfig(template))
     expect(reparsed.defaults).toEqual(template.defaults)
     expect(reparsed.pipelines).toEqual(template.pipelines)

--- a/test/openspec.test.ts
+++ b/test/openspec.test.ts
@@ -398,12 +398,12 @@ describe("--change wiring through the reviewed run plan", () => {
     await expect(runPlanFor(["--dir", plain, "--change", "add-foo", "review this"])).rejects.toThrow("--change \"add-foo\"")
   })
 
-  test("implement refuses when openspec/ is present but no change is active (selection rule 5)", async () => {
+  test("the default pipeline refuses when openspec/ is present but no change is active (selection rule 5)", async () => {
     const repo = await repoOn("main")
     await mkdir(join(repo, openspecDirName, "changes"), { recursive: true })
     await writeFile(join(repo, openspecDirName, "changes", "README.md"), "# changes\n")
 
-    await expect(runPlanFor(["--dir", repo, "-p", "implement", "build it"])).rejects.toThrow("/opsx:propose")
+    await expect(runPlanFor(["--dir", repo, "build it"])).rejects.toThrow("/opsx:propose")
   })
 
   test("review keeps the diff-inference fallback when openspec/ is present but no change is active", async () => {

--- a/test/pipeline.test.ts
+++ b/test/pipeline.test.ts
@@ -9,6 +9,7 @@ import {
   defaultImplementReviewModel,
   defaultOpusModel,
   defaultPipeline,
+  defaultPipelineName,
   defaultDeliverableContract,
   deliverableContractForPhase,
   qualityScoreDeliverableContract,
@@ -34,6 +35,9 @@ const resolve = (spec: PipelineSpec, defaultModel?: string) =>
 
 const agentSteps = (spec: PipelineSpec) => resolve(spec).steps.filter((step): step is AgentStep => step.type === "agent")
 
+/** Resolves the built-in `implement` pipeline explicitly, since it is no longer the default. */
+const implement = () => resolvePipeline({ name: "implement", spec: builtInPipelines.implement!, agents: builtInAgents })
+
 describe("model shorthand", () => {
   test("splits provider/model#variant", () => {
     expect(splitModelVariant("openai/gpt-5.5#xhigh")).toEqual({ model: "openai/gpt-5.5", variant: "xhigh" })
@@ -43,9 +47,9 @@ describe("model shorthand", () => {
   })
 })
 
-describe("default pipeline", () => {
+describe("built-in implement pipeline", () => {
   test("matches the historical six phases plus the closing run recap", () => {
-    const pipeline = defaultPipeline()
+    const pipeline = implement()
 
     expect(stepNames(pipeline)).toEqual(["implementer", "patterns", "security", "design", "tests", "adversarial", "run-report"])
     expect(pipeline.steps.some((step) => step.type === "human")).toBe(false)
@@ -53,7 +57,7 @@ describe("default pipeline", () => {
 
   test("wires inputs by convention exactly like the static pipeline did", () => {
     const steps = Object.fromEntries(
-      defaultPipeline()
+      implement()
         .steps.filter((step): step is AgentStep => step.type === "agent")
         .map((step) => [step.name, step]),
     )
@@ -78,7 +82,7 @@ describe("default pipeline", () => {
 
   test("pins Terra xhigh for implementation, GLM 5.3 high for the audits, and Grok 4.6 high for design and adversarial", () => {
     const byName = Object.fromEntries(
-      defaultPipeline()
+      implement()
         .steps.filter((step): step is AgentStep => step.type === "agent")
         .map((step) => [step.name, step]),
     )
@@ -93,7 +97,7 @@ describe("default pipeline", () => {
 
   test("advises the implementation phase only: Sol xhigh at Terra's decision points", () => {
     const byName = Object.fromEntries(
-      defaultPipeline()
+      implement()
         .steps.filter((step): step is AgentStep => step.type === "agent")
         .map((step) => [step.name, step]),
     )
@@ -103,7 +107,7 @@ describe("default pipeline", () => {
       expect(byName[name]?.advisor).toBeUndefined()
     }
     // Exactly one step carries the advisor cost.
-    expect(defaultPipeline().steps.filter((step) => step.type === "agent" && step.advisor).length).toBe(1)
+    expect(implement().steps.filter((step) => step.type === "agent" && step.advisor).length).toBe(1)
   })
 
   test("the audits opt out of the advisor explicitly, so defaults.advisor cannot re-advise them", () => {
@@ -127,11 +131,11 @@ describe("default pipeline", () => {
   })
 
   test("does not score: measurement belongs to ship, not to the first draft", () => {
-    expect(stepNames(defaultPipeline())).not.toContain("score-report")
+    expect(stepNames(implement())).not.toContain("score-report")
   })
 
   test("closes with the read-only run recap: every report, no diff, cheapest model", () => {
-    const steps = defaultPipeline()
+    const steps = implement()
       .steps.filter((step): step is AgentStep => step.type === "agent")
       .map((step) => [step.name, step] as const)
     const byName = Object.fromEntries(steps)
@@ -182,13 +186,64 @@ describe("default pipeline", () => {
   })
 })
 
+describe("default pipeline", () => {
+  test("is the terminal goal pipeline full-cycle, not the plain implement", () => {
+    expect(defaultPipelineName).toBe("full-cycle")
+    const pipeline = defaultPipeline()
+    expect(pipeline.name).toBe("full-cycle")
+    expect(pipeline.goalPlan).toBeDefined()
+    expect(pipeline.goalPlan?.target).toBe(90)
+    expect(pipeline.goalPlan?.maxIterations).toBe(3)
+    expect(pipeline.goalPlan?.plateau).toBe(3)
+    expect(pipeline.goalPlan?.briefRecipient).toBe("fix")
+    expect(pipeline.goalPlan?.scoreProducer).toBe("score-report")
+  })
+
+  test("starts with the writing phases and closes with the goal step, with no run recap", () => {
+    const pipeline = defaultPipeline()
+    expect(pipeline.steps.filter((step): step is AgentStep => step.type === "agent").map((step) => step.stepName)).toEqual([
+      "implementer",
+      "patterns",
+      "security",
+      "design",
+      "tests",
+    ])
+    expect(pipeline.goalPlan).toBeDefined()
+    expect(pipeline.steps.some((step) => step.type === "agent" && step.stepName === "run-report")).toBe(false)
+  })
+
+  test("advises the implementer with Grok 4.6, leaves design unadvised, and advises the fixer with Grok 4.6", () => {
+    const prefix = Object.fromEntries(
+      defaultPipeline()
+        .steps.filter((step): step is AgentStep => step.type === "agent")
+        .map((step) => [step.name, step]),
+    )
+    expect(prefix.implementer).toMatchObject({ advisor: "openrouter/x-ai/grok-4.6", advisorVariant: "high" })
+    expect(prefix.design?.advisor).toBeUndefined()
+    const [fix] = defaultPipeline().goalPlan!.improve.steps
+    expect(fix).toMatchObject({ advisor: "openrouter/x-ai/grok-4.6", advisorVariant: "high" })
+  })
+
+  test("runs the whole cycle on cheap models with DeepSeek V4 Flash on the audits and fixer", () => {
+    const prefix = Object.fromEntries(
+      defaultPipeline()
+        .steps.filter((step): step is AgentStep => step.type === "agent")
+        .map((step) => [step.name, step]),
+    )
+    expect(prefix.implementer).toMatchObject({ model: "openrouter/z-ai/glm-5.3-flash", variant: "high" })
+    expect(prefix.patterns).toMatchObject({ model: "openrouter/deepseek/deepseek-v4-flash-0731", variant: "high" })
+    const [fix] = defaultPipeline().goalPlan!.improve.steps
+    expect(fix).toMatchObject({ model: "openrouter/deepseek/deepseek-v4-flash-0731", variant: "high" })
+  })
+})
+
 describe("built-in implement-lite pipeline", () => {
   const implementLite = (defaultModel?: string) =>
     resolvePipeline({ name: "implement-lite", spec: builtInPipelines["implement-lite"]!, agents: builtInAgents, defaultModel })
 
-  test("keeps the implement workflow and agents while swapping the code-writing phases to DeepSeek V4 Flash 0731 and the audits to GLM 5.3", () => {
+  test("keeps the implement workflow and agents while writing on GLM 5.3 Flash and auditing on DeepSeek V4 Flash advised by GLM 5.3", () => {
     const lite = implementLite().steps.filter((step): step is AgentStep => step.type === "agent")
-    const standard = defaultPipeline().steps.filter((step): step is AgentStep => step.type === "agent")
+    const standard = implement().steps.filter((step): step is AgentStep => step.type === "agent")
 
     const workflowShape = (step: AgentStep) => ({
       name: step.name,
@@ -201,11 +256,11 @@ describe("built-in implement-lite pipeline", () => {
     expect(lite.map(workflowShape)).toEqual(standard.map(workflowShape))
 
     const byName = Object.fromEntries(lite.map((step) => [step.name, step]))
-    expect(byName.implementer?.model).toBe("openrouter/deepseek/deepseek-v4-flash-0731")
+    expect(byName.implementer?.model).toBe("openrouter/z-ai/glm-5.3-flash")
     expect(byName.implementer?.variant).toBe("high")
-    expect(byName.patterns?.model).toBe("openrouter/z-ai/glm-5.3")
-    expect(byName.security?.model).toBe("openrouter/z-ai/glm-5.3")
-    expect(byName.tests?.model).toBe("openrouter/z-ai/glm-5.3")
+    expect(byName.patterns?.model).toBe("openrouter/deepseek/deepseek-v4-flash-0731")
+    expect(byName.security?.model).toBe("openrouter/deepseek/deepseek-v4-flash-0731")
+    expect(byName.tests?.model).toBe("openrouter/deepseek/deepseek-v4-flash-0731")
     expect(byName.design?.model).toBe("openrouter/x-ai/grok-4.6")
     expect(byName.adversarial?.model).toBe("openrouter/z-ai/glm-5.3")
   })
@@ -217,32 +272,32 @@ describe("built-in implement-lite pipeline", () => {
         .map((step) => [step.name, step]),
     )
 
-    expect(byName.implementer).toMatchObject({ model: "openrouter/deepseek/deepseek-v4-flash-0731", variant: "high" })
-    expect(byName.patterns).toMatchObject({ model: "openrouter/z-ai/glm-5.3", variant: "high" })
-    expect(byName.security).toMatchObject({ model: "openrouter/z-ai/glm-5.3", variant: "high" })
-    expect(byName.tests).toMatchObject({ model: "openrouter/z-ai/glm-5.3", variant: "high" })
+    expect(byName.implementer).toMatchObject({ model: "openrouter/z-ai/glm-5.3-flash", variant: "high" })
+    expect(byName.patterns).toMatchObject({ model: "openrouter/deepseek/deepseek-v4-flash-0731", variant: "high" })
+    expect(byName.security).toMatchObject({ model: "openrouter/deepseek/deepseek-v4-flash-0731", variant: "high" })
+    expect(byName.tests).toMatchObject({ model: "openrouter/deepseek/deepseek-v4-flash-0731", variant: "high" })
     expect(byName.design).toMatchObject({ model: "openrouter/x-ai/grok-4.6", variant: "high" })
     expect(byName.adversarial).toMatchObject({ model: "openrouter/z-ai/glm-5.3", variant: "high" })
   })
 
-  test("distinguishes itself from implement by the phases that write and judge, not the audits", () => {
+  test("distinguishes itself from implement by the phases that write, audit, and judge", () => {
     const lite = Object.fromEntries(implementLite().steps.filter((s): s is AgentStep => s.type === "agent").map((step) => [step.name, step]))
-    const standard = Object.fromEntries(defaultPipeline().steps.filter((s): s is AgentStep => s.type === "agent").map((step) => [step.name, step]))
+    const standard = Object.fromEntries(implement().steps.filter((s): s is AgentStep => s.type === "agent").map((step) => [step.name, step]))
 
-    // Both run the audits on GLM 5.3 high; what the lite variant actually gives
-    // up is Sol writing the code and Grok judging it at the end.
-    for (const step of ["patterns", "security", "tests"]) {
-      expect(lite[step]?.model).toBe(standard[step]!.model)
-      expect(lite[step]?.variant).toBe("high")
-      expect(standard[step]?.variant).toBe("high")
-    }
+    // Lite writes on GLM 5.3 Flash and audits on DeepSeek advised by GLM 5.3 high;
+    // implement writes on Terra and audits unadvised on GLM 5.3 high.
     expect(lite.implementer?.model).not.toBe(standard.implementer?.model)
+    expect(lite.patterns?.model).not.toBe(standard.patterns?.model)
+    expect(lite.patterns?.advisor).toBe("openrouter/z-ai/glm-5.3")
+    expect(standard.patterns?.advisor).toBeUndefined()
     expect(lite.adversarial?.model).not.toBe(standard.adversarial?.model)
+    // The run recap is the same cheap model on both.
+    expect(lite["run-report"]?.model).toBe(standard["run-report"]?.model)
   })
 
   test("closes with the same read-only run recap as implement", () => {
     const lite = implementLite().steps.filter((step): step is AgentStep => step.type === "agent")
-    const standard = defaultPipeline().steps.filter((step): step is AgentStep => step.type === "agent")
+    const standard = implement().steps.filter((step): step is AgentStep => step.type === "agent")
     const liteRecap = lite.find((step) => step.stepName === "run-report")
     const standardRecap = standard.find((step) => step.stepName === "run-report")
 
@@ -499,16 +554,16 @@ describe("built-in review-lite pipeline", () => {
     expect(scope).toMatchObject({ agentName: "review-scope", readOnly: true, verify: true })
   })
 
-  test("runs entirely on low-cost models: GLM 5.3 scopes and reconciles, DeepSeek V4 Flash 0731 reports, and the fan-outs pair GLM 5.3 with Grok 4.6", () => {
+  test("runs entirely on low-cost models: DeepSeek V4 Flash scopes, audits, and reports, and the scoring stays on GLM 5.3 + Grok 4.6", () => {
     const pipeline = reviewLite()
     expect(stepNames(pipeline)).toEqual([
       "scope",
-      "clean-code__openrouter-z-ai-glm-5-3-high",
-      "clean-code__openrouter-x-ai-grok-4-6-high",
-      "security__openrouter-z-ai-glm-5-3-high",
-      "security__openrouter-x-ai-grok-4-6-high",
-      "bugs__openrouter-z-ai-glm-5-3-high",
-      "bugs__openrouter-x-ai-grok-4-6-high",
+      "clean-code__openrouter-deepseek-deepseek-v4-flash-0731-high",
+      "clean-code__openrouter-z-ai-glm-5-3-flash-high",
+      "security__openrouter-deepseek-deepseek-v4-flash-0731-high",
+      "security__openrouter-z-ai-glm-5-3-flash-high",
+      "bugs__openrouter-deepseek-deepseek-v4-flash-0731-high",
+      "bugs__openrouter-z-ai-glm-5-3-flash-high",
       "report",
       "score__openrouter-z-ai-glm-5-3-high",
       "score__openrouter-x-ai-grok-4-6-high",
@@ -518,17 +573,17 @@ describe("built-in review-lite pipeline", () => {
     const byName = Object.fromEntries(
       pipeline.steps.filter((step): step is AgentStep => step.type === "agent").map((step) => [step.name, step]),
     )
-    expect(byName.scope?.model).toBe("openrouter/z-ai/glm-5.3")
+    expect(byName.scope?.model).toBe("openrouter/deepseek/deepseek-v4-flash-0731")
     expect(byName.report?.model).toBe("openrouter/deepseek/deepseek-v4-flash-0731")
     expect(byName.report?.inputFiles).toEqual([
       "prd.md",
       "reports/scope.md",
-      "reports/clean-code__openrouter-z-ai-glm-5-3-high.md",
-      "reports/clean-code__openrouter-x-ai-grok-4-6-high.md",
-      "reports/security__openrouter-z-ai-glm-5-3-high.md",
-      "reports/security__openrouter-x-ai-grok-4-6-high.md",
-      "reports/bugs__openrouter-z-ai-glm-5-3-high.md",
-      "reports/bugs__openrouter-x-ai-grok-4-6-high.md",
+      "reports/clean-code__openrouter-deepseek-deepseek-v4-flash-0731-high.md",
+      "reports/clean-code__openrouter-z-ai-glm-5-3-flash-high.md",
+      "reports/security__openrouter-deepseek-deepseek-v4-flash-0731-high.md",
+      "reports/security__openrouter-z-ai-glm-5-3-flash-high.md",
+      "reports/bugs__openrouter-deepseek-deepseek-v4-flash-0731-high.md",
+      "reports/bugs__openrouter-z-ai-glm-5-3-flash-high.md",
     ])
   })
 
@@ -566,6 +621,14 @@ describe("built-in fixer pipeline", () => {
     expect(byName.reproduction).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
     expect(byName.fixes).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
     expect(byName.validation).toMatchObject({ model: "openai/gpt-5.6-terra", variant: "xhigh" })
+  })
+
+  test("advises the writing phases with Astra 6 extra high and leaves validation unadvised", () => {
+    const byName = Object.fromEntries(fixer().map((step) => [step.name, step]))
+
+    expect(byName.reproduction).toMatchObject({ advisor: "openai/gpt-6-astra", advisorVariant: "xhigh" })
+    expect(byName.fixes).toMatchObject({ advisor: "openai/gpt-6-astra", advisorVariant: "xhigh" })
+    expect(byName.validation?.advisor).toBeUndefined()
   })
 
   test("lets reproduction and fixes write, and lets validation run checks without editing", () => {
@@ -857,7 +920,7 @@ describe("pipeline resolution", () => {
 
 describe("step filters", () => {
   test("validates --only/--skip names against the pipeline, tolerating human gates", () => {
-    const pipeline = defaultPipeline()
+    const pipeline = implement()
 
     expect(() => validateStepFilters(pipeline, { onlySteps: ["implementer"], skipSteps: ["tests"] })).not.toThrow()
     expect(() => validateStepFilters(pipeline, { onlySteps: ["secuirty"], skipSteps: [] })).toThrow('unknown step "secuirty"')
@@ -1076,7 +1139,7 @@ describe("synthesizeReadOnlyAgents", () => {
   })
 
   test("returns nothing when no step needed a synthesized variant", () => {
-    expect(synthesizeReadOnlyAgents(defaultPipeline(), builtInAgents)).toEqual([])
+    expect(synthesizeReadOnlyAgents(implement(), builtInAgents)).toEqual([])
   })
 })
 
@@ -1374,7 +1437,7 @@ describe("deliverable contracts", () => {
     // A writable phase gets the same markdown-report contract as a read-only
     // phase; the tool persists every agent step's deliverable.
     const defaultSteps = Object.fromEntries(
-      defaultPipeline()
+      implement()
         .steps.filter((step): step is AgentStep => step.type === "agent")
         .map((step) => [step.name, step]),
     )


### PR DESCRIPTION
## Qué hace

Consolida los pipelines custom que vivían como overrides del config global en los built-in de Convoy, y hace que el default del launcher sea `full-cycle`.

## Cambios

- **`implement-lite`, `review-lite`, `full-cycle` y `astra`** pasan a `builtInPipelines`, usando el alias OpenRouter de DeepSeek (`openrouter/deepseek/deepseek-v4-flash-0731`) en vez del provider local `nan` — así son portables y dejan de ser overrides del config global.
- **`full-cycle`** (implementa → mide → itera hasta 90/100) ahora es el default (`defaultPipelineName` deja de ser `implement`). `implement` se corre explícitamente con `-p implement`.
- **`fixer`**: los advisors de `reproduction` y `fixes` pasan de Sol xhigh a **Astra 6 extra high** (`openai/gpt-6-astra#xhigh`); `validation` queda sin advisor.
- El `defaultConfigTemplate` materializa el default (full-cycle) bajo su propia clave en vez de hardcodear `implement`.
- Se limpian los overrides y el agente temporal (`combined-auditor`) del config global; se conserva `modelRouting` para `branchNameModel`.

## Notas

- El default en código afecta a todos los usuarios: una ejecución implícita ahora entra en el goal loop de `full-cycle`. La regla de OpenSpec "requiere change" aplica al default (`full-cycle`).
- Tests actualizados para reflejar los nuevos modelos, el default full-cycle con goal step y los advisors Astra en fixer.