### PR TITLE
feat(lifecycle): stable feature identities, shared assessment, identity-based close

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -51,17 +51,7 @@ jobs:
         run: bun run typecheck
 
       - name: Test and enforce coverage
-        # Temporary: tee the full test output to a file so a failing runner's
-        # log (truncated by GitHub's stream cap) can be read from the artifact.
-        run: set -o pipefail && bun run scripts/coverage.ts 2>&1 | tee /tmp/test-output.log
-
-      - name: Upload test output
-        if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v5.0.0
-        with:
-          name: test-output-${{ matrix.os }}
-          path: /tmp/test-output.log
-          retention-days: 3
+        run: bun run test:coverage
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v5.0.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -51,7 +51,17 @@ jobs:
         run: bun run typecheck
 
       - name: Test and enforce coverage
-        run: bun run test:coverage
+        # Temporary: tee the full test output to a file so a failing runner's
+        # log (truncated by GitHub's stream cap) can be read from the artifact.
+        run: set -o pipefail && bun run scripts/coverage.ts 2>&1 | tee /tmp/test-output.log
+
+      - name: Upload test output
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v5.0.0
+        with:
+          name: test-output-${{ matrix.os }}
+          path: /tmp/test-output.log
+          retention-days: 3
 
       - name: Upload coverage report
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v5.0.0

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Install locked dependencies
         run: bun install --frozen-lockfile --os='*' --cpu='*'
 
+      - name: Install OpenSpec CLI
+        # Convoy shells out to `openspec` (board reads, close's archive step),
+        # and the e2e ownership tests run a real archive against fixture
+        # repos. CI must carry the same tool a developer's environment has or
+        # those paths fail with a raw spawn ENOENT instead of serving. Pinned
+        # to the version the maintainers run locally.
+        run: bun add -g @fission-ai/openspec@1.10.0
+
       - name: Verify cross-platform native dependencies
         # OpenTUI resolves each target dynamically, so a missing package can
         # produce a binary that reports a version but cannot open the TUI.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,21 @@ convoy --change add-login -p review
 
 ## The feature lifecycle: control, spin, close
 
-Everything the board shows is derived at render time from git, OpenSpec, and run plans — Convoy keeps no feature registry. If it appears, it is correct; if a worktree is deleted outside Convoy, the next open simply shows it gone.
+A unit of work has a stable, repository-scoped identity that survives renames, archiving, and cleanup. Convoy keeps a small local registry in the repository's Git common directory (`<git-common-dir>/convoy/`) — a repository UUID, one record per feature (its change contracts, intended base, current branch/worktree, runs, and close attempts), and immutable per-attempt landing receipts. The registry remembers what the operator associated with a context; everything it *displays* — worktrees, branches, tasks, run liveness, integration eligibility — is still derived at render time from fresh evidence, so if a worktree is deleted outside Convoy, the next open simply shows it gone. Records are keyed by opaque ids, so branch renames and reused branch names never alias old work into new authority.
+
+### Stable identities: `convoy feature`
+
+```bash
+convoy feature show                 # the feature for this context (or list discovery evidence)
+convoy feature show <id> --json     # machine-readable record, receipts, blockers
+convoy feature adopt --branch team/alice/release-42 --change add-widget --base main
+convoy feature bind <id> --branch feature/renamed --worktree <path>   # rebind after a rename/move
+convoy feature revise <id> --change one --change two --base main      # replace the contract set
+convoy feature recover --legacy --change add-widget                   # adopt a completed legacy landing
+convoy feature new-work --branch feat/one --worktree <path> --change next --base main
+```
+
+Adoption and rebinding are explicit consent operations: they validate repository membership, the actual checked-out branch, worktree registration, and the selected sources, and they never rename a branch (any Git-valid name is accepted as-is). Adoption records intent — it never marks tasks, archives, or integration complete. A completed feature (verified landing receipt) releases its claim on its branch; starting new work on that branch is the explicit `new-work` decision, which mints a fresh identity and inherits nothing. Legacy close journals from before stable ids are readable evidence: `recover --legacy` imports one only after validating its embedded landing against current Git, refusing collisions with registered features.
 
 ### The specs board (`convoy specs`)
 
@@ -213,7 +227,7 @@ branch: feat/add-login
 continue the same OpenCode conversation: run /move and pick the worktree above
 ```
 
-The operator's OpenCode session relocates with `/move` (OpenCode's own command — Convoy never forks or summarizes a session). If `/move`'s picker doesn't list the fresh worktree, open a session in the printed directory instead. A tree dirty outside `openspec/` refuses to spin; a change already committed on the base branch spins with nothing moved.
+The operator's OpenCode session relocates with `/move` (OpenCode's own command — Convoy never forks or summarizes a session). If `/move`'s picker doesn't list the fresh worktree, open a session in the printed directory instead. A tree dirty outside `openspec/` refuses to spin; a change already committed on the base branch spins with nothing moved. A successful spin also **registers the feature**: the stable identity, the selected contract, and the created branch/worktree are durably associated before the handoff prints, so every later board, launcher, and close lookup resolves the same feature by identity rather than by branch spelling. If the registry write fails, spin refuses to claim success and prints the created worktree, transferred files, and recovery steps — nothing is committed or deleted.
 
 The global `/convoy-spin` OpenCode command is opt-in: run `convoy opencode install` once and the thin wrapper at `~/.config/opencode/commands/convoy-spin.md` tells the agent to run `convoy spin` and relay its output, touching no other command files (spin never writes into your global config).
 
@@ -237,9 +251,19 @@ In a terminal the whole sequence runs in a full-screen TUI: completed, skipped (
 
 The message review is a vertical Accept / Edit / Cancel list: `↑`/`↓` (or `j`/`k`) move the selection, `Enter` activates the highlighted choice, and the direct shortcuts `y` / `e` / `n` still work. **Edit opens an inline multiline editor inside the TUI** — no external `$EDITOR` round-trip. Type freely (`Enter` inserts a newline), press `Ctrl+S` to save and return to review, or `Esc` to discard the draft and keep the previously reviewed message. Nothing lands until you explicitly choose Accept, so saving an edit is not a confirmation.
 
-Push, worktree removal, and branch deletion are separate, deliberate offers — never automatic. Push uses the base branch's configured remote with an explicit refspec, and is unavailable (with the setup step printed instead) when the base branch has no upstream. Worktree removal must succeed before branch deletion is offered, because git refuses to delete a checked-out branch; and because a squash-landed branch has no merge ancestry, deletion is gated on close's verified landing receipt — the exact feature tip unchanged and the landing commit still reachable from the base — with the printed command re-checking both facts right before `git branch -D`. Headless runs print the equivalent guarded commands in that same safe order.
+Push, worktree removal, and branch deletion are separate, deliberate offers — never automatic. Push uses the base branch's configured remote with an explicit refspec, and is unavailable (with the setup step printed instead) when the base branch has no upstream. Worktree removal must succeed before branch deletion is offered, because git refuses to delete a checked-out branch; and because a squash-landed branch has no merge ancestry, deletion is gated on close's verified landing receipt — the exact feature tip unchanged and the landing commit still reachable from the base — and executed as an **atomic expected-tip deletion** (`git update-ref -d refs/heads/<branch> <expected-tip>`): if the branch moved between the check and the deletion — for example because a new feature reused the name — the expected-old value refuses, so the wrong work is never deleted. Headless runs print the equivalent guarded commands in that same safe order.
 
 One cleanup nuance: when close was **launched from inside the feature worktree**, worktree removal and branch deletion are presented as *deferred cleanup* — an explanation plus the exact `git -C <main-checkout>` commands in dependency order — rather than as selectable actions. A process cannot remove the directory its own shell sits in, so no amount of navigation inside this session can make those actions runnable; leave the worktree in your terminal first and run the printed commands from outside. Push is unaffected: it is offered either way.
+
+### What close's evidence means (and what it doesn't)
+
+Lifecycle facts are kept deliberately orthogonal — none implies another:
+
+- **Tasks complete** is not "ready to close": a live run, an unverified context, or an unreadable source each blocks the close review with its reason, and the review stays reachable while blocked.
+- **Archived** is not "integrated": a change can be archived (including by hand, or by `m` archive-on-main) while its branch is unlanded. The board reports *Implementation complete · archive verified* and keeps the close review available.
+- **Probably merged** is not "merged": patch equivalence without a receipt stays probabilistic, forever.
+- **A verified landing receipt** is the only certain local integration: it names the exact feature tip and the landing commit, and counts only while that landing is still reachable from the base and the tip is unchanged. That is *integrated locally* — it says nothing about a remote, a PR, or a hosted merge.
+- **Landing is two recorded stages**: the base ref moves through an expected-old guarded ref transaction (after which the landing has happened, even if the process dies), and the base checkout is then materialized with a guarded update. A crash between them is reconciled on the next `close --resume` — the landing is recognized, the checkout is brought up to date, the receipt is written, and no second commit is ever created for the same closed tip.
 
 ## Goal mode
 

--- a/openspec/changes/stable-feature-lifecycle/.openspec.yaml
+++ b/openspec/changes/stable-feature-lifecycle/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/stable-feature-lifecycle/design.md
+++ b/openspec/changes/stable-feature-lifecycle/design.md
@@ -1,0 +1,250 @@
+## Context
+
+See `proposal.md` for motivation and `specs/feature-lifecycle/spec.md` for the new domain contract. The planning baseline is the current main checkout, which already includes automatic run compaction, protected recovery refs, a repository mutation lease, squash-close candidates/receipts, and goal dashboard improvements. This is not a replacement for those safety mechanisms.
+
+Current responsibilities are fragmented:
+
+- `control-board.ts` discovers active directories across worktrees, chooses a copy through branch/Markdown/list-order precedence, and derives stage separately from browser action gates.
+- `openspec.ts` selects run contracts using explicit ID, sole change, branch match, or diff overlap; that selection is not a durable ownership relationship.
+- `specs.ts` and browser handoffs can lose the authoritative checkout, and archived work drops out of active-only discovery.
+- `run-plan.ts`, metadata, and run indexes contain useful frozen boundaries, but no universally durable feature/contract link. The board can reinterpret old target paths using today's checked-out branch.
+- Close supports explicit change selectors but otherwise derives a slug from branch spelling. Its missing-active-directory shortcut is not positive archive proof. Journals use lossy branch/change filenames, and some crash windows precede durable outcome recording.
+
+The existing control-board requirement prohibits a registry, and its purpose text repeats that assumption. This change deliberately replaces that contract. Canonical purpose summaries for control-board/feature-spin must be reconciled during implementation/spec synchronization; the present planning operation does not edit canonical specs.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Introduce a small shared lifecycle domain, not a new hosted tracker or daemon.
+- Make identity selection stable and action authorization conservative; separate historical intention from current verifiable state.
+- Support work created outside Convoy, archived before close, renamed, relocated, or interrupted, without asking the operator to restore a magic branch name.
+- Preserve whole-feature squash landing and exact-tip cleanup evidence while eliminating repeat-close and resume ambiguity.
+- Make the ordinary UI explain the next useful action, with identical targets and reasons in CLI, root, detail, and follow-ups.
+
+**Non-Goals:**
+
+- No automatic hosted PR merge, remote status polling, cross-machine registry synchronization, or automatic publication/deletion.
+- No path-filtered close, stacked-branch orchestration, or aggregation of several implementation branches into one feature. One feature has one current context and an explicitly reviewed set of change contracts.
+- No change to OpenSpec artifact formats, no agent-authored archive repair by Convoy, and no automatic reactivation of archived changes.
+- No weakening of run compaction boundaries: a feature rename can preserve lifecycle identity while an old run still refuses a rewrite because its originating boundary no longer validates.
+- No unconditional guarantee against arbitrary concurrent filesystem writes by external programs. Serialize Convoy operations, use Git's own safety/ref guards, detect divergence, and stop with recovery evidence rather than overwrite unverified work.
+
+## Decisions
+
+### D1. Persist associations and evidence, never an authoritative display status
+
+Add a versioned repository-local store under the canonical Git common directory:
+
+```text
+<git-common-dir>/convoy/
+  repository.json                     # repository UUID and schema version
+  features/<feature-id>/
+    feature.json                      # current association, revision, history pointers
+    attempts/<attempt-id>/journal.json
+    receipts/<attempt-id>.json         # immutable verified landing record
+```
+
+Use opaque UUIDs for repository, feature, and attempt identities; do not encode branch/change spellings into filenames. Protected refs use `refs/convoy/features/<feature-id>/<attempt-id>/...` and verify existing ref values rather than accepting any pre-existing object. Validate schema, embedded IDs, repository membership, relative paths, and ref syntax on every load. Read failures are typed as missing, corrupt, unsupported, or unreadable, never all collapsed to absence.
+
+A feature record stores:
+
+- Display name and stable ID; repository ID and monotonically increasing association revision.
+- Ordered contract set: change ID, resolved planning source, active-relative path or explicit archive candidate, and association provenance. Preserve each revision's selected set.
+- Intended local base ref, not a permanently frozen base SHA; each close attempt captures its own base SHA.
+- Current full branch ref, canonical checkout path, and worktree administrative identity where Git exposes one. Path and branch are current attributes, not identity keys.
+- Historical observations/rebindings, durable run IDs, and close attempt/receipt references. A feature record does not store `ready`, `integrated`, or `clean` as authoritative facts.
+
+Creation occurs only on explicit adoption, successful spin registration, or acceptance of a new feature-backed launch. Reads do not create the repository UUID, lock sidecars, migration files, or indexes. No-spec runs remain valid without a feature; explicit adoption of an archived change requires its source selection and does not imply verification success.
+
+**Alternative rejected:** a cached status enum or full event-sourced workflow engine. The former becomes stale after external Git/OpenSpec actions; the latter adds machinery beyond the association and recovery evidence needed here. Atomic versioned records plus immutable attempts/receipts fit existing patterns.
+
+### D2. One feature owns one current context; contract selection is separate
+
+Allow a feature to carry multiple explicitly selected changes because existing run bundle composition already supports that. Close validates every associated contract, archives remaining active contracts in deterministic ID order, and lands the entire branch once. Do not expose independent closes for each contract on that branch. The UI names the complete set and whole-branch scope.
+
+At most one active association can claim a branch/worktree context. The same change slug in multiple worktrees is a collection of artifact copies, not multiple owners. Reusing a closed branch name or starting further implementation after a completed feature creates a new feature ID through an explicit new-work decision; never silently reopen the old receipt. Changes to a live feature's contract set require a reviewed association revision and are blocked during a live run or unresolved close attempt. Historical runs keep their original contract set.
+
+**Alternative rejected:** one feature per directory or per run. Directories are copied/archived and runs are repeated; neither corresponds to the operator's unit of implementation.
+
+### D3. Explicit adoption and rebinding replace naming authority
+
+Introduce these user-facing operations (planned commands, not executed by this change):
+
+```text
+convoy feature show [<feature-id>] [--json]
+convoy feature adopt --branch <name> --change <id> [--change <id> ...] --base <local-ref> [--archive-path <path>]
+convoy feature bind <feature-id> --branch <name> --worktree <path>
+convoy feature revise <feature-id> --change <id> [--change <id> ...] --base <local-ref>
+convoy feature recover <feature-id> [--legacy]
+convoy feature new-work --branch <name> --worktree <path> [--change <id> ...] --base <local-ref>
+convoy close --feature <feature-id> [--resume]
+convoy close --feature <feature-id> --cleanup worktree
+convoy close --feature <feature-id> --cleanup branch
+```
+
+`show` is read-only and can show unresolved discovery evidence for the current context. `adopt` names existing work; all required values are explicit in headless mode. A single `--archive-path` disambiguates one archived contract; multi-contract ambiguous archives are selected one at a time in the TUI/adoption review rather than inferred from date ordering. The implementation must expose an equivalent unambiguous repeated mapping form for headless multi-contract adoption (`--archive-source <change-id>=<path>`); it is mutually exclusive with the single-contract shorthand. Paths must resolve within the selected planning root, with symlink escape checks.
+
+`bind` is explicit consent to update a feature's context, but not to change its base/contracts, migrate a foreign receipt, rewrite a run boundary, or claim landing. Verify Git common-directory membership, registered worktree root, actual branch, context uniqueness, and absence of live/unreconciled mutation before updating its revision. A tip match can support inspection, never by itself prove a rename: several branches may share a tip. Wrong refs, detached contexts, and a directory that is merely a subdirectory of main are rejected as implementation contexts. New integration requires a source context distinct from the landing checkout and source branch distinct from the base.
+
+`revise` is explicit reviewed consent to add/remove/reorder a live feature's contract set and change its intended base. It is refused during a live run or unresolved close attempt. `recover` is evidence-only import of a completed feature whose worktree is gone; it validates embedded identity, repository membership, protected refs, candidate/feature trees, and landing reachability, then grants only receipt-verified follow-up/cleanup eligibility, never new execution authority. It does not require the historical worktree or branch to exist. `new-work` is explicit consent to start a new feature on a retained completed context; it creates a new identity and does not reopen the completed feature's receipt or inherit its runs. All three persist a new association revision and are refused on ambiguity without a reviewed selection.
+
+Existing `--branch`, `--change`, and `--resume` remain selectors. When several selectors are supplied they must agree with the registered feature. For multi-contract features, `--change` can locate a containing feature only if unique; it never narrows landing scope. An unassociated interactive close opens adoption review without running sync/archive. An unassociated headless close exits non-zero with the exact explicit adoption command. Naming/sole-change/diff heuristics may propose a contract selection in the launcher, but only accepted review establishes the relationship.
+
+Resolver order: explicit feature ID; verified current context association; unique association selected by explicit branch/change filters; otherwise unresolved candidates. It returns a tagged result with evidence and blockers, not an optional branch string. Invalid explicit selectors never fall through to a different heuristic. Deletion/move/rename leaves the feature visible; rebinding is a guarded recovery action.
+
+**Alternative rejected:** remove the branch-name condition and keep other discovery heuristics. That hides the ownership problem rather than fixing it and can close the wrong branch.
+
+### D4. Durable run links complement immutable execution boundaries
+
+Add optional repository/feature ID, association revision, and reviewed contract IDs/source references to reviewed plans, persisted run metadata, and cleanup-surviving run indexes. Write the link before execution, including for failed/aborted runs, not only after successful compaction. Reader adapters preserve frozen branch/path/start-SHA fields and never reconstruct history by mapping an old path to today's branch.
+
+Spin records the actual created branch/path, with an intent/recovery marker before transfer and a committed association before success output. A partial failure exposes the created worktree and moved files; retry can explicitly adopt that context without allocating a duplicate. Accepted launcher creation follows the same staged pattern; cancellation before acceptance writes no feature record. Reusing an association does not change it merely because a different checkout launched the command.
+
+Feature-linked Apply and Continue carry a complete action target; Iterate uses the associated planning checkout. Continue disables *new worktree creation* rather than relying on an ambiguous isolation label. Archived contracts support reading and close, not another apply run until the operator creates/selects new active work. Multi-change selection is explicit in review.
+
+No-spec publication retains verified run-context selection. Feature-backed publication uses the current associated context and current safety checks, not a historical HEAD as authority. The lease and final checks apply at actual push time; missing tools/auth remain publication-specific blockers, not close blockers. Run compaction still validates its original run boundary even after a feature was rebound.
+
+**Alternative rejected:** use existing run branch fields as the feature registry. Some work has no run, old plans may be temporary, and a mutable branch is not a stable join key.
+
+### D5. Shared pure assessment over typed observations
+
+Introduce a lifecycle module boundary with separate read adapters, identity resolver, pure fact/capability evaluation, and action executors. Initial integration points are `control-board.ts`, `specs.ts`, launcher/CLI, `publish.ts`, and feature-close. Remove the dependency whereby close imports board-specific task helpers; artifact/task observation belongs below both consumers.
+
+An assessment contains:
+
+```text
+feature / association revision / observed-at
+context: verified | unassociated | ambiguous | missing | unreadable
+contracts[]: active | verified-archived | missing | ambiguous | unreadable
+tasks[]: done/total | unknown
+execution: live run IDs | no-live-runs | unknown
+integration: pending | probable | verified(receipt) | stale | unknown
+publication: observed remote/upstream/PR facts, each with provenance
+cleanup: worktree and branch observations, independently verified
+actions[]: { id, applicable, enabled, blockers[], remediation[], target }
+```
+
+Action targets include repository/feature IDs, association revision, contract sources, source/base refs, and relevant observed SHAs. Executors acquire mutation coordination and reload fresh evidence before acting; an assessment is an explanation, not a transferable permission token. Adapters return structured read errors. In particular run-discovery failures cannot masquerade as an empty live-run set.
+
+Summary precedence favors recovery/unknown blockers over claimed readiness. Typical presentation:
+
+| Observed facts | Summary | Useful next action |
+| --- | --- | --- |
+| Candidate without association | Association needed | Adopt or spin |
+| Associated, tasks incomplete or run live | In implementation | Continue / inspect run |
+| Tasks complete but close blockers | Implementation complete · blocked | Review close |
+| All close-start prerequisites pass | Ready to close | Close |
+| Verified archive, no verified integration | Implementation complete · archive verified | Review close |
+| Patch-equivalent, no receipt | Probably merged | Inspect / archive on main |
+| Verified landing, cleanup remains | Integrated locally | Push / guarded cleanup |
+| Verified landing and absent cleaned context | Completed | History |
+
+Task checkboxes do not prove tests passed. Archived alone does not prove integration; receipt reachability does not prove remote publication or PR merge. No new hosted polling is added.
+
+**Alternative rejected:** reuse only the existing preflight for rendering. That preflight assumes a resolved active worktree and cannot describe unassociated, archived, removed, or cleanup-only subjects; the shared evaluator must cover discovery through history, with phase-specific prerequisites.
+
+### D6. Read-only discovery and UI actions stay coherent
+
+Discover registered features first, then unassociated active candidates and legacy evidence; enumerate worktrees and sources without granting ownership. Include archived sources referenced by records/attempts and offer explicit archive selection during adoption. Do not flood the default board with every historical archive directory. Registered pending features remain in **Features** even when active directories vanish; registered completed work is accessible through **History**. Run-bearing no-spec contexts stay in **Worktrees without spec** even when they contain copied changes.
+
+Associated artifact inventory always comes from its validated source using absolute paths. Broken association yields missing/unreadable information, not a silent same-slug fallback. Unassociated duplicate sources are readable through source selection without creating records. Board rows and artifact inventories share feature identity keys and source provenance to avoid mixed titles/tasks/targets.
+
+Add a discoverable `Actions` menu in root and ordinary detail, available even when footer hints truncate. Close review remains applicable while integration is pending and shows blocked execution reasons. Fullscreen reader keys remain unchanged; leaving fullscreen restores the selected feature and menu. Provide explicit refresh and refresh after external action return; invalidate artifact/assessment caches together and preserve selection by identity. This change does not add a background daemon or require continuous polling.
+
+Headless listing uses the same assessment. JSON inspection exposes machine-readable blockers, provenance, observed revision, and action targets without performing repair writes. Menu dispatch, shortcut dispatch, and CLI checks consume the same capabilities; no duplicated branch/path gate remains in the renderer.
+
+**Alternative rejected:** always show `x close` and let the command fail. That leaves wrong/missing targets and invisible context transitions unresolved and still provides no path from detail to identity repair.
+
+### D7. Archive is positively verified, including external archive
+
+Introduce one artifact-state reader used by adoption, assessment, and close. Capture original active-contract identity, task counts, delta capability/requirement inventory, and proposal context before invoking OpenSpec. Task completion is required for every contract. For a previously archived contract, find a unique archive candidate tied to the selected ID and explicit source; do not take the latest date prefix as ownership proof. Parse selected paths as paths within the planning root, never interpolate unchecked branch spelling into them.
+
+Archive evidence includes source/archive relative paths, associated feature/contract revision, checked task counts, archive artifact blob identities, canonical-spec requirement effects, and committed feature SHA/tree. Verification requires:
+
+1. The archive source is unambiguous and readable, with the expected change metadata/artifacts and completed tasks.
+2. Active/archive coexistence is explained by an in-progress recorded operation; unexplained competing active/archived sources are blocked.
+3. Delta effects are represented in canonical specs: ADDED/MODIFIED requirement blocks and scenarios, REMOVED absence, and RENAMED source/destination rules, preserving full capability paths. Normalize only structural Markdown differences; do not substitute an LLM's semantic guess for proof. A verified no-delta change with valid metadata needs no canonical effect comparison.
+4. The prepared result is committed and related to the current feature preparation. Recheck after base sync and before candidate creation.
+
+Use a focused deterministic delta/effect verifier shared across these paths, reusing existing OpenSpec parsing facilities where available. It is verification only: OpenSpec CLI remains the artifact writer. If later legitimate canonical changes make exact evidence insufficient, report the conflicting requirement and ask for explicit OpenSpec reconciliation rather than silently weakening verification. Unsupported structures and unprovable external archives stay blocked with source-specific guidance. Completed task evidence remains required even if OpenSpec previously archived with warnings.
+
+For recorded interrupted archive work, expected affected paths/effects are captured before CLI invocation. Resume accepts only the verified intended archive result; unrelated dirty paths stop it before committing. Multi-contract archive proceeds deterministically, preserving a completion record per contract. Archived proposal/capability context feeds message composition after the live directory disappears. When several contracts touch the same requirement, verification is applied over the ordered composed effect with retained per-contract evidence; an unprovable composition stops before the first archive mutation rather than validating each contract against a final tree that another contract already changed.
+
+**Alternative rejected:** `!exists(activeDir)` or merely `exists(archiveDir)`. Neither establishes identity, task completion, or canonical spec synchronization. No automatic “skip verification” flag is introduced.
+
+### D8. Close becomes an identity-keyed recoverable transaction
+
+Keep existing one-parent squash construction and conventional-message review, but persist an attempt before the first mutation and reconcile by observed effects rather than phase name alone:
+
+```text
+resolved/reviewed
+  → sync intent → sync verified (or conflict recovery)
+  → archive intent/result per contract
+  → prepared feature tip/tree + preserved message context
+  → candidate intent → protected candidate verified
+  → landing intent → ref landed → base checkout reconciled
+  → immutable receipt
+  → independent cleanup intents/results
+```
+
+Journals capture expected association revision, source/base refs and SHAs, source/worktree observations, per-contract archive evidence, protected feature/candidate refs, and operation IDs. Save intent before each mutation and result afterward. Required persistence failures stop before the corresponding mutation. Existing record/ref mismatches are errors, not success.
+
+Every close, not just `--resume`, first checks pending attempts and completed receipts. For unchanged verified landed work it returns the original landing plus still-applicable follow-ups; it does not merge the base again, clear the receipt on tree equality, or create another commit. `--resume` selects recovery of the current feature/attempt; a valid current association permits bare resume, and `--feature` permits resume after worktree deletion. Multiple unfinished legacy candidates require explicit selection.
+
+Crash reconciliation rules:
+
+- **During sync:** recorded pre-sync tip/base plus actual merge state identify a conflict or a completed merge. Leave conflicts for the operator; do not rerun a merge blindly.
+- **After archive but before commit:** verify intended archive effects and scoped dirt before committing; unrelated changes stop recovery.
+- **After candidate creation:** reload protected refs and verify one captured-base parent and exact prepared tree before reuse.
+- **After base landing but before receipt:** if the recorded candidate remains reachable from the intended base and the prepared feature context is unchanged, reconcile checkout/evidence and record that landing, including when base advanced afterward.
+- **Base moved without candidate:** do not reuse the stale candidate. Offer renewed sync/review with a new preparation/attempt retaining the old evidence, and revalidate archive effects.
+- **Feature moved after receipt:** show stale current eligibility. Never silently reland or clean it up; retain the old receipt and require explicit new-work/recovery planning.
+
+Patch equivalence without a receipt remains probable. Direct close must consult that assessment before sync/landing, as the canonical spec already requires. This change does not introduce an “external squash equals verified receipt” shortcut; archive-on-main stays available after deliberate review and verifies the actual base checkout branch. Archive-on-main also verifies the base-checkout copy corresponds to the selected contract before archiving and records the resulting archive source/evidence, leaving integration as probably merged or pending rather than confirmed. When the feature worktree retains its active copy afterward, discovery must prefer the recorded archive source for that contract instead of continuing to report the unarchived copy as current work.
+
+**Alternative rejected:** one mutable journal per branch/change, plus a `landed` boolean. It collides on names, loses generations after rename/reuse, and cannot distinguish a completed Git effect from a missing acknowledgement.
+
+### D9. Guard landing and cleanup at the operation boundary
+
+Reuse the repository mutation lease for association writes, run finalization, close mutation segments, publication, and cleanup. Do not hold it while waiting for message review; persist preparation, release it, and reacquire/revalidate afterward. The lease serializes Convoy only. Git reference updates additionally use expected-old values; landing should atomically verify the prepared feature ref and update the captured base ref through a Git ref transaction rather than rely solely on a prior `baseNow` check plus `merge --ff-only`.
+
+Ref landing and checkout materialization are distinct recorded stages because Git does not atomically update a branch ref, the entire worktree, and Convoy's journal. Record the clean base index/tree/HEAD before landing. Once the guarded ref transaction succeeds, the landing has happened: subsequent failure is checkout/evidence recovery, not a claim that the base is unadvanced. Materialize the candidate into the base checkout only when its recorded branch/index/worktree preconditions still hold, using Git's guarded two-tree checkout/update behavior rather than an unconditional hard reset. If unexpected edits, checkout switches, or external ref movements appear, leave them intact and require reconciliation; block cleanup/publication while this recovery is unresolved. Tests must cover each boundary and no overwrite of unrelated edits.
+
+Both worktree removal and branch deletion reload receipt and association, check landing reachability and exact source tip, verify no live run/recovery, and require consent. Worktree removal uses Git's non-forced removal protections after clean-context checks. Local branch deletion uses an expected-tip ref deletion after confirming no registered worktree checks out the branch; remove branch configuration only after successful guarded deletion, not before. Do not use a separate tip test followed by unconditional `branch -D` as the safety mechanism.
+
+Deferred/headless cleanup prints the feature-keyed guarded `convoy close --feature ... --cleanup ...` commands, with worktree removal before branch deletion and an explicit instruction to leave the source checkout first. These execute the same checks as the TUI, eliminating evidence loss through display-only command objects. A later branch at the same spelling must not be deleted using the old receipt. If both branch/worktree are already absent, record observable cleanup state without recreating them; feature/run evidence remains retained.
+
+**Alternative rejected:** let the TUI carry an old “safe” boolean or an unprotected shell recipe. Eligibility can change after rendering, and shell check-then-delete is not an atomic expected-tip mutation.
+
+### D10. Conservative compatibility and migration
+
+New readers accept current legacy records and distinguish them from stable-ID records. On explicit adoption, inspect embedded journal branch/change fields, repository evidence, protected refs, candidate/feature trees and landing reachability. Never trust a lossy filename alone. Write a new identity-keyed import record with provenance and preserve the original bytes and refs. A collision, unsupported version, or contradictory context stays unresolved. Legacy run links are imported only when their durable evidence and selected association agree; missing boundaries do not become rewrite permissions.
+
+No read-time migration or automatic relabelling of old paths. A new clone or lost common-directory store displays unassociated work and offers adoption; filenames and commit prose cannot recreate proven lifecycle facts. Existing valid local receipts can be recovered explicitly. The registry is local operational metadata, not part of the committed proposal and not shared by pushing a branch.
+
+Canonical purpose summaries that say “no registry” or describe only active-directory navigation must be updated when applying/synchronizing this change, without removing unrelated requirements. The old `finish` lookup example is replaced by Close/Continue context lookup in the worktree delta. Conventional branch creation, location templates, dirty-tree consent, no-spec runs, and automatic run-compaction protections remain compatible.
+
+**Alternative rejected:** transparently write migrated associations during board load. That promotes heuristics to authority without consent and makes inspection mutate the repository's operational state.
+
+## Risks / Trade-offs
+
+- **Local association metadata can be lost or copied between clones** → Validate repository identity/common directory and current Git membership; expose recovery/adoption instead of silently granting authority. No cross-machine identity guarantee in this scope.
+- **Explicit adoption adds a one-time step for old work** → Pre-fill evidence-backed suggestions and show all fields together; new spin/accepted launch registers automatically. Refuse only uncertain mutation, not reading.
+- **Strict archive verification can block legitimate evolved specs** → Name the exact unproven delta effect and retain all artifacts; require OpenSpec reconciliation rather than guessing or editing specs inside Convoy.
+- **Multi-contract close can partially archive before a later failure** → Persist per-contract intent/result, stop before landing, and resume with verified effects. The confirmation always states whole-branch scope.
+- **A shared assessment could become an expensive monolith** → Separate pure policy from adapters; batch worktree/run discovery and memoize only within one observation snapshot. Explicit refresh replaces caches, and execution always rereads required evidence.
+- **External Git/filesystem actions do not honor Convoy's lease** → Expected-ref transactions, registered-context checks, Git's non-forced checkout/removal protections, durable intent, and recovery on divergence. Never advertise complete cross-process filesystem atomicity.
+- **Ref landing succeeds while checkout/receipt update fails** → Model landing and checkout recovery separately, preserve candidate refs, block follow-up mutation until reconciliation, and fault-inject both sides of every acknowledgement boundary.
+- **Stable identity is mistaken for history-rewrite permission** → Keep run boundaries immutable and compaction guards independent; rebinding never rewrites old run metadata or loosens publication safety.
+- **Large cross-cutting rollout leaves a mixed model** → Land implementation in dependency order but switch user-facing resolution only when all action consumers share the resolver; enforce end-to-end invariant tests before release.
+
+## Migration Plan
+
+1. Add versioned readers/store and shared observation/resolution APIs with legacy records still readable. Introduce explicit feature inspection/adoption/rebinding and test typed corruption/ambiguity paths.
+2. Wire registration into spin and accepted launch; persist feature/run links before execution. Preserve no-spec flows and cancelled-preview behavior.
+3. Replace board ownership, artifact resolution, handoffs, action menus, refresh, and publication selection together. Legacy candidates remain visible with one-time adoption guidance.
+4. Migrate close execution to stable attempt identity, positive archive verification, immutable receipts, guarded landing/recovery, and shared cleanup executors. Import legacy evidence only through explicit validated adoption.
+5. Run lifecycle scenario, crash-boundary, concurrency, compatibility, typecheck, and full-suite coverage; document the local-record contract, archive/integration distinctions, and guarded commands. Synchronize delta specs and their outdated purpose summaries through the normal reviewed OpenSpec workflow.
+
+**Rollback:** retain legacy evidence and all new protected refs; never delete operational history as part of a downgrade. A pre-change binary cannot safely interpret new feature associations/attempts, so downgrade requires stopping writers and resolving pending transactions with the newer binary first. Read-only Git/OpenSpec inspection remains available. Do not describe rollback as transparent compatibility or automatically convert new receipts to lossy old keys.

--- a/openspec/changes/stable-feature-lifecycle/proposal.md
+++ b/openspec/changes/stable-feature-lifecycle/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Convoy currently reconstructs feature identity from mutable branch names and copies of active OpenSpec directories, so routine merges, renames, and early archiving can hide unfinished work or show “ready to close” without a close action. A reliable workflow must remember which work the operator associated with a context, independently verify its current progress, and retain enough evidence to finish or resume safely.
+
+## What Changes
+
+- Introduce repository-local stable feature identities with explicit change-contract, implementation-context, base, run, and close-attempt associations. Persist intent and evidence, not a cached authoritative lifecycle status.
+- Register associations during successful spin and accepted run launch; provide explicit inspection, adoption, and rebinding for pre-existing or externally changed contexts. Conventional names remain defaults, never ownership proof.
+- **BREAKING**: replace branch-name/Markdown/list-order ownership and silent close-target guesses with one shared resolver. Unassociated legacy work stays visible; mutation requires a verified association or explicit adoption. Existing `--branch`, `--change`, and `--resume` spellings remain supported as selectors, not safety bypasses.
+- Derive orthogonal artifact, task, execution, integration, publication, and cleanup facts through one assessment shared by the board, launcher, run publication, and close. Explain blocked actions instead of hiding them and revalidate targets before mutation.
+- Keep archived-but-unintegrated features and integrated-but-not-cleaned features discoverable. Read artifacts from their associated source, including verified archives, without substituting unrelated copies.
+- Make close identity-based, positively verify archive completion, preserve whole-branch squash semantics, reconcile interrupted landings, retain immutable receipts, and make repeated close and cleanup safe across rename, worktree removal, and retries.
+- Migrate legacy run/journal evidence conservatively and preserve run-boundary, recovery, signing, hooks, secret-file, and exact-tip cleanup protections. Missing or ambiguous evidence is not success.
+
+## Capabilities
+
+### New Capabilities
+
+- `feature-lifecycle`: Stable repository-scoped identity, explicit associations and reconciliation, lifecycle evidence, shared assessment and action capabilities, and conservative legacy adoption.
+
+### Modified Capabilities
+
+- `control-board`: Replace inferred ownership with associated feature rows and shared assessment; retain pending lifecycle work after archive or worktree deletion.
+- `specs-viewer`: Read-only lifecycle discovery, authoritative active/archive artifact sources, feature-aware handoffs, and discoverable actions in root and detail views.
+- `feature-spin`: Persist the feature/context association on successful spin without changing conventional default names or proposal-transfer behavior.
+- `run-launcher`: Review and persist explicit feature/contract/context selection and revalidate it before execution.
+- `run-finalization`: Preserve feature linkage in durable run history and resolve publication against the verified current feature context without weakening run-specific rewrite boundaries.
+- `feature-close`: Shared target/preflight assessment, verified archive state, stable transaction identity, idempotent landing recovery, and evidence-gated cleanup.
+- `worktree-location`: Separate new-worktree path allocation from lookup/rebinding of existing feature contexts.
+
+## Impact
+
+- Affects `src/control-board.ts`, `src/openspec.ts`, `src/specs.ts`, `src/specs-browser.ts`, spin/launcher/CLI handoffs, reviewed plans and run metadata/indexes, publication, close journals/commands, and Git mutation coordination. Introduces a shared lifecycle domain and repository-common-directory storage.
+- Changes local CLI/TUI selection and compatibility behavior; no hosted service, new runtime dependency, remote registry, automatic publication, automatic branch deletion, or changes to OpenSpec's on-disk artifact format are required.
+- Preserves ordinary no-spec runs and multi-change run contracts; an implementation context has one current feature association with an explicit contract set. Adoption does not imply task completion, archive success, integration, or permission to rewrite old run history.
+- Requires end-to-end and fault-injection tests across copies, renames, archive-before-close, stale/corrupt evidence, concurrent changes, and partial cleanup, plus updated workflow documentation. This change creates planning artifacts only; implementation is a separate apply operation.

--- a/openspec/changes/stable-feature-lifecycle/specs/control-board/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/control-board/spec.md
@@ -1,0 +1,87 @@
+## MODIFIED Requirements
+
+### Requirement: Control command is the single inferred board
+
+`convoy specs` SHALL present the board, retaining `convoy control` as a compatibility alias, and use the shared feature resolver and lifecycle assessment. It SHALL persist explicit identity and associations but derive current worktrees, branches, task completion, run liveness, and integration eligibility from fresh evidence. Read-only OpenSpec task queries SHALL be permitted with filesystem fallback when the CLI is unavailable; unreadable evidence SHALL remain unknown. Historical run linkage SHALL use durable feature identity and frozen provenance, not the branch currently checked out at an old run path. Browsing SHALL NOT write the registry. The board SHALL distinguish unresolved legacy candidates from registered features.
+
+#### Scenario: Deleting the worktree updates the board
+- **WHEN** a feature's worktree is removed outside Convoy and the board is reopened
+- **THEN** the feature remains visible without claiming a worktree and offers missing-context or remaining-cleanup guidance as appropriate
+
+#### Scenario: One resolver everywhere
+- **WHEN** a branch with any valid name is explicitly associated with a change
+- **THEN** board and run selection use that association and show the same verified implementation context
+
+### Requirement: Active change rows derive their lifecycle state
+
+The board SHALL show registered pending features and unassociated active-change candidates, not only active directories. Each feature row SHALL show its assessed lifecycle summary, tasks done/total when known, linked runs and liveness, uncommitted proposal signal, base synchronization, artifact/archive state, and integration evidence with its certainty. Verified local landing SHALL be labelled integrated locally; patch equivalence alone SHALL remain probably merged. Archived-but-unintegrated features and integrated features with pending cleanup SHALL remain in the pending-work surface. Completed features SHALL remain accessible through history. Unassociated candidates SHALL show association or spin remediation rather than asserting ready-to-close ownership. “Ready to close” SHALL require the shared close-start prerequisites, and blockers SHALL be visible.
+
+#### Scenario: Implementing feature
+- **WHEN** a feature has two associated runs, one live
+- **THEN** its row shows implementation in progress with two runs and the live one marked, rather than claiming ready to close from task counts alone
+
+#### Scenario: Stranded change on main
+- **WHEN** an uncommitted change exists on the base checkout with no feature association
+- **THEN** it remains visible as unassociated work and offers spin or explicit association without inventing an implementation branch
+
+#### Scenario: Archived before integration
+- **WHEN** a feature's own change is archived while its branch also contains an unrelated active change inherited from main
+- **THEN** the feature remains listed with its archived contract and pending integration; the inherited change does not replace its identity
+
+#### Scenario: Definite local landing
+- **WHEN** a feature has a verified receipt whose landing remains reachable and its feature tip is unchanged
+- **THEN** the board reports integrated locally and offers only applicable follow-ups without labelling the evidence as patch-equivalence probability
+
+### Requirement: Worktrees without spec get their own section
+
+The board SHALL include a peer section for run-bearing worktrees without an associated OpenSpec feature, each linking to its runs. Presence of unrelated change-directory copies SHALL NOT suppress this section. Registered features with archived contracts SHALL stay in the feature lifecycle surface rather than being downgraded to specless worktrees. Empty peer sections SHALL be omitted entirely. A non-empty worktree section SHALL make the board interactive even without changes or canonical specs.
+
+#### Scenario: Plain isolated run appears
+- **WHEN** an isolated run's worktree exists without an associated OpenSpec feature
+- **THEN** it is listed with its branch and run count and can open its runs
+
+#### Scenario: Worktree-only board remains interactive
+- **WHEN** only run-bearing unassociated worktrees exist
+- **THEN** the interactive board opens with that section and no empty feature or canonical-spec headers
+
+#### Scenario: Foreign artifacts do not hide a worktree
+- **WHEN** a no-spec run's worktree contains active changes copied from the base
+- **THEN** those copies do not assign the run to a feature or remove the worktree's run-navigation entry
+
+### Requirement: Continue reuses the feature's worktree and branch
+
+Launching continue from a feature SHALL carry stable feature identity, its explicit contract set, intended base, and verified implementation context into the launcher. Continue SHALL reuse that worktree and actual branch without creating another worktree or invoking the branch namer; new-worktree isolation SHALL be disabled for this handoff. The reviewed plan SHALL freeze the association revision and current context for execution-time validation. Invalid or missing associations SHALL present resolution guidance rather than silently creating replacement work. Archived contracts SHALL remain available for closing/history but SHALL require an explicit new active-work decision before another implementation run.
+
+#### Scenario: Second run lands on the same branch
+- **WHEN** an active feature already ran once and continue launches another run
+- **THEN** the reviewed plan retains the same feature identity, actual branch, worktree, and contracts without minting a new branch
+
+#### Scenario: Rename requires verified context
+- **WHEN** continue is requested after an external branch rename
+- **THEN** Convoy resolves a previously verified rebind or offers rebinding before launch, rather than choosing another change by branch spelling
+
+### Requirement: Change rows resolve to the owning worktree
+
+Explicit verified feature associations SHALL determine the authoritative context and artifact sources for feature rows. Branch-name matches, Markdown presence, and worktree-list order SHALL NOT select ownership. Discovered copies SHALL remain inspectable as candidates with their source locations. Ambiguous, missing, or unreadable associations SHALL keep the feature visible without borrowing another copy's tasks, title, runs, or mutation target. Unassociated candidates SHALL offer explicit selection/adoption, with no automatic writes while browsing.
+
+#### Scenario: A husk in an earlier worktree cannot steal the row
+- **WHEN** an unrelated earlier-listed worktree contains a husk while the explicitly associated worktree carries the complete change
+- **THEN** the associated context supplies the row's facts and action assessment regardless of listing order
+
+#### Scenario: Branch match outranks a fuller foreign copy
+- **WHEN** two worktrees both carry the same change and only one carries the explicitly associated implementation context
+- **THEN** the explicitly associated context supplies the row even when the other copy lists more files or its branch name happens to match the change id
+
+#### Scenario: Husk-only candidates keep the row present
+- **WHEN** every discovered copy of a change id carries only husk directories and none is explicitly associated
+- **THEN** the candidate remains listed with its source locations and no fabricated task counts, ownership, or close eligibility
+
+## ADDED Requirements
+
+### Requirement: Board assessment can be refreshed without changing selection identity
+
+The board SHALL provide an explicit refresh action, refresh after returning from lifecycle actions, and invalidate cached artifact and assessment data together. Selection SHALL remain attached to feature identity rather than list position or branch name where that identity still exists. A failed refresh SHALL disclose unavailable/stale evidence and SHALL NOT present stale readiness as a current verified fact.
+
+#### Scenario: External archive becomes visible
+- **WHEN** the operator archives a selected feature outside Convoy and refreshes the board
+- **THEN** the same feature remains selected with updated artifact state and close prerequisites

--- a/openspec/changes/stable-feature-lifecycle/specs/feature-close/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/feature-close/spec.md
@@ -1,0 +1,159 @@
+## MODIFIED Requirements
+
+### Requirement: Close preflights before touching anything
+
+`convoy close` SHALL resolve stable feature identity, its explicit contract set, intended local base, and verified current context through the shared lifecycle assessment. Branch/change selectors SHALL be validated against that identity; unresolved legacy work SHALL require explicit adoption rather than a branch-name guess. For a new integration, the feature tree SHALL be clean, all associated contracts' task prerequisites SHALL be verified complete, no live run SHALL be attached to the feature or implementation context, and the base checkout SHALL be clean and on the intended local base branch. Required repository identities, context registration, current branch/HEAD, and Git/run state MUST be verifiable. An archived contract SHALL require positive archive/task evidence; missing active files SHALL not bypass task checks. Each blocker SHALL include remediation. Cleanup-only continuation of verified landing SHALL assess remaining cleanup prerequisites without demanding removed worktrees or active task files. A published branch SHALL NOT block close merely because it is published; known remote context SHALL be disclosed without asserting a PR exists or merged. An upstream alone SHALL NOT be proof of publication. Close MUST NOT force-push or automatically publish.
+
+#### Scenario: Incomplete tasks stop the sequence
+- **WHEN** close runs on a feature with an associated change at 8 of 11 tasks complete
+- **THEN** no branch changes and the blocker identifies the change and missing task count
+
+#### Scenario: Main checkout is unavailable for landing
+- **WHEN** the base checkout is dirty or not on the intended local base branch
+- **THEN** close stops before sync or archive with the concrete prerequisite
+
+#### Scenario: Published feature closes normally
+- **WHEN** a complete clean feature has published commits and all other preconditions hold
+- **THEN** close discloses remote context and proceeds without rewriting published feature history or requiring a force-push
+
+#### Scenario: A mistyped change is not an archive
+- **WHEN** an explicit change selector is absent from the feature's contract set or its required artifact/evidence source cannot be verified
+- **THEN** close refuses before mutation rather than skipping tasks or declaring the change already archived
+
+#### Scenario: Worktree and branch disagree
+- **WHEN** explicit or recorded worktree/branch selectors refer to different checked-out contexts or repositories
+- **THEN** close refuses before sync or archive and identifies the conflicting context
+
+### Requirement: Close archives through the OpenSpec CLI
+
+After required synchronization, close SHALL archive each associated active change through the OpenSpec CLI in the verified feature checkout and commit the archive result under the operator's identity; Convoy SHALL not author OpenSpec artifacts itself. Archive success SHALL require verified correspondence between the selected change, archive artifacts, canonical-spec synchronization, completed task evidence, and committed result. An absent active directory alone SHALL never mean already archived. An externally archived change SHALL be accepted only after locating and validating its unambiguous archived artifacts, task completion, and canonical-spec result; otherwise close SHALL stop with remediation. For previously verified archives, close SHALL revalidate their applicability after base synchronization and SHALL not archive them a second time. Failure or ambiguity SHALL stop before landing, preserve completed archive evidence, and support resumption of remaining contracts. Message context SHALL include verified archived proposal/capability artifacts when active artifacts are no longer present.
+
+#### Scenario: Archive then commit
+- **WHEN** sync completes and an associated contract is active
+- **THEN** OpenSpec archives it in the feature worktree, canonical specs receive the deltas, the result is committed on the feature branch, and close retains its archive evidence
+
+#### Scenario: External archive before close
+- **WHEN** an operator already archived a feature's change and its archived tasks and canonical-spec result can be verified
+- **THEN** close shows archive verified/skipped, retains the proposal context, and continues integration without recreating the active directory
+
+#### Scenario: Archive directory exists but canonical sync is missing
+- **WHEN** archived delta artifacts are present but their required canonical-spec effect cannot be established
+- **THEN** close blocks before landing and asks for archive/spec reconciliation rather than treating directory presence as success
+
+#### Scenario: Multi-contract archive is interrupted
+- **WHEN** one contract is verified archived and archiving the next fails
+- **THEN** no landing occurs and resume revalidates the first result before continuing only the unmet archive work
+
+#### Scenario: Overlapping contracts compose their effects
+- **WHEN** two associated contracts modify the same requirement and both must be verified before landing
+- **THEN** close verifies the ordered composed effect against retained per-contract evidence, or refuses before the first archive mutation when it cannot establish that composition
+
+### Requirement: Close always squash-lands the complete feature
+
+After verified archive processing, close SHALL land the entire feature-exclusive result as exactly one regular conventional commit under the operator's identity on the captured local base revision. The commit SHALL have one parent, that base revision, and include operator commits, previous run-compaction results, remaining intermediate run work, sync resolutions, and archive output as content rather than additional base-history commits. Commits already reachable from the base SHALL NOT be duplicated. Close MUST NOT squash-rewrite the feature branch, fast-forward the base to its tip, or create an additional merge commit. Feature history SHALL remain intact apart from additive sync/archive work. Review SHALL identify the feature, complete contract set, source branch, intended base, and whole-branch landing scope; selecting a contract SHALL NOT imply path-filtered integration. Empty aggregate changes SHALL produce an explicit no-change result, not an empty commit or unsupported prior-landing claim.
+
+The landing SHALL preserve operator signing, hooks, and secret-file protections and guard against stale association, branch/base/index/worktree state. A failure before landing MUST leave the base unadvanced; interrupted operations SHALL expose durable recovery evidence and MUST NOT discard unrelated work. Landing and cleanup evidence SHALL be tied to stable feature identity, an individual attempt, exact prepared feature tip/tree, and the captured base and resulting landing. Conflicting Convoy mutations SHALL be serialized and final ref changes SHALL be guarded against intervening external changes.
+
+After verified landing, base push, worktree removal, and local feature-branch deletion SHALL remain separate deliberate choices. Push SHALL be normal, never forced. Both worktree removal and branch deletion SHALL require a verified landing still contained in the intended base and a verified association to the exact unchanged feature tip, not squash ancestry assumptions or tree equality alone. Worktree removal SHALL precede branch deletion, refuse dirty/changed contexts, and preserve unrelated branches at reused names or paths. Inside the feature worktree, removal/deletion SHALL remain deferred guarded guidance, not runnable in-session actions. Headless guidance SHALL name the configured remote/base and preserve the same identity, landing, tip, and execution-order guards. Missing base upstream SHALL disable push with setup guidance. Remote feature-branch deletion SHALL NOT be automatic. Run recovery refs and completed landing evidence SHALL survive ordinary cleanup.
+
+#### Scenario: One conventional commit lands
+- **WHEN** close completes for a branch containing an operator proposal, two compacted runs, and archive output
+- **THEN** the base gains exactly one regular commit containing the complete result and the feature worktree remains until deliberate cleanup
+
+#### Scenario: Advanced base still receives one commit
+- **WHEN** the base advanced since the fork and sync resolved integration before archive
+- **THEN** close lands one commit on the synchronized base without an extra merge commit or duplicated base changes
+
+#### Scenario: Uncompacted or operator-only feature
+- **WHEN** a feature contains unsquashed machine commits or only operator-authored work
+- **THEN** close includes the complete result without depending on automatic compaction success
+
+#### Scenario: Empty aggregate change
+- **WHEN** the verified archived feature tree equals the captured base tree and no landing receipt exists
+- **THEN** close reports no content to land, creates no empty commit, and does not authorize destructive cleanup on equality alone
+
+#### Scenario: Cleanup respects git dependencies
+- **WHEN** close has verified evidence, runs outside the unchanged feature worktree, and that worktree still exists
+- **THEN** push and clean worktree removal are runnable after consent, branch deletion remains unavailable until removal succeeds, and every operation revalidates its evidence
+
+#### Scenario: Cleanup is deferred inside the feature worktree
+- **WHEN** close completes from within that worktree
+- **THEN** configured base push remains runnable while worktree/branch cleanup is shown as guarded continuation commands for execution after leaving it
+
+#### Scenario: Feature changes before cleanup
+- **WHEN** the feature tip changes, association changes, or worktree becomes dirty after landing
+- **THEN** cleanup refuses removal/deletion rather than applying a stale receipt or unconditional force-delete
+
+#### Scenario: Missing upstream disables push
+- **WHEN** the base has no configured upstream after close
+- **THEN** push is unavailable with setup guidance and no invalid push command is printed
+
+#### Scenario: Reused branch is not cleaned up
+- **WHEN** an old feature's original branch name now points to another feature's work
+- **THEN** old-receipt cleanup refuses to remove that branch or its worktree even if names match
+
+### Requirement: Merged detection reports probability, not certainty
+
+Board and close SHALL use the same integration assessment. Patch equivalence without verified Convoy landing evidence SHALL remain *probably merged*, never a completed close or cleanup authorization. A verified durable receipt for the selected feature and unchanged feature tip, with its landing still reachable from the intended base, SHALL establish completed local integration even after base advancement. Every close invocation, with or without `--resume`, SHALL consult existing attempts and receipts before new sync/archive work and SHALL not create another landing for the same closed tip. Missing worktree or renamed branch SHALL not erase the feature's evidence; any current binding SHALL be verified before mutation. Tree equality alone SHALL not establish a previous close or authorize branch deletion. Probable external integration SHALL stop direct close before duplicate landing and retain deliberate archive-on-main remediation for active contracts. Archive-on-main SHALL verify a clean checkout on the intended base, invoke OpenSpec there, and commit only the archive result without feature sync/landing. Neither local landing, base push, nor archive-on-main SHALL assert hosted PR merge.
+
+#### Scenario: Squash-merged change shows honestly
+- **WHEN** a feature appears externally squash-merged without a Convoy receipt and remains unarchived
+- **THEN** the board reports probably merged and offers deliberate archive-on-main guidance without inventing a certain landing
+
+#### Scenario: Direct close encounters probable external landing
+- **WHEN** direct close finds patch-equivalence evidence without a verified receipt
+- **THEN** it stops before sync or another landing and provides inspection/archive-on-main guidance
+
+#### Scenario: Archive on main
+- **WHEN** the operator accepts archive on main and the base checkout is verified clean and on the intended base branch
+- **THEN** OpenSpec archives there and the result is committed without feature sync, squash, or merge
+
+#### Scenario: Archive on main verifies its source
+- **WHEN** archive-on-main is selected for a feature whose active artifacts also exist in the feature worktree
+- **THEN** Convoy verifies the base-checkout copy corresponds to the selected contract before archiving, records the archive source and evidence, and leaves integration reported as probably merged or pending rather than confirmed
+
+#### Scenario: Resume after base advances beyond a completed landing
+- **WHEN** close targets an unchanged feature whose recorded landing remains reachable from the advanced base
+- **THEN** it reports the existing landing and offers only applicable safe follow-ups without another commit, regardless of whether `--resume` was supplied
+
+#### Scenario: Resume after worktree removal
+- **WHEN** verified close removed a feature's worktree but branch cleanup was interrupted
+- **THEN** feature-identity lookup reconstructs remaining cleanup without requiring the worktree and rechecks the current branch tip and landing
+
+#### Scenario: Landing evidence becomes stale
+- **WHEN** the base no longer contains the recorded landing or the associated feature tip has advanced
+- **THEN** close reports stale evidence and requests explicit recovery or new-work planning instead of relanding or deleting automatically
+
+## ADDED Requirements
+
+### Requirement: Close attempts reconcile every mutation boundary
+
+Close SHALL persist feature/attempt identity and the intended operation before each irreversible or externally visible repository mutation, and persist verified outcomes after it. Sync conflicts, archive execution/commit, candidate creation, base landing, and cleanup SHALL have recoverable before/after evidence. Resumption SHALL inspect current Git and artifact state to reconcile a completed operation whose acknowledgement was not saved; it SHALL not rely solely on the journal's last phase label. A candidate already reachable from the base with the recorded parent/tree and unchanged feature preparation SHALL be reconciled as the existing landing even if the base advanced afterward. Unexplained divergence SHALL stop for recovery. Renewed integration after an unrelated base advance SHALL retain prior evidence and revalidate archive output against the new preparation. Successful receipts SHALL be immutable and survive later attempts, no-change outcomes, and cleanup.
+
+#### Scenario: Crash after base landing before receipt acknowledgement
+- **WHEN** the base contains the recorded candidate but the journal still describes landing as pending
+- **THEN** resume verifies candidate, preparation, and ancestry, records the existing landing, and does not create another commit
+
+#### Scenario: Crash after archive before archive commit
+- **WHEN** OpenSpec completed archive but the process stopped before committing it
+- **THEN** resume checks the recorded archive intent, expected artifact effects, and absence of unrelated dirt before committing only the verified archive result or stops with recovery guidance
+
+#### Scenario: Base moves without containing the candidate
+- **WHEN** a pending candidate was built against an older base and the current base does not contain it
+- **THEN** close refuses the stale candidate and requests renewed integration/review without deleting its recovery evidence
+
+#### Scenario: Repeated close after success
+- **WHEN** the operator invokes close again for the same feature and unchanged landed tip
+- **THEN** the prior receipt remains intact and no sync, archive, or second landing is performed
+
+### Requirement: Close and cleanup expose the same recoverable action assessment
+
+Interactive close SHALL retain its existing checklist, message-review, and failure-display behavior while adding verified feature/context identification and explicit archive/integration/cleanup distinctions. Applicable blocked actions SHALL expose reasons rather than disappear. Completed steps SHALL show verified skip/completion reasons; missing evidence SHALL not be rendered as completion. Cleanup eligibility and evidence SHALL be preserved through command output, TUI follow-up selection, and action-time revalidation. Deferred/headless follow-ups SHALL invoke the same guarded operations rather than print an unprotected check-then-force-delete recipe. Cancellation SHALL preserve recoverable preparation but SHALL not authorize landing or cleanup.
+
+#### Scenario: Cleanup evidence reaches the action
+- **WHEN** the operator chooses worktree removal or branch deletion from close's result screen
+- **THEN** the operation receives the selected feature/attempt identity, reloads and validates current evidence, and either performs that authorized action or explains its blocker
+
+#### Scenario: Close review is opened while blocked
+- **WHEN** a feature has complete tasks but an unresolved association or live run
+- **THEN** close review remains reachable, explains what must be resolved, and performs no Git or archive mutation

--- a/openspec/changes/stable-feature-lifecycle/specs/feature-lifecycle/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/feature-lifecycle/spec.md
@@ -1,0 +1,145 @@
+## Purpose
+
+Track a unit of implementation through explicit repository-scoped identity and independently verified lifecycle evidence, so branch names, artifact copies, archive operations, and checkout cleanup do not redefine or erase the operator's work.
+
+## ADDED Requirements
+
+### Requirement: Features have stable repository-scoped identities
+
+Convoy SHALL assign a stable identity to each registered feature and persist its explicit change-contract set, intended local base, current implementation-context association, historical run links, and close-attempt references independently of branch names and worktree paths. Worktrees sharing a Git common directory SHALL share the records. A feature SHALL have one current implementation context; multiple changes in that context SHALL be an explicitly reviewed contract set, not separate independently closable slices of the same branch. A context SHALL NOT be silently claimed by two features. New incarnations of a completed feature SHALL receive new identities even when a branch name or change slug is reused. No-spec runs SHALL remain supported without creating a fictitious OpenSpec change.
+
+#### Scenario: Two checkouts inspect the same work
+- **WHEN** Convoy opens in two worktrees of one repository
+- **THEN** both resolve a registered feature to the same identity and contract set while observing current Git state independently
+
+#### Scenario: A branch name is reused
+- **WHEN** a new feature uses the former branch name of a completed feature
+- **THEN** the new feature has a different identity and does not inherit the old feature's runs or landing authority
+
+#### Scenario: Several contracts share a branch
+- **WHEN** an operator accepts one implementation context with two selected changes
+- **THEN** one feature records both contracts and close assesses the entire feature rather than offering two partial branch landings
+
+### Requirement: Associations express explicit intent rather than naming heuristics
+
+Successful spin and accepted feature-backed launch SHALL persist the operator-approved association before any run executes. Convoy SHALL offer explicit adoption of existing work and explicit rebinding of an existing feature to a verified context, without requiring branch renaming. Association SHALL validate repository membership, actual checked-out branch, worktree registration, intended base, and the selected active or archived artifacts. Any Git-valid existing branch name SHALL be supported. Adoption SHALL NOT mark tasks, archives, or integration complete. Branch spelling, a sole active directory, matching commit tips, and worktree enumeration order SHALL be suggestions only and MUST NOT independently authorize lifecycle mutation. Browsing, preparing a launch, or cancelling selection SHALL NOT create an association.
+
+#### Scenario: An arbitrary branch is adopted
+- **WHEN** the operator explicitly associates change `add-widget` with registered worktree branch `team/alice/release-42` and base `main`
+- **THEN** Convoy records the association without renaming the branch and resolves subsequent lifecycle actions through the feature identity
+
+#### Scenario: A copied change is discovered
+- **WHEN** an unrelated worktree inherits a completed change directory by merging its base
+- **THEN** the copy supplies discovery evidence but does not change the feature's association or enable closing that unrelated branch
+
+#### Scenario: Conflicting context selection
+- **WHEN** adoption or rebinding names a branch different from the checkout's actual branch, another repository, or a context already assigned to another feature
+- **THEN** the operation refuses without running or closing work and explains the conflicting identities
+
+### Requirement: One resolver supplies all lifecycle action targets
+
+Board, launcher, continue, publication, and close SHALL resolve a selected feature using the same association rules. Explicit selectors SHALL be cross-checked rather than silently overriding contradictory selectors. Resolution SHALL distinguish verified, unassociated, ambiguous, missing, and unreadable contexts and expose the evidence and remediation. Existing branch/change selectors SHALL remain accepted for lookup; unresolved headless requests SHALL exit non-zero with an explicit adoption or rebinding command rather than guessing. A rename or moved worktree SHALL retain the historical feature record; verified rebinding SHALL update current attributes without rewriting historical run boundaries. Rebinding SHALL NOT run while a live run or unreconciled mutation makes the transition unsafe.
+
+#### Scenario: Branch rename is not a new feature
+- **WHEN** a feature's branch is renamed outside Convoy
+- **THEN** its record and history remain visible, and an unverified association offers rebinding instead of becoming another feature or silently authorizing mutation
+
+#### Scenario: A run and close select the same work
+- **WHEN** a feature is selected for a run and later for close from another checkout
+- **THEN** both resolve the same feature, contracts, base, and verified implementation context regardless of branch naming convention
+
+#### Scenario: An explicit selector is mistyped
+- **WHEN** a close request includes a change selector that conflicts with the selected feature's contracts
+- **THEN** Convoy refuses with a selector diagnostic before checking or modifying another change
+
+### Requirement: Lifecycle facts remain orthogonal and evidence-based
+
+Assessment SHALL distinguish association validity; artifact state per contract as active, verified-archived, missing, ambiguous, or unreadable; task completion; execution/liveness; local integration as pending, probable, verified, stale, or unknown; remote publication observations; and cleanup progress. Task completion SHALL NOT imply successful validation or close eligibility. Archive SHALL NOT imply integration. Local landing or push SHALL NOT imply hosted PR merge. Missing files, inaccessible Git/run records, and malformed lifecycle evidence SHALL NOT be converted into completed facts. A human-readable summary SHALL be derived from those facts rather than persisted as authoritative status.
+
+#### Scenario: Archived implementation is not integrated
+- **WHEN** a feature's contracts have verified archive evidence but no verified integration
+- **THEN** its summary retains pending integration and permits reviewing close prerequisites instead of describing the feature as finished
+
+#### Scenario: State cannot be read
+- **WHEN** required run-state or Git evidence is unreadable
+- **THEN** relevant capabilities report unknown evidence and a concrete blocker rather than assuming no live runs or a clean tree
+
+### Requirement: Shared action capabilities explain eligibility and revalidate execution
+
+Every lifecycle assessment SHALL supply applicable actions with availability, concrete blocker reasons, remediation, target identity/context, and evidence freshness. UI labels, menus, keyboard handlers, and CLI decisions SHALL consume the same eligibility rules. “Ready to close” SHALL only describe a verified association whose current close-start prerequisites pass; complete tasks alone SHALL be described as implementation complete. Reviewing close prerequisites SHALL remain discoverable when integration is pending, even when executing close is blocked. Each mutation SHALL freshly revalidate association revision, repository, branch/HEAD, worktree, base, and required evidence, refusing changed targets instead of switching automatically.
+
+#### Scenario: Complete tasks with a live run
+- **WHEN** all tasks are checked but a run is still live
+- **THEN** Convoy does not label the feature ready to close and its close review explains the live-run blocker
+
+#### Scenario: The target changes after review
+- **WHEN** a branch or association changes after the operator reviewed an action
+- **THEN** executing the action refuses the stale target and requests refreshed review without mutating the replacement context
+
+### Requirement: Discovery survives archive and cleanup without inventing ownership
+
+Read-only discovery SHALL combine registered features, active contract candidates, associated archive/evidence references, legacy run/close evidence, and actual Git worktrees. Registered unfinished features SHALL remain discoverable after archive or worktree removal. Completed features SHALL remain accessible in history without requiring obsolete worktrees. Artifact copies SHALL be represented as sources rather than competing owners. A missing associated source SHALL NOT silently fall back to a same-slug foreign copy. Discovery and history inspection SHALL NOT create, migrate, or repair records as a side effect.
+
+#### Scenario: Worktree disappears before integration
+- **WHEN** an unfinished feature's worktree is deleted outside Convoy
+- **THEN** the feature remains visible with its history and missing-context remediation, without claiming that the old path still exists
+
+#### Scenario: Reopening completed history
+- **WHEN** a feature has been integrated and cleaned up
+- **THEN** its contracts, runs, and landing evidence remain inspectable in history without replaying close
+
+### Requirement: Legacy evidence is adopted conservatively
+
+Existing names, runs, and close journals SHALL remain readable as legacy evidence with provenance and uncertainty disclosed. Import SHALL require explicit adoption, validate stored identity fields and repository membership, preserve original evidence, and reject ambiguous or mismatched records. A branch-derived journal filename SHALL NOT establish identity. Imported run associations SHALL NOT manufacture run-start rewrite authority; imported landing evidence SHALL retain exact-tip and reachable-landing checks. Corrupt, unsupported-version, or colliding records SHALL produce repair guidance rather than silent reassignment. Loss of local registry state SHALL yield adoption/recovery, not invented success.
+
+#### Scenario: Two legacy names collide
+- **WHEN** legacy journal naming maps two branch spellings to one filename
+- **THEN** adoption checks embedded identity and evidence, rejects a conflicting association, and does not reuse a foreign landing receipt
+
+#### Scenario: Legacy run has no durable feature ID
+- **WHEN** a legacy run is displayed after its checkout path was reused
+- **THEN** it retains historical evidence and remains unassociated unless explicitly verified, rather than being attributed to the feature now at that path
+
+#### Scenario: Completed legacy work is recovered without a worktree
+- **WHEN** an operator explicitly recovers a completed feature from legacy landing evidence whose worktree no longer exists
+- **THEN** Convoy creates a stable feature record from that evidence, grants only receipt-verified cleanup/follow-up eligibility, and does not grant new execution authority or require the historical path to exist
+
+### Requirement: Contract sets and new incarnations have explicit reviewed transitions
+
+Adding, removing, or reordering a live feature's contract set SHALL be an explicit reviewed association revision. The review SHALL show the complete proposed set, selected sources, and intended base; a revision SHALL be refused during a live run or unresolved close attempt. Completing a feature SHALL release its context claim so a new feature may reuse the same branch or worktree, but reuse SHALL require an explicit new-work decision that creates a new identity and does not reopen the old receipt. A retained completed context SHALL NOT silently accept another implementation run or lifecycle mutation without that decision.
+
+#### Scenario: A second contract is added
+- **WHEN** an operator explicitly revises a live feature to include a second change and accepts it while no run is live
+- **THEN** the feature records the complete reviewed contract set and close assesses the whole branch
+
+#### Scenario: New work begins on a completed context
+- **WHEN** the operator explicitly starts new work on a retained branch/worktree after a completed feature
+- **THEN** a new feature identity is created without inheriting the completed feature's runs or landing authority
+
+#### Scenario: Contract revision is blocked while running
+- **WHEN** an operator attempts to revise a live feature's contract set while a run is live or a close attempt is unresolved
+- **THEN** the revision is refused until the run completes or the attempt is reconciled
+
+### Requirement: Recovery reconciles interrupted work after a context moves
+
+A pending close attempt whose context moves, is renamed, or loses its worktree SHALL remain a distinct unresolved attempt. Verified rebinding of the feature SHALL be permitted as explicit recovery even while that attempt is pending, provided no other live or unreconciled mutation conflicts; it SHALL update current attributes and invalidate stale attempt targets rather than silently replaying them. New work or a resumed attempt SHALL be a new attempt with fresh revalidation and an explicit decision; old evidence SHALL be preserved, never treated as authority over the moved context.
+
+#### Scenario: Context moves after archive preparation
+- **WHEN** an interrupted close attempt prepared an archive but the feature's worktree then moved to a new path
+- **THEN** the operator can explicitly rebind the feature, the stale attempt target is marked invalid, and recovery offers a fresh revalidated attempt while preserving the archive evidence
+
+#### Scenario: Rename does not require restoring the old name
+- **WHEN** a feature's branch is renamed between an interrupted close and resume
+- **THEN** explicit rebinding allows resume without recreating the old branch or path, and no stale target is reused for mutation
+
+### Requirement: Lifecycle records preserve safety across concurrent updates
+
+Feature associations and close evidence SHALL be versioned, validated, and written atomically with conflict detection. An inability to persist required intent or recovery evidence SHALL block the corresponding mutation. Close attempts SHALL have distinct identities; completed landing receipts SHALL not be overwritten by a later attempt or no-change result. Concurrent Convoy operations SHALL serialize conflicting repository mutations; external changes SHALL be detected through current Git evidence and guarded ref updates. Ordinary cleanup SHALL NOT delete feature/run recovery evidence.
+
+#### Scenario: Concurrent association edits
+- **WHEN** two sessions attempt to change the same association from the same prior version
+- **THEN** only one update succeeds and the other requests refreshed inspection instead of overwriting it
+
+#### Scenario: Storage fails before landing
+- **WHEN** required candidate or recovery evidence cannot be persisted
+- **THEN** no landing occurs and the operator receives a recoverable error

--- a/openspec/changes/stable-feature-lifecycle/specs/feature-spin/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/feature-spin/spec.md
@@ -1,0 +1,17 @@
+## ADDED Requirements
+
+### Requirement: Successful spin registers an explicit feature association
+
+Spin SHALL durably register a stable feature identity linking the selected change, resolved base, actual created branch, and registered worktree before reporting success. Conventional initial naming and documented worktree allocation SHALL remain unchanged; the name SHALL not become identity authority for subsequent operations. Spin SHALL continue to transfer proposal files without committing them or modifying OpenCode sessions. Record persistence failure SHALL prevent a success handoff and expose any created context and transferred files with recovery guidance, preserving operator work. Retrying or adopting that partial result SHALL not create a duplicate feature/context. Read-only preview and refusal before creation SHALL not persist a feature.
+
+#### Scenario: Spin establishes ownership
+- **WHEN** spin successfully creates a worktree for `add-widget`
+- **THEN** its output identifies the stable feature, selected contract, actual branch/worktree, and existing `/move` handoff, and all repository worktrees resolve that same association
+
+#### Scenario: Association persistence fails
+- **WHEN** the worktree and proposal transfer succeed but association persistence fails
+- **THEN** spin reports the partial operation and exact recovery context without claiming successful registration, committing files, or deleting the transferred proposal
+
+#### Scenario: Rename after spin
+- **WHEN** the operator renames a spun-out branch and explicitly rebinds its verified context
+- **THEN** the original feature, contract, and history remain associated without requiring restoration of the conventional branch name

--- a/openspec/changes/stable-feature-lifecycle/specs/run-finalization/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/run-finalization/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Create pull request is the only run-publication action
+
+Run completion SHALL expose `Create pull request` in the command palette independently of compaction success, with no manual finish or standalone push action. Existing inspection and navigation actions SHALL remain. For feature-linked runs, publication SHALL use the shared assessment of the selected feature's currently verified associated branch, not the branch now occupying the historical run path. For no-spec runs, publication SHALL retain explicit verified run-context selection without requiring a fabricated feature contract. Selecting the action SHALL explicitly authorize a normal push to the disclosed repository/remote followed by PR creation; it MUST NOT publish automatically, force-push, delete branches, or remove worktrees. The action SHALL revalidate current identity, branch state, and unresolved recovery blockers immediately before publication rather than treating an old run's HEAD or a prior assessment as authority. A resulting run commit SHALL seed the PR title/body when applicable; otherwise the run summary and current branch context SHALL seed them. Missing GitHub CLI/authentication or unsafe/unresolved state SHALL disable publishing with actionable guidance. Headless output SHALL provide guidance only unless a separate explicit publication request exists. Publication SHALL NOT mark local integration, archive, or hosted PR merge complete.
+
+#### Scenario: Deliberate PR creation
+- **WHEN** the operator selects Create pull request on a safe verified feature branch
+- **THEN** Convoy performs a normal push and creates the PR, displaying its URL without a separate push choice
+
+#### Scenario: Push is rejected or PR already exists
+- **WHEN** the normal push is rejected, or a matching open PR already exists
+- **THEN** Convoy respectively stops before PR creation with no force-push fallback, or opens/reports the existing PR rather than creating a duplicate
+
+#### Scenario: GitHub CLI is unavailable
+- **WHEN** a completed run is viewed without a usable GitHub CLI
+- **THEN** Create pull request is unavailable with setup/manual guidance while inspection remains usable
+
+#### Scenario: Historical path has been reused
+- **WHEN** an old run's former worktree path now belongs to another feature
+- **THEN** publication resolves the old run's feature through its current verified association or explains why it is unavailable, and never pushes the replacement branch
+
+## ADDED Requirements
+
+### Requirement: Run history preserves feature identity independently of rewrite authority
+
+New feature-backed runs SHALL retain stable repository/feature identity and their reviewed contract set in durable metadata and cleanup-surviving run records, alongside immutable run-start branch/path/commit provenance. Board, attach, and historical views SHALL join by that identity rather than reinterpret the current checkout at a stored path. Legacy records SHALL disclose missing association evidence until explicitly adopted. Rebinding a feature SHALL NOT rewrite the originating run boundary or grant permission to compact across a changed branch, independent commits, or missing evidence. Existing compaction eligibility, protected recovery history, signing/hooks, and publication-safety rules SHALL remain authoritative. Feature cleanup SHALL NOT remove run recovery evidence.
+
+#### Scenario: Two runs and a renamed feature
+- **WHEN** two runs finish for a feature and its context is later explicitly rebound after a branch rename
+- **THEN** both runs remain linked to the feature, their original branch observations remain inspectable, and no automatic rewrite occurs during inspection or rebinding
+
+#### Scenario: Association does not repair missing provenance
+- **WHEN** a legacy run is adopted into a feature but lacks a trustworthy run-start boundary
+- **THEN** the history link becomes available while automatic compaction still refuses to rewrite without the required provenance

--- a/openspec/changes/stable-feature-lifecycle/specs/run-launcher/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/run-launcher/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Launch review distinguishes contracts from feature association
+
+The launcher SHALL show the selected contract set separately from the stable feature and verified execution context. A feature-aware apply or continue handoff SHALL preserve that identity and associated context from any launch checkout. Automatic contract suggestions, including a sole active change or branch-name match, SHALL not silently establish ownership. An accepted new feature-backed run SHALL explicitly register or reuse the reviewed association before execution. A selected context already owned by another feature SHALL require an explicit compatible selection or rebinding decision, not overwrite that association. No-spec runs SHALL keep their existing flow without inventing a change. Cancelling before acceptance SHALL leave no new feature record or worktree.
+
+#### Scenario: One active spec on an arbitrary branch
+- **WHEN** an unassociated branch contains one active change and the launcher suggests it
+- **THEN** review shows the proposed feature/context/contract association, and only acceptance records that intent
+
+#### Scenario: Apply from another checkout
+- **WHEN** Apply is invoked on a registered feature while the browser was launched in a different worktree
+- **THEN** the launcher pins the selected contracts and associated execution context instead of resolving a same-id change in the launch directory
+
+#### Scenario: Multiple changes are selected
+- **WHEN** review accepts two contracts for one implementation context
+- **THEN** the feature and reviewed plan record the complete selected set and explain that close integrates the whole branch
+
+### Requirement: Execution revalidates reviewed identity and persists run linkage
+
+Before a feature-backed run starts, Convoy SHALL revalidate the reviewed repository, feature identity, association revision, actual branch/worktree, base, and active contract sources. Persistence of the feature link in durable run metadata SHALL precede execution. A changed or unverifiable target SHALL stop with remediation rather than silently selecting another contract or branch. This check SHALL be additional to, not a replacement for, the existing dirty-tree consent and execution-time gate. Association confirmation SHALL NOT imply consent to include dirty files. Reopening a historical run SHALL not change its frozen context.
+
+#### Scenario: Branch switches after review
+- **WHEN** the worktree changes branches after an operator accepts review
+- **THEN** the run refuses before execution and does not attach the new branch's changes to the reviewed feature
+
+#### Scenario: Dirty consent remains separate
+- **WHEN** a feature association is confirmed while the execution tree is dirty and include-dirty is off
+- **THEN** the existing explicit dirty-tree choice and final execution gate remain effective
+
+#### Scenario: Run survives temporary workspace cleanup
+- **WHEN** an accepted feature-backed run finishes and its temporary run workspace is removed
+- **THEN** its durable record still identifies the feature, selected contracts, and frozen execution context

--- a/openspec/changes/stable-feature-lifecycle/specs/specs-viewer/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/specs-viewer/spec.md
@@ -1,0 +1,123 @@
+## MODIFIED Requirements
+
+### Requirement: Specs command discovers OpenSpec state from the filesystem
+
+`convoy specs` SHALL discover OpenSpec artifacts from the filesystem: active changes are real directories in `openspec/changes/` excluding `archive`, dotfiles, and stray non-directory files; canonical specs are Markdown files under `openspec/specs/**`. It SHALL also read repository-scoped feature associations, referenced archives, run/close evidence, and current Git context for lifecycle discovery. Read-only OpenSpec task queries SHALL be permitted by the shared assessment contract. Discovery, refresh, and browsing MUST NOT write any file or silently adopt/migrate features. Absence of active changes or of the launch checkout's `openspec/` SHALL NOT suppress registered features or run-bearing worktrees.
+
+#### Scenario: Repo without openspec directory
+- **WHEN** a repository has no `openspec/` directory and no discoverable registered features or run-bearing worktrees
+- **THEN** Convoy reports that no specs were found and exits successfully without launching a UI
+
+#### Scenario: Repo with openspec directory but no active changes
+- **WHEN** a repository has `openspec/` but its changes directory holds only `archive` and there are no pending registered features
+- **THEN** the pending-feature section is omitted, canonical specs remain browsable, and registered completed features remain accessible in history
+
+#### Scenario: Archived work remains pending
+- **WHEN** only archived contracts remain for a registered feature awaiting integration
+- **THEN** the feature remains discoverable and its verified archived artifacts are readable
+
+### Requirement: Worktree-backed changes read their artifacts from the worktree
+
+The specs view SHALL load a registered feature's title and artifact inventory from its verified associated contract source, using absolute paths into its active change tree or verified archive. That source SHALL take precedence over same-id copies in the launch checkout. A missing, ambiguous, or unreadable associated source SHALL display its condition rather than fall back silently to another checkout. Unassociated active changes SHALL remain readable from explicitly identified discovered sources; multiple copies SHALL be selectable without assigning ownership. The operator SHALL not need to relaunch from the source checkout to read available artifacts.
+
+#### Scenario: Stale skeleton on the launch checkout
+- **WHEN** the launch checkout holds a husk while the verified associated worktree contains the change's full artifacts
+- **THEN** the worktree supplies the title and readable artifact inventory
+
+#### Scenario: Reading works from any launch directory
+- **WHEN** a feature's artifacts live outside the browser's process directory
+- **THEN** absolute artifact paths load the associated source without read placeholders caused by the launch location
+
+#### Scenario: Diverging copies resolve to the worktree
+- **WHEN** the launch checkout and the verified associated worktree carry differing copies of a change
+- **THEN** the associated source supplies feature artifacts and facts without mixing in the launch copy
+
+#### Scenario: Changes without a worktree are unchanged
+- **WHEN** an active change is not associated with any feature context and is discovered in the launch checkout
+- **THEN** its files remain readable there with unassociated status and no inferred mutation target
+
+#### Scenario: Associated artifacts are missing
+- **WHEN** the associated worktree is absent but another checkout has the same slug
+- **THEN** the feature shows missing-source remediation and exposes the other copy only as a candidate, not as a replacement owner
+
+### Requirement: Root view shows only non-empty sections
+
+The root SHALL present non-empty sections in this order: **Features**, **Worktrees without spec**, and **Canonical Specs**. Features SHALL include registered pending lifecycle work and unassociated active-change candidates. A discoverable history view SHALL expose completed registered features without requiring them to clutter pending work. Section headers SHALL remain distinct and reachable while scrolling; empty sections and headers SHALL be omitted. Missing proposals SHALL not hide entries; features SHALL use their recorded display identity and unassociated changes their change id. Selection SHALL use stable feature identity where available, not a mutable branch or directory name.
+
+#### Scenario: Sections appear in order
+- **WHEN** all three root sections have entries
+- **THEN** Features precedes Worktrees without spec, which precedes Canonical Specs, with distinct headers
+
+#### Scenario: Empty root sections disappear
+- **WHEN** any root section is empty
+- **THEN** neither its rows nor its title are rendered
+
+#### Scenario: Change missing its proposal
+- **WHEN** a candidate change has no readable proposal
+- **THEN** the candidate remains listed by id with its artifact availability disclosed
+
+#### Scenario: Completed feature is inspected
+- **WHEN** the operator opens feature history after worktree cleanup
+- **THEN** the feature's recorded contracts, runs, and integration evidence remain inspectable
+
+### Requirement: Apply this spec hands off to the launcher preselected
+
+While browsing an active contract, **Apply this spec** SHALL open the standard launcher with the selected contract and its explicit source pinned. For a registered feature it SHALL also carry feature identity, complete associated contract set, verified context, and intended base; execution SHALL reuse that context unless the operator explicitly chooses a separate new feature. For an unassociated candidate, normal context selection and association review SHALL precede execution. No missing preset SHALL silently fall back to another contract. A cancelled launcher SHALL start no run and leave no newly created context or association. An archived contract SHALL remain readable but implementation SHALL require an explicit new active-work decision, not silently reactivate the archive.
+
+#### Scenario: Handoff preselects the change
+- **WHEN** Apply is selected on an active `add-specs-viewer` feature and accepted through the launcher
+- **THEN** the resulting run uses its reviewed contract set and associated context without re-asking which copy to use
+
+#### Scenario: Launcher cancelled after handoff
+- **WHEN** the operator invokes Apply and aborts before acceptance
+- **THEN** no run starts and no new context or association remains
+
+#### Scenario: Selected source disappears
+- **WHEN** an active contract disappears between browsing and launch review
+- **THEN** the launcher reports the missing selected source instead of choosing a different active change
+
+### Requirement: Iterate on this plan opens an OpenCode session on the change
+
+**Iterate on this plan** SHALL open a standalone OpenCode session rooted at the verified checkout containing the selected active planning artifacts, with proposal, design, tasks, and delta specs referenced as context. For a registered feature the source SHALL come from its association; for an unassociated candidate the source SHALL be explicitly selected. The session SHALL be pre-authorized to read the entire selected repository checkout without per-file read confirmations; only reads are pre-granted and writes retain normal defaults. The session SHALL outlive the browser and use OpenSpec authoring commands for edits, not Convoy artifact writes. Missing, ambiguous, or archived-only planning sources SHALL yield guidance rather than silently opening an unrelated checkout for editing.
+
+#### Scenario: Iterate opens a repo-rooted session
+- **WHEN** Iterate is selected for an active change associated with another worktree
+- **THEN** the standalone session opens at that worktree's root with its planning files as context
+
+#### Scenario: Iterate requires no launcher
+- **WHEN** the operator iterates and closes the session without running a pipeline
+- **THEN** no run starts and only the standalone session was opened
+
+#### Scenario: Iterate session is pre-authorized to read the repository
+- **WHEN** Iterate opens on a verified planning checkout
+- **THEN** reads across that checkout are pre-granted while writes follow normal session permissions
+
+### Requirement: Non-TTY invocations print a plain listing
+
+Non-TTY `convoy specs` SHALL print a plain listing of pending features/candidates, their artifact inventories and lifecycle summaries, applicable actions with blocker/remediation information, run-bearing unassociated worktrees, and canonical specs, rather than launching a TUI. Headless and interactive listings SHALL use the same assessment and expose history inspection guidance. Listing SHALL not mutate or silently adopt work.
+
+#### Scenario: Piped output
+- **WHEN** `convoy specs` runs with stdout redirected in a repository containing lifecycle work
+- **THEN** it prints the shared lifecycle facts and action reasons without terminal control sequences and exits successfully
+
+#### Scenario: Empty state when piped
+- **WHEN** no OpenSpec artifacts or lifecycle work are discoverable
+- **THEN** a single empty-state message prints and the process exits successfully
+
+## ADDED Requirements
+
+### Requirement: Lifecycle actions are discoverable in root and detail
+
+The selected feature's root and ordinary detail views SHALL expose the same applicable lifecycle action menu, including close review, association/rebinding, refresh, and history navigation as appropriate. Blocked actions SHALL remain inspectable with reasons and remediation rather than disappear. Footer truncation SHALL retain a discoverable action-menu entry so omitted hints do not remove access; handlers and menu availability SHALL consume shared capabilities. Fullscreen reader copy/close/tab keys SHALL remain unchanged; returning to detail SHALL restore lifecycle actions without losing subject identity. Invoking close review SHALL disclose the feature, contracts, entire source branch, base, and any blockers before mutation.
+
+#### Scenario: Narrow terminal hides the close shortcut hint
+- **WHEN** footer space cannot show every shortcut
+- **THEN** the action menu remains discoverable and exposes close review and its current blockers
+
+#### Scenario: Ready feature is opened in detail
+- **WHEN** a feature assessed ready to close is selected and its detail reader is opened
+- **THEN** its ordinary detail action menu offers the same close action as the root
+
+#### Scenario: Reader copy remains copy
+- **WHEN** the operator presses `c` in the fullscreen reader
+- **THEN** the active tab is copied as before and no lifecycle mutation is triggered

--- a/openspec/changes/stable-feature-lifecycle/specs/worktree-location/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/worktree-location/spec.md
@@ -7,10 +7,15 @@ New-worktree creation, collision handling, and launcher preview SHALL use the sa
 #### Scenario: Suffix avoids collision at a declared location
 - **WHEN** the launcher's worktree allocation finds the resolved branch location occupied
 - **THEN** its existing suffix policy selects a non-colliding branch/location consistently in preview and creation, and any resulting feature association records the actual result
-
 #### Scenario: Finish locates a non-default worktree
+
 - **WHEN** a lifecycle action such as close or continue targets a feature associated with a worktree outside the built-in default location
 - **THEN** Convoy validates that context against Git's worktree inventory instead of assuming a branch-derived path
+
+#### Scenario: Close and continue locate a non-default worktree
+
+- **WHEN** close or continue resolves a feature whose verified association points at a worktree outside the built-in default location
+- **THEN** Convoy locates the worktree from the repository's worktree list (or the feature's verified association) rather than reconstructing a fixed path
 
 #### Scenario: Worktree moves outside Convoy
 - **WHEN** Git reports a feature's worktree at a new path

--- a/openspec/changes/stable-feature-lifecycle/specs/worktree-location/spec.md
+++ b/openspec/changes/stable-feature-lifecycle/specs/worktree-location/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Consistent path across decision points
+
+New-worktree creation, collision handling, and launcher preview SHALL use the same documented/configured/default location allocation. A path already considered taken SHALL never be handed to `git worktree add` again. Existing feature contexts SHALL instead be located through verified associations and the current repository's Git worktree inventory, never by reconstructing ownership from branch-derived directory names. A moved context SHALL require verified rebinding when its association is stale. Rebinding SHALL not rename or recreate the directory merely to match current branch spelling. Branch slug templates SHALL remain allocation/display conventions.
+
+#### Scenario: Suffix avoids collision at a declared location
+- **WHEN** the launcher's worktree allocation finds the resolved branch location occupied
+- **THEN** its existing suffix policy selects a non-colliding branch/location consistently in preview and creation, and any resulting feature association records the actual result
+
+#### Scenario: Finish locates a non-default worktree
+- **WHEN** a lifecycle action such as close or continue targets a feature associated with a worktree outside the built-in default location
+- **THEN** Convoy validates that context against Git's worktree inventory instead of assuming a branch-derived path
+
+#### Scenario: Worktree moves outside Convoy
+- **WHEN** Git reports a feature's worktree at a new path
+- **THEN** the feature remains visible, verified rebinding updates its current location, and old run paths remain historical observations rather than current mutation targets

--- a/openspec/changes/stable-feature-lifecycle/tasks.md
+++ b/openspec/changes/stable-feature-lifecycle/tasks.md
@@ -2,74 +2,74 @@
 
 ## 1. Lifecycle storage and identity foundation
 
-- [ ] 1.1 Add a repository-common-directory versioned store with opaque repository/feature/attempt UUIDs and schema/ref validation; verify readers return typed missing/corrupt/unsupported/unreadable results via unit tests for each.
-- [ ] 1.2 Implement atomic versioned feature records (contract set, base, current context, revision, history pointers) with conflict detection; verify a lost-update write is refused and inspected before retry.
-- [ ] 1.3 Implement immutable close attempt journals and receipts keyed by feature/attempt, with embedded identity and repository validation; verify a read ignores foreign or unsupported-version records.
-- [ ] 1.4 Add protected feature/attempt refs and verify existing ref values; verify create-only refs are never overwritten and a pre-existing mismatched ref is refused.
-- [ ] 1.5 Add read-only discovery combining registered features, active candidates, referenced archives, legacy run/close evidence, and Git worktrees; verify browsing never creates or migrates records (assert no writes).
+- [x] 1.1 Add a repository-common-directory versioned store with opaque repository/feature/attempt UUIDs and schema/ref validation; verify readers return typed missing/corrupt/unsupported/unreadable results via unit tests for each.
+- [x] 1.2 Implement atomic versioned feature records (contract set, base, current context, revision, history pointers) with conflict detection; verify a lost-update write is refused and inspected before retry.
+- [x] 1.3 Implement immutable close attempt journals and receipts keyed by feature/attempt, with embedded identity and repository validation; verify a read ignores foreign or unsupported-version records.
+- [x] 1.4 Add protected feature/attempt refs and verify existing ref values; verify create-only refs are never overwritten and a pre-existing mismatched ref is refused.
+- [x] 1.5 Add read-only discovery combining registered features, active candidates, referenced archives, legacy run/close evidence, and Git worktrees; verify browsing never creates or migrates records (assert no writes).
 
 ## 2. Shared observation and resolver
 
-- [ ] 2.1 Add a pure lifecycle assessment module (context, per-contract artifact state, tasks, execution, integration, publication, cleanup, actions) over typed observations; verify unit tests cover each orthogonal fact and unknown/unreadable evidence.
-- [ ] 2.2 Add structured run/Git/artifact read adapters that surface unreadable evidence; verify a run-discovery failure is reported as unknown, not as an empty live-run set.
-- [ ] 2.3 Implement the shared resolver (explicit feature ID → verified context → unique explicit branch/change filter → unresolved candidates); verify it returns a tagged result with evidence and blockers and never falls through an invalid selector to a heuristic.
-- [ ] 2.4 Add deterministic archive-effect verification (ADDED/MODIFIED/REMOVED/RENAMED, full capability paths) and overlapping-contract composed-effect handling; verify with multi-contract fixtures and an unprovable composition stop.
-- [ ] 2.5 Wire the assessment into control-board, specs-viewer, launcher, publication, and close so they consume identical action eligibility; verify the same blocked action renders the same reason in headless and TUI.
+- [x] 2.1 Add a pure lifecycle assessment module (context, per-contract artifact state, tasks, execution, integration, publication, cleanup, actions) over typed observations; verify unit tests cover each orthogonal fact and unknown/unreadable evidence.
+- [x] 2.2 Add structured run/Git/artifact read adapters that surface unreadable evidence; verify a run-discovery failure is reported as unknown, not as an empty live-run set.
+- [x] 2.3 Implement the shared resolver (explicit feature ID → verified context → unique explicit branch/change filter → unresolved candidates); verify it returns a tagged result with evidence and blockers and never falls through an invalid selector to a heuristic.
+- [x] 2.4 Add deterministic archive-effect verification (ADDED/MODIFIED/REMOVED/RENAMED, full capability paths) and overlapping-contract composed-effect handling; verify with multi-contract fixtures and an unprovable composition stop.
+- [x] 2.5 Wire the assessment into control-board, specs-viewer, launcher, publication, and close so they consume identical action eligibility; verify the same blocked action renders the same reason in headless and TUI.
 
 ## 3. Feature identity operations
 
-- [ ] 3.1 Implement `convoy feature show` (read-only, with `--json`) for a feature or current context, including unresolved discovery evidence; verify it mutates nothing and reports provenance.
-- [ ] 3.2 Implement `convoy feature adopt` (branch/change/base, optional archive-path and headless `--archive-source <change>=<path>` mapping) validating repository membership, checked-out branch, worktree registration, and source; verify an arbitrary branch name is accepted and never renamed.
-- [ ] 3.3 Implement `convoy feature bind` (context rebind) with uniqueness, common-directory, live-run, and unresolved-mutation checks; verify a renamed/moved context is rebound without rewriting run boundaries.
-- [ ] 3.4 Implement `convoy feature revise` (contract set/base change) with live-run and unresolved-attempt refusal; verify adding a second contract records the complete reviewed set and that a running feature refuses.
-- [ ] 3.5 Implement `convoy feature recover` for evidence-only completed features without a worktree; verify it grants only receipt-verified follow-ups and never new execution authority.
-- [ ] 3.6 Implement `convoy feature new-work` to start a new identity on a retained completed context; verify it does not inherit the completed feature's runs or receipt.
+- [x] 3.1 Implement `convoy feature show` (read-only, with `--json`) for a feature or current context, including unresolved discovery evidence; verify it mutates nothing and reports provenance.
+- [x] 3.2 Implement `convoy feature adopt` (branch/change/base, optional archive-path and headless `--archive-source <change>=<path>` mapping) validating repository membership, checked-out branch, worktree registration, and source; verify an arbitrary branch name is accepted and never renamed.
+- [x] 3.3 Implement `convoy feature bind` (context rebind) with uniqueness, common-directory, live-run, and unresolved-mutation checks; verify a renamed/moved context is rebound without rewriting run boundaries.
+- [x] 3.4 Implement `convoy feature revise` (contract set/base change) with live-run and unresolved-attempt refusal; verify adding a second contract records the complete reviewed set and that a running feature refuses.
+- [x] 3.5 Implement `convoy feature recover` for evidence-only completed features without a worktree; verify it grants only receipt-verified follow-ups and never new execution authority.
+- [x] 3.6 Implement `convoy feature new-work` to start a new identity on a retained completed context; verify it does not inherit the completed feature's runs or receipt.
 
 ## 4. Registration into spin and launch
 
-- [ ] 4.1 Persist a stable association on successful spin (intent before transfer, committed association before success output); verify a persistence failure exposes the created context and transferred files without committing or deleting them.
-- [ ] 4.2 Persist an association on accepted feature-backed launch and persist the feature link in durable run metadata before execution; verify cancellation before acceptance writes no feature record.
-- [ ] 4.3 Carry stable feature identity, contract set, base, and verified context through feature Apply/Continue handoffs from any launch checkout; verify cross-checkout Apply/Continue reuse the associated context instead of a same-id launch copy.
-- [ ] 4.4 Revalidate reviewed identity/revision/branch/worktree/base before execution and stop on a changed target; verify a branch switch after review refuses and attaches nothing to the new branch.
+- [x] 4.1 Persist a stable association on successful spin (intent before transfer, committed association before success output); verify a persistence failure exposes the created context and transferred files without committing or deleting them.
+- [x] 4.2 Persist an association on accepted feature-backed launch and persist the feature link in durable run metadata before execution; verify cancellation before acceptance writes no feature record.
+- [x] 4.3 Carry stable feature identity, contract set, base, and verified context through feature Apply/Continue handoffs from any launch checkout; verify cross-checkout Apply/Continue reuse the associated context instead of a same-id launch copy.
+- [x] 4.4 Revalidate reviewed identity/revision/branch/worktree/base before execution and stop on a changed target; verify a branch switch after review refuses and attaches nothing to the new branch.
 
 ## 5. Run history and publication
 
-- [ ] 5.1 Add repository/feature identity, association revision, and reviewed contract references to durable run metadata and cleanup-surviving records; verify board/attach/history join by identity and never reinterpret a stored path as today's branch.
-- [ ] 5.2 Resolve feature-backed `Create pull request` through the shared current-context assessment and revalidate before push; verify publication never pushes the replacement branch at a reused historical path and never marks local integration/archive/PR merge complete.
-- [ ] 5.3 Keep legacy run evidence readable until explicitly adopted and preserve immutable run-start boundaries; verify a legacy run without a durable boundary cannot authorize a compaction rewrite.
+- [x] 5.1 Add repository/feature identity, association revision, and reviewed contract references to durable run metadata and cleanup-surviving records; verify board/attach/history join by identity and never reinterpret a stored path as today's branch.
+- [x] 5.2 Resolve feature-backed `Create pull request` through the shared current-context assessment and revalidate before push; verify publication never pushes the replacement branch at a reused historical path and never marks local integration/archive/PR merge complete.
+- [x] 5.3 Keep legacy run evidence readable until explicitly adopted and preserve immutable run-start boundaries; verify a legacy run without a durable boundary cannot authorize a compaction rewrite.
 
 ## 6. Board and specs viewer
 
-- [ ] 6.1 Replace ownership resolution and stage/action gates with feature identity and shared capabilities; verify an inherited copy never claims a foreign feature and unassociated candidates show association/spin remediation.
-- [ ] 6.2 Load associated artifact inventory from the verified source using absolute paths, and show missing/ambiguous/unreadable conditions without same-slug fallback; verify a missing associated worktree exposes another copy only as a candidate.
-- [ ] 6.3 Add **Features** / **Worktrees without spec** / **Canonical Specs** sections with a discoverable **History** view; verify archived-but-unintegrated and integrated-but-not-cleaned work remain visible and completed work is reachable in history.
-- [ ] 6.4 Add a discoverable `Actions` menu in root and ordinary detail using shared capabilities, available when footer hints truncate; verify a blocked close action stays inspectable with its reason and remediation.
-- [ ] 6.5 Add explicit refresh (and refresh after external action return) preserving selection by identity and invalidating artifact/assessment caches together; verify a failed refresh discloses stale evidence instead of presenting readiness as current.
-- [ ] 6.6 Keep fullscreen reader copy/close/tab keys unchanged and restore feature identity and lifecycle actions on return; verify `c` copies and performs no lifecycle mutation.
+- [x] 6.1 Replace ownership resolution and stage/action gates with feature identity and shared capabilities; verify an inherited copy never claims a foreign feature and unassociated candidates show association/spin remediation.
+- [x] 6.2 Load associated artifact inventory from the verified source using absolute paths, and show missing/ambiguous/unreadable conditions without same-slug fallback; verify a missing associated worktree exposes another copy only as a candidate.
+- [x] 6.3 Add **Features** / **Worktrees without spec** / **Canonical Specs** sections with a discoverable **History** view; verify archived-but-unintegrated and integrated-but-not-cleaned work remain visible and completed work is reachable in history.
+- [x] 6.4 Add a discoverable `Actions` menu in root and ordinary detail using shared capabilities, available when footer hints truncate; verify a blocked close action stays inspectable with its reason and remediation.
+- [x] 6.5 Add explicit refresh (and refresh after external action return) preserving selection by identity and invalidating artifact/assessment caches together; verify a failed refresh discloses stale evidence instead of presenting readiness as current.
+- [x] 6.6 Keep fullscreen reader copy/close/tab keys unchanged and restore feature identity and lifecycle actions on return; verify `c` copies and performs no lifecycle mutation.
 
 ## 7. Close transaction rework
 
-- [ ] 7.1 Resolve close through stable feature identity and validate selectors, verifying a mistyped change or contradictory worktree/branch refuses before mutation.
-- [ ] 7.2 Capture original contract/task/delta/proposal context and require positive archive evidence (unique source, completed tasks, canonical-spec effects, committed result); verify an absent active directory alone is never treated as already archived.
-- [ ] 7.3 Persist a close attempt before the first mutation and reconcile every boundary from observed effects; verify crash-after-landing, crash-after-archive, stale-candidate, and repeat-close scenarios behave as specified.
-- [ ] 7.4 Preserve whole-branch squash landing (one parent, captured base, entire feature-exclusive result) and immutable receipts; verify no path-filtered landing, no duplicate base commits, and receipt survival across later attempts.
-- [ ] 7.5 Make landing an expected-old guarded ref transaction distinct from checkout materialization; verify an interrupted landing after ref success is reconciled and a moved base rejects the stale candidate.
-- [ ] 7.6 Gate both worktree removal and branch deletion on verified landing, exact unchanged feature tip, no live run, and consent; verify a reused branch name or changed tip is never deleted and removal precedes deletion.
-- [ ] 7.7 Expose the same guarded cleanup through command output, TUI follow-up, and headless guidance; verify deferred/headless commands execute the same checks rather than an unprotected check-then-force-delete recipe.
-- [ ] 7.8 Extend the interactive close checklist with verified feature/context identification and explicit archive/integration/cleanup distinctions; verify a blocked close review remains reachable and performs no Git or archive mutation.
-- [ ] 7.9 For archive-on-main, verify the base-checkout copy corresponds to the selected contract, record the archive source/evidence, and keep integration as probably merged or pending; verify the feature worktree's active copy no longer displaces the recorded archive source.
+- [x] 7.1 Resolve close through stable feature identity and validate selectors, verifying a mistyped change or contradictory worktree/branch refuses before mutation.
+- [x] 7.2 Capture original contract/task/delta/proposal context and require positive archive evidence (unique source, completed tasks, canonical-spec effects, committed result); verify an absent active directory alone is never treated as already archived.
+- [x] 7.3 Persist a close attempt before the first mutation and reconcile every boundary from observed effects; verify crash-after-landing, crash-after-archive, stale-candidate, and repeat-close scenarios behave as specified.
+- [x] 7.4 Preserve whole-branch squash landing (one parent, captured base, entire feature-exclusive result) and immutable receipts; verify no path-filtered landing, no duplicate base commits, and receipt survival across later attempts.
+- [x] 7.5 Make landing an expected-old guarded ref transaction distinct from checkout materialization; verify an interrupted landing after ref success is reconciled and a moved base rejects the stale candidate.
+- [x] 7.6 Gate both worktree removal and branch deletion on verified landing, exact unchanged feature tip, no live run, and consent; verify a reused branch name or changed tip is never deleted and removal precedes deletion.
+- [x] 7.7 Expose the same guarded cleanup through command output, TUI follow-up, and headless guidance; verify deferred/headless commands execute the same checks rather than an unprotected check-then-force-delete recipe.
+- [x] 7.8 Extend the interactive close checklist with verified feature/context identification and explicit archive/integration/cleanup distinctions; verify a blocked close review remains reachable and performs no Git or archive mutation.
+- [x] 7.9 For archive-on-main, verify the base-checkout copy corresponds to the selected contract, record the archive source/evidence, and keep integration as probably merged or pending; verify the feature worktree's active copy no longer displaces the recorded archive source.
 
 ## 8. Migration and compatibility
 
-- [ ] 8.1 Keep legacy readers and distinguish legacy evidence from stable-ID records; verify legacy records remain readable and are never migrated as a read-time side effect.
-- [ ] 8.2 Add explicit legacy adoption with embedded identity/repository validation, preserving original bytes/refs; verify a filename collision or mismatched embedded identity is refused and not reassigned.
-- [ ] 8.3 Update canonical purpose summaries (control-board, feature-spin, specs-viewer) that describe active-only navigation or "no registry", and the worktree delta's stale `finish` lookup behavior; verify no unrelated requirement is removed and validation stays green.
-- [ ] 8.4 Preserve no-spec runs, multi-change contracts, conventional branch creation, location templates, dirty-tree consent, and run-compaction boundaries; verify existing run-launcher, feature-spin, worktree-location, and run-finalization behavior remains compatible.
+- [x] 8.1 Keep legacy readers and distinguish legacy evidence from stable-ID records; verify legacy records remain readable and are never migrated as a read-time side effect.
+- [x] 8.2 Add explicit legacy adoption with embedded identity/repository validation, preserving original bytes/refs; verify a filename collision or mismatched embedded identity is refused and not reassigned.
+- [x] 8.3 Update canonical purpose summaries (control-board, feature-spin, specs-viewer) that describe active-only navigation or "no registry", and the worktree delta's stale `finish` lookup behavior; verify no unrelated requirement is removed and validation stays green.
+- [x] 8.4 Preserve no-spec runs, multi-change contracts, conventional branch creation, location templates, dirty-tree consent, and run-compaction boundaries; verify existing run-launcher, feature-spin, worktree-location, and run-finalization behavior remains compatible.
 
 ## 9. End-to-end verification
 
-- [ ] 9.1 Add lifecycle scenario tests covering copies, renames, moves, archive-before-close, external archive, ambiguous/missing sources, and repeated cleanup; verify the full suite passes.
-- [ ] 9.2 Add crash-boundary and concurrency fault-injection tests for association writes, archive, candidate, landing, and cleanup; verify no unrelated work is overwritten and every boundary reconciles.
-- [ ] 9.3 Add end-to-end test that a completed feature stays discoverable and a renamed/unassociated feature is not silently closed or claimed; verify no ownership regression.
-- [ ] 9.4 Run typecheck and the full test suite and record results; verify a clean build and zero regressions.
-- [ ] 9.5 Document the local record contract, archive/integration distinctions, guarded cleanup commands, and the explicit identity operations; verify documentation matches the implemented commands.
+- [x] 9.1 Add lifecycle scenario tests covering copies, renames, moves, archive-before-close, external archive, ambiguous/missing sources, and repeated cleanup; verify the full suite passes.
+- [x] 9.2 Add crash-boundary and concurrency fault-injection tests for association writes, archive, candidate, landing, and cleanup; verify no unrelated work is overwritten and every boundary reconciles.
+- [x] 9.3 Add end-to-end test that a completed feature stays discoverable and a renamed/unassociated feature is not silently closed or claimed; verify no ownership regression.
+- [x] 9.4 Run typecheck and the full test suite and record results; verify a clean build and zero regressions.
+- [x] 9.5 Document the local record contract, archive/integration distinctions, guarded cleanup commands, and the explicit identity operations; verify documentation matches the implemented commands.

--- a/openspec/changes/stable-feature-lifecycle/tasks.md
+++ b/openspec/changes/stable-feature-lifecycle/tasks.md
@@ -1,0 +1,75 @@
+# Tasks
+
+## 1. Lifecycle storage and identity foundation
+
+- [ ] 1.1 Add a repository-common-directory versioned store with opaque repository/feature/attempt UUIDs and schema/ref validation; verify readers return typed missing/corrupt/unsupported/unreadable results via unit tests for each.
+- [ ] 1.2 Implement atomic versioned feature records (contract set, base, current context, revision, history pointers) with conflict detection; verify a lost-update write is refused and inspected before retry.
+- [ ] 1.3 Implement immutable close attempt journals and receipts keyed by feature/attempt, with embedded identity and repository validation; verify a read ignores foreign or unsupported-version records.
+- [ ] 1.4 Add protected feature/attempt refs and verify existing ref values; verify create-only refs are never overwritten and a pre-existing mismatched ref is refused.
+- [ ] 1.5 Add read-only discovery combining registered features, active candidates, referenced archives, legacy run/close evidence, and Git worktrees; verify browsing never creates or migrates records (assert no writes).
+
+## 2. Shared observation and resolver
+
+- [ ] 2.1 Add a pure lifecycle assessment module (context, per-contract artifact state, tasks, execution, integration, publication, cleanup, actions) over typed observations; verify unit tests cover each orthogonal fact and unknown/unreadable evidence.
+- [ ] 2.2 Add structured run/Git/artifact read adapters that surface unreadable evidence; verify a run-discovery failure is reported as unknown, not as an empty live-run set.
+- [ ] 2.3 Implement the shared resolver (explicit feature ID → verified context → unique explicit branch/change filter → unresolved candidates); verify it returns a tagged result with evidence and blockers and never falls through an invalid selector to a heuristic.
+- [ ] 2.4 Add deterministic archive-effect verification (ADDED/MODIFIED/REMOVED/RENAMED, full capability paths) and overlapping-contract composed-effect handling; verify with multi-contract fixtures and an unprovable composition stop.
+- [ ] 2.5 Wire the assessment into control-board, specs-viewer, launcher, publication, and close so they consume identical action eligibility; verify the same blocked action renders the same reason in headless and TUI.
+
+## 3. Feature identity operations
+
+- [ ] 3.1 Implement `convoy feature show` (read-only, with `--json`) for a feature or current context, including unresolved discovery evidence; verify it mutates nothing and reports provenance.
+- [ ] 3.2 Implement `convoy feature adopt` (branch/change/base, optional archive-path and headless `--archive-source <change>=<path>` mapping) validating repository membership, checked-out branch, worktree registration, and source; verify an arbitrary branch name is accepted and never renamed.
+- [ ] 3.3 Implement `convoy feature bind` (context rebind) with uniqueness, common-directory, live-run, and unresolved-mutation checks; verify a renamed/moved context is rebound without rewriting run boundaries.
+- [ ] 3.4 Implement `convoy feature revise` (contract set/base change) with live-run and unresolved-attempt refusal; verify adding a second contract records the complete reviewed set and that a running feature refuses.
+- [ ] 3.5 Implement `convoy feature recover` for evidence-only completed features without a worktree; verify it grants only receipt-verified follow-ups and never new execution authority.
+- [ ] 3.6 Implement `convoy feature new-work` to start a new identity on a retained completed context; verify it does not inherit the completed feature's runs or receipt.
+
+## 4. Registration into spin and launch
+
+- [ ] 4.1 Persist a stable association on successful spin (intent before transfer, committed association before success output); verify a persistence failure exposes the created context and transferred files without committing or deleting them.
+- [ ] 4.2 Persist an association on accepted feature-backed launch and persist the feature link in durable run metadata before execution; verify cancellation before acceptance writes no feature record.
+- [ ] 4.3 Carry stable feature identity, contract set, base, and verified context through feature Apply/Continue handoffs from any launch checkout; verify cross-checkout Apply/Continue reuse the associated context instead of a same-id launch copy.
+- [ ] 4.4 Revalidate reviewed identity/revision/branch/worktree/base before execution and stop on a changed target; verify a branch switch after review refuses and attaches nothing to the new branch.
+
+## 5. Run history and publication
+
+- [ ] 5.1 Add repository/feature identity, association revision, and reviewed contract references to durable run metadata and cleanup-surviving records; verify board/attach/history join by identity and never reinterpret a stored path as today's branch.
+- [ ] 5.2 Resolve feature-backed `Create pull request` through the shared current-context assessment and revalidate before push; verify publication never pushes the replacement branch at a reused historical path and never marks local integration/archive/PR merge complete.
+- [ ] 5.3 Keep legacy run evidence readable until explicitly adopted and preserve immutable run-start boundaries; verify a legacy run without a durable boundary cannot authorize a compaction rewrite.
+
+## 6. Board and specs viewer
+
+- [ ] 6.1 Replace ownership resolution and stage/action gates with feature identity and shared capabilities; verify an inherited copy never claims a foreign feature and unassociated candidates show association/spin remediation.
+- [ ] 6.2 Load associated artifact inventory from the verified source using absolute paths, and show missing/ambiguous/unreadable conditions without same-slug fallback; verify a missing associated worktree exposes another copy only as a candidate.
+- [ ] 6.3 Add **Features** / **Worktrees without spec** / **Canonical Specs** sections with a discoverable **History** view; verify archived-but-unintegrated and integrated-but-not-cleaned work remain visible and completed work is reachable in history.
+- [ ] 6.4 Add a discoverable `Actions` menu in root and ordinary detail using shared capabilities, available when footer hints truncate; verify a blocked close action stays inspectable with its reason and remediation.
+- [ ] 6.5 Add explicit refresh (and refresh after external action return) preserving selection by identity and invalidating artifact/assessment caches together; verify a failed refresh discloses stale evidence instead of presenting readiness as current.
+- [ ] 6.6 Keep fullscreen reader copy/close/tab keys unchanged and restore feature identity and lifecycle actions on return; verify `c` copies and performs no lifecycle mutation.
+
+## 7. Close transaction rework
+
+- [ ] 7.1 Resolve close through stable feature identity and validate selectors, verifying a mistyped change or contradictory worktree/branch refuses before mutation.
+- [ ] 7.2 Capture original contract/task/delta/proposal context and require positive archive evidence (unique source, completed tasks, canonical-spec effects, committed result); verify an absent active directory alone is never treated as already archived.
+- [ ] 7.3 Persist a close attempt before the first mutation and reconcile every boundary from observed effects; verify crash-after-landing, crash-after-archive, stale-candidate, and repeat-close scenarios behave as specified.
+- [ ] 7.4 Preserve whole-branch squash landing (one parent, captured base, entire feature-exclusive result) and immutable receipts; verify no path-filtered landing, no duplicate base commits, and receipt survival across later attempts.
+- [ ] 7.5 Make landing an expected-old guarded ref transaction distinct from checkout materialization; verify an interrupted landing after ref success is reconciled and a moved base rejects the stale candidate.
+- [ ] 7.6 Gate both worktree removal and branch deletion on verified landing, exact unchanged feature tip, no live run, and consent; verify a reused branch name or changed tip is never deleted and removal precedes deletion.
+- [ ] 7.7 Expose the same guarded cleanup through command output, TUI follow-up, and headless guidance; verify deferred/headless commands execute the same checks rather than an unprotected check-then-force-delete recipe.
+- [ ] 7.8 Extend the interactive close checklist with verified feature/context identification and explicit archive/integration/cleanup distinctions; verify a blocked close review remains reachable and performs no Git or archive mutation.
+- [ ] 7.9 For archive-on-main, verify the base-checkout copy corresponds to the selected contract, record the archive source/evidence, and keep integration as probably merged or pending; verify the feature worktree's active copy no longer displaces the recorded archive source.
+
+## 8. Migration and compatibility
+
+- [ ] 8.1 Keep legacy readers and distinguish legacy evidence from stable-ID records; verify legacy records remain readable and are never migrated as a read-time side effect.
+- [ ] 8.2 Add explicit legacy adoption with embedded identity/repository validation, preserving original bytes/refs; verify a filename collision or mismatched embedded identity is refused and not reassigned.
+- [ ] 8.3 Update canonical purpose summaries (control-board, feature-spin, specs-viewer) that describe active-only navigation or "no registry", and the worktree delta's stale `finish` lookup behavior; verify no unrelated requirement is removed and validation stays green.
+- [ ] 8.4 Preserve no-spec runs, multi-change contracts, conventional branch creation, location templates, dirty-tree consent, and run-compaction boundaries; verify existing run-launcher, feature-spin, worktree-location, and run-finalization behavior remains compatible.
+
+## 9. End-to-end verification
+
+- [ ] 9.1 Add lifecycle scenario tests covering copies, renames, moves, archive-before-close, external archive, ambiguous/missing sources, and repeated cleanup; verify the full suite passes.
+- [ ] 9.2 Add crash-boundary and concurrency fault-injection tests for association writes, archive, candidate, landing, and cleanup; verify no unrelated work is overwritten and every boundary reconciles.
+- [ ] 9.3 Add end-to-end test that a completed feature stays discoverable and a renamed/unassociated feature is not silently closed or claimed; verify no ownership regression.
+- [ ] 9.4 Run typecheck and the full test suite and record results; verify a clean build and zero regressions.
+- [ ] 9.5 Document the local record contract, archive/integration distinctions, guarded cleanup commands, and the explicit identity operations; verify documentation matches the implemented commands.

--- a/openspec/specs/control-board/spec.md
+++ b/openspec/specs/control-board/spec.md
@@ -1,23 +1,23 @@
 # control-board Specification
 
 ## Purpose
-One inferred surface — `convoy specs` — where every feature's stage is derived live from git, OpenSpec, and run plans, with the actions that move it along; no persisted registry, one shared change resolver.
+One inferred surface — `convoy specs` — where every feature's stage is derived live from git, OpenSpec, run plans, and the repository-scoped feature registry, with the actions that move it along; registered features and explicit associations provide stable identity, while worktrees, branches, tasks, and run liveness stay derived from fresh evidence with one shared change resolver.
 
 ## Requirements
 
 ### Requirement: Control command is the single inferred board
 
-`convoy specs` SHALL present the board (with `convoy control` retained only as a compatibility alias) and derive every displayed fact at render time from the filesystem: worktrees and branches from git, task completion from the OpenSpec CLI, run linkage from run plans' frozen branch field, and change identity from the same resolver the launcher and runs use for branch↔change matching. Convoy SHALL NOT persist any feature registry — a row's existence in the world is its existence on the board.
+`convoy specs` SHALL present the board, retaining `convoy control` as a compatibility alias, and use the shared feature resolver and lifecycle assessment. It SHALL persist explicit identity and associations but derive current worktrees, branches, task completion, run liveness, and integration eligibility from fresh evidence. Read-only OpenSpec task queries SHALL be permitted with filesystem fallback when the CLI is unavailable; unreadable evidence SHALL remain unknown. Historical run linkage SHALL use durable feature identity and frozen provenance, not the branch currently checked out at an old run path. Browsing SHALL NOT write the registry. The board SHALL distinguish unresolved legacy candidates from registered features.
 
 #### Scenario: Deleting the worktree updates the board
 
-- **WHEN** a feature's worktree is removed outside convoy and the board is reopened
-- **THEN** the row no longer claims a worktree, without any cache to invalidate
+- **WHEN** a feature's worktree is removed outside Convoy and the board is reopened
+- **THEN** the feature remains visible without claiming a worktree and offers missing-context or remaining-cleanup guidance as appropriate
 
 #### Scenario: One resolver everywhere
 
-- **WHEN** a branch named `feat/add-foo` exists while a change `add-foo` is active
-- **THEN** the board links them by the same matching rule a run's spec bundle would use
+- **WHEN** a branch with any valid name is explicitly associated with a change
+- **THEN** board and run selection use that association and show the same verified implementation context
 
 ### Requirement: Active change rows derive their lifecycle state
 

--- a/openspec/specs/feature-spin/spec.md
+++ b/openspec/specs/feature-spin/spec.md
@@ -1,7 +1,7 @@
 # feature-spin Specification
 
 ## Purpose
-Deterministically materialize a working context — isolated worktree, conventional branch — for an OpenSpec change proposed on the base checkout, and hand the operator's existing OpenCode session over to it without summarizing, forking, or persisting any registry state.
+Deterministically materialize a working context — isolated worktree, conventional branch — for an OpenSpec change proposed on the base checkout, register the feature's stable identity and association durably as part of a successful spin, and hand the operator's existing OpenCode session over to it without summarizing, forking, or touching any session state.
 
 ## Requirements
 

--- a/openspec/specs/specs-viewer/spec.md
+++ b/openspec/specs/specs-viewer/spec.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The `convoy specs` command lets an operator browse OpenSpec state — active changes and canonical specs — in a terminal UI, read each change's artifacts as rendered markdown, hand a selected change straight to the interactive run launcher with it already pinned as the contract, or open a standalone OpenCode session on the repo rooted at the change's planning files.
+The `convoy specs` command lets an operator browse OpenSpec state — registered features and active changes (lifecycle work), canonical specs — in a terminal UI, read each change's artifacts as rendered markdown from its authoritative source, hand a selected change straight to the interactive run launcher with it already pinned as the contract, or open a standalone OpenCode session on the repo rooted at the change's planning files.
 
 ## Requirements
 

--- a/openspec/specs/worktree-location/spec.md
+++ b/openspec/specs/worktree-location/spec.md
@@ -71,10 +71,10 @@ All Convoy operations that reason about a worktree by its name SHALL resolve to 
 - **WHEN** a worktree already exists at the resolved location for a branch
 - **THEN** Convoy uses a suffixed branch and location (`-2`, `-3`, …) so no collision occurs
 
-#### Scenario: Finish locates a non-default worktree
+#### Scenario: Close and continue locate a non-default worktree
 
-- **WHEN** `convoy finish --branch <name>` targets a worktree that is not at the built-in default location
-- **THEN** Convoy locates the worktree from the repository's worktree list rather than assuming a fixed path
+- **WHEN** a lifecycle action such as close or continue targets a worktree that is not at the built-in default location
+- **THEN** Convoy locates the worktree from the repository's worktree list (or the feature's verified association) rather than assuming a fixed path
 
 ### Requirement: Conventional branch naming preserved
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,7 @@ import { preflightRunPlan } from "./preflight"
 import type { LaunchBranchCheck, LaunchBranchProposal, LaunchRunPreparation, LaunchRunSelection } from "./launch-tui"
 import type { SpinOptions } from "./spin"
 import type { CloseOptions } from "./feature-close-command"
+import { resolveFeatureForLaunch, revalidateFeatureLink } from "./feature-lifecycle/launch"
 import { formatVersion } from "./version"
 import type { UpdateResult } from "./update"
 import type { TuiRoute } from "./tui-session"
@@ -75,6 +76,8 @@ export type ParsedArgs = {
   noConfirm?: boolean
   /** --change: explicit OpenSpec change id; wins over every selection heuristic. */
   change?: string
+  /** --feature: explicit feature id; resolves the feature/contract/context link (feature-lifecycle). */
+  featureId?: string
 }
 
 export type InitOptions = {
@@ -92,6 +95,7 @@ export type CliCommand =
   | { type: "spin"; options: SpinOptions }
   | { type: "opencode-install" }
   | { type: "close"; options: CloseOptions }
+  | { type: "feature"; args: string[] }
   | { type: "config"; targetDir: string }
   | { type: "init"; options: InitOptions }
   | { type: "agents"; action: "eject"; agentName: string; options: InitOptions }
@@ -154,6 +158,11 @@ export async function parseAndRun(argv: string[]) {
     await runCloseCommand(command.options)
     return
   }
+  if (command.type === "feature") {
+    const { runFeatureCommand, parseFeatureArgs } = await import("./feature-lifecycle/command-cli")
+    await runFeatureCommand(parseFeatureArgs(command.args))
+    return
+  }
   if (command.type === "config") {
     await openConfigEditor(command.targetDir)
     return
@@ -211,6 +220,13 @@ export async function parseAndRun(argv: string[]) {
     process.stdout.write(renderRunPlan(plan, true))
   }
   await preflightRunPlan(plan)
+  // Execution-time identity revalidation (capability feature-lifecycle, task
+  // 4.4): the reviewed feature link must still verify — same repository,
+  // association revision, branch, and base. A changed target refuses before
+  // anything is created; this is additional to the dirty-tree gate below.
+  if (plan.feature) {
+    await revalidateFeatureLink({ cwd: command.options.targetDir, link: plan.feature })
+  }
   // Nothing has touched the repo yet; the worktree is the first effect, and only
   // once the plan has been accepted.
   let options = command.options
@@ -314,7 +330,19 @@ async function buildReviewedPlan(input: BuildRunPlanInput): Promise<RunPlan> {
   if (openspec && openspec.changeIds.length === 0 && input.pipeline.name === defaultPipelineName) {
     throw new Error("no change; run /opsx:propose first (or pass --change <id>)")
   }
-  return buildRunPlan({ ...input, prdHistoryPreview: preview, ...(openspec ? { openspec } : {}) })
+  // The feature link (capability feature-lifecycle, tasks 4.3/4.4): an
+  // explicit `--feature` must resolve to a verified association — it never
+  // falls through to naming heuristics, and a refusal carries the exact
+  // adoption command. Without `--feature`, an unassociated context launches
+  // unlinked (the ordinary flow).
+  const feature = await resolveFeatureForLaunch({
+    cwd: input.targetDir,
+    ...(input.featureId ? { featureId: input.featureId } : {}),
+    ...(input.change ? { changeId: input.change } : {}),
+    ...(input.branch ? { branch: input.branch } : {}),
+    ...(input.worktreeDir ? { worktreeDir: input.worktreeDir } : {}),
+  })
+  return buildRunPlan({ ...input, prdHistoryPreview: preview, ...(openspec ? { openspec } : {}), ...(feature ? { feature } : {}) })
 }
 
 /** The result of deciding whether goal mode applies to a resolved run. */
@@ -692,6 +720,15 @@ export async function openSpecsBrowser(targetDir: string, route?: TuiRoute): Pro
     )
     return
   }
+  if (resolution.type === "close-feature") {
+    // The identity-keyed handoff (task 6.4): close resolves through the
+    // feature's stable id, so a removed worktree still reaches the close
+    // review — it reports the recorded landing (with remaining follow-ups)
+    // or the concrete missing-context blocker, never a silent no-op.
+    const { runCloseCommand } = await import("./feature-close-command")
+    await runCloseCommand({ targetDir, featureId: resolution.featureId }, route)
+    return
+  }
   if (resolution.type === "archive-change-main") {
     const { runArchiveOnMain } = await import("./feature-close-command")
     await runArchiveOnMain({ targetDir, changeID: resolution.changeID })
@@ -859,6 +896,13 @@ export async function parseCommand(argv: string[]): Promise<CliCommand> {
     }
     const { parseCloseArgs } = await import("./feature-close-command")
     return { type: "close", options: parseCloseArgs(argv.slice(1)) }
+  }
+  if (argv[0] === "feature") {
+    if (argv.slice(1).some((arg) => arg === "--help" || arg === "-h")) {
+      const { featureHelp } = await import("./feature-lifecycle/command-cli")
+      return { type: "help", text: featureHelp() }
+    }
+    return { type: "feature", args: argv.slice(1) }
   }
   if (argv[0] === "config") {
     if (argv.length > 1) throw new Error("usage: convoy config")
@@ -1111,6 +1155,7 @@ export async function resolveRunOptions(parsed: ParsedArgs): Promise<Omit<RunOpt
     resumeRunID: parsed.resumeRunID ?? "",
     prdHistory: defaults.prdHistory ?? true,
     ...(parsed.change ? { change: parsed.change } : {}),
+    ...(parsed.featureId ? { featureId: parsed.featureId } : {}),
     keepRunDir: parsed.keepRunDir ?? true,
     modelOverride: parsed.modelOverride ?? "",
     advisorOverride: parsed.advisorOverride ?? "",
@@ -1316,6 +1361,9 @@ export function parseArgs(argv: string[]): ParsedArgs {
         break
       case "--change":
         parsed.change = takeValue()
+        break
+      case "--feature":
+        parsed.featureId = takeValue()
         break
       case "--base":
         parsed.baseRef = takeValue()

--- a/src/close-journal.ts
+++ b/src/close-journal.ts
@@ -4,6 +4,8 @@ import { dirname, join } from "node:path"
 import { execFile, isAncestor, resolveCommit } from "./git"
 import { createRefIfAbsent, gitCommonDir, refExists } from "./finalization/refs"
 
+import type { RequiredEffect } from "./feature-lifecycle/records"
+
 /**
  * The close journal and landing receipt (capability feature-close, design D6
  * and D7, tasks 5.1/5.5/5.7): a versioned record in the repository's Git
@@ -50,6 +52,21 @@ export type CloseJournal = {
   candidateSha?: string
   /** The base branch after the guarded landing. */
   landingSha?: string
+  /**
+   * The canonical effects the archive must prove, snapshotted from the
+   * change's own deltas BEFORE the archive mutation (task 7.2). Resume
+   * validates against this snapshot — an operator editing or deleting the
+   * archived copy's deltas after the fact cannot make verification vacuous.
+   * Absent on journals written before this field existed.
+   */
+  requiredEffects?: RequiredEffect[]
+  /**
+   * Whether the base checkout has been materialized onto the landed ref
+   * (task 7.5): the guarded ref transaction is the landing; the checkout
+   * update is a distinct recorded stage. `false` means the landing stands
+   * but the checkout still needs reconciliation before cleanup.
+   */
+  checkoutMaterialized?: boolean
   phase: CloseJournalPhase
   recordedAt: number
   updatedAt: number
@@ -98,6 +115,21 @@ export function readCloseJournalValue(value: unknown): CloseJournal | undefined 
           : [],
       }
     : undefined
+  let requiredEffects: RequiredEffect[] | undefined
+  if (value.requiredEffects !== undefined) {
+    if (!Array.isArray(value.requiredEffects)) return undefined
+    requiredEffects = []
+    for (const effect of value.requiredEffects) {
+      if (!isRecord(effect)) return undefined
+      if ((effect.kind !== "present" && effect.kind !== "absent") || typeof effect.capability !== "string" || typeof effect.name !== "string") return undefined
+      requiredEffects.push({
+        kind: effect.kind,
+        capability: effect.capability,
+        name: effect.name,
+        scenarios: Array.isArray(effect.scenarios) ? effect.scenarios.filter((scenario): scenario is string => typeof scenario === "string") : [],
+      })
+    }
+  }
   return {
     schemaVersion: closeJournalSchemaVersion,
     attemptID: optionalString(value.attemptID) ?? "",
@@ -112,6 +144,8 @@ export function readCloseJournalValue(value: unknown): CloseJournal | undefined 
     ...(optionalString(value.message) ? { message: optionalString(value.message) } : {}),
     ...(optionalString(value.candidateSha) ? { candidateSha: optionalString(value.candidateSha) } : {}),
     ...(optionalString(value.landingSha) ? { landingSha: optionalString(value.landingSha) } : {}),
+    ...(requiredEffects ? { requiredEffects } : {}),
+    ...(typeof value.checkoutMaterialized === "boolean" ? { checkoutMaterialized: value.checkoutMaterialized } : {}),
     phase: phase as CloseJournalPhase,
     recordedAt: typeof value.recordedAt === "number" ? value.recordedAt : 0,
     updatedAt: typeof value.updatedAt === "number" ? value.updatedAt : 0,

--- a/src/feature-close-command.ts
+++ b/src/feature-close-command.ts
@@ -3,7 +3,7 @@ import { stat } from "node:fs/promises"
 import { resolve } from "node:path"
 import type { Readable } from "node:stream"
 
-import { archiveChangeOnMain, runClose, verifiedCloseReceipt, type CloseEvent, type CloseInput, type CloseMessageProposal, type CloseResult, type CloseStep } from "./feature-close"
+import { archiveChangeOnMain, runClose, runCloseCleanup, verifiedCloseReceipt, type CloseEvent, type CloseInput, type CloseMessageProposal, type CloseResult, type CloseStep } from "./feature-close"
 import { stripControlBytes } from "./commit-text"
 import {
   applyCloseEvent,
@@ -51,6 +51,10 @@ export type CloseOptions = {
   /** The worktree directory, when the caller (the board) already resolved it. */
   worktreeDir?: string
   changeID?: string
+  /** Explicit stable feature id: identity-keyed resolution, resume, and cleanup (design D3/D9). */
+  featureId?: string
+  /** Cleanup-only continuation of a verified landing: `worktree` then `branch`. */
+  cleanup?: "worktree" | "branch"
   /** Continue a stopped sequence from the first incomplete step. */
   resume?: boolean
   message?: string
@@ -64,11 +68,32 @@ export async function runCloseCommand(options: CloseOptions, route?: TuiRoute): 
     stdout.write(`close would run: preflight → sync → archive → squash-merge${options.resume ? " (resuming)" : ""}\n`)
     return
   }
+  // Cleanup is its own deliberate surface (design D9): the feature-keyed
+  // guarded commands the TUI and headless output print are executable here,
+  // running the same action-time revalidation as the TUI follow-ups.
+  if (options.cleanup) {
+    try {
+      const outcome = await runCloseCleanup({
+        targetDir: options.targetDir,
+        ...(options.featureId ? { featureId: options.featureId } : {}),
+        ...(options.worktreeDir ? { worktreeDir: resolve(options.worktreeDir) } : {}),
+        cleanup: options.cleanup,
+      })
+      stdout.write(`${outcome}\n`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      stdout.write(`${firstLine(message)}\n`)
+      log.error(message)
+      process.exitCode = 1
+    }
+    return
+  }
   const input: CloseInput = {
     targetDir: options.targetDir,
     ...(options.worktreeDir ? { worktreeDir: resolve(options.worktreeDir) } : {}),
     ...(options.branch ? { branch: options.branch } : {}),
     ...(options.changeID ? { changeID: options.changeID } : {}),
+    ...(options.featureId ? { featureId: options.featureId } : {}),
     ...(options.resume ? { resume: true } : {}),
     ...(options.message !== undefined ? { message: options.message } : {}),
   }
@@ -104,6 +129,7 @@ export async function runCloseHeadless(input: CloseInput): Promise<void> {
       baseRef: result.baseRef,
       branch: result.branch,
       worktreeDir: result.worktreeDir,
+      ...(result.featureId ?? input.featureId ? { featureId: result.featureId ?? input.featureId } : {}),
       ...(evidence ? { evidence: { landingSha: evidence.landingSha, featureTip: evidence.postArchiveTip } } : {}),
     })
     stdout.write(formatCloseEvents(events, { followUps }))
@@ -196,6 +222,8 @@ export async function resolveCloseFollowUps(args: {
   baseRef: string
   branch: string
   worktreeDir: string
+  /** The resolved feature: cleanup then prints the feature-keyed guarded commands (design D9). */
+  featureId?: string
   /** Present only when a verified receipt authorizes branch deletion. */
   evidence?: CloseLandingEvidence
 }): Promise<CloseFollowUps> {
@@ -216,39 +244,59 @@ export async function resolveCloseFollowUps(args: {
     pushRemediation = `${shq(args.baseRef)} has no configured upstream — set one first: ${gitC} branch --set-upstream-to=<remote>/<branch> ${shq(args.baseRef)}`
   }
 
+  // Cleanup commands are the feature-keyed guarded operations (design D9):
+  // `convoy close --feature <id> --cleanup worktree` then `--cleanup branch`.
+  // They execute the same identity-aware checks the TUI actions do — fresh
+  // association, unresolved-attempt, live-run, and mutation-lease checks on
+  // top of the landing evidence — so a deferred or headless operator never
+  // falls back to a display-only git recipe. The raw git forms below remain
+  // only as the pre-identity display for synthetic callers with no feature.
   let worktreeRemoval: string | undefined
   const isMainCheckout = (await sameDir(mainDir, args.worktreeDir)) === true
   const worktreeExists = await stat(args.worktreeDir).then(
     () => true,
     () => false,
   )
-  if (!isMainCheckout && worktreeExists) worktreeRemoval = `${gitC} worktree remove ${shq(args.worktreeDir)}`
+  if (args.featureId) {
+    if (!isMainCheckout && worktreeExists) worktreeRemoval = `convoy close --feature ${shq(args.featureId)} --cleanup worktree`
+  } else if (!isMainCheckout && worktreeExists) {
+    worktreeRemoval = `${gitC} worktree remove ${shq(args.worktreeDir)}`
+  }
 
   // Branch deletion is evidence-gated (design D7, task 6.3): a locally
   // squash-landed branch has no merge ancestry, so plain `branch -d` refuses
   // it and force deletion is permitted ONLY behind a verified receipt naming
   // the exact current feature tip and a landing still reachable from the
-  // base. The printed command re-checks both facts immediately before the
-  // deletion, so a branch that moved between close and cleanup refuses
-  // instead of deleting new work; shell quoting covers branch names with
-  // unusual characters. Without a receipt there is no deletion command at
-  // all — only the inspection guidance.
+  // base. With the feature id the printed command IS the guarded operation —
+  // it re-verifies the association, receipt, tip, worktree inventory, and
+  // lease at action time and refuses a moved tip with its diagnostic — so
+  // the old check-then-delete shell recipe is no longer the safety
+  // mechanism. Without a receipt there is no deletion command at all — only
+  // the inspection guidance.
   let branchDelete: string | undefined
   let branchDeleteRemediation: string | undefined
   if (args.evidence) {
-    const tipNow = await execFile("git", ["rev-parse", "--verify", "--quiet", `refs/heads/${args.branch}`], {
-      cwd: mainDir,
-      allowFailure: true,
-    })
-    if (tipNow.exitCode === 0 && tipNow.stdout.trim() === args.evidence.featureTip) {
-      branchDelete =
-        `${gitC} rev-parse --verify refs/heads/${shq(args.branch)} | grep -qx ${shq(args.evidence.featureTip)} && ` +
-        `${gitC} merge-base --is-ancestor ${shq(args.evidence.landingSha)} ${shq(args.baseRef)} && ` +
-        `${gitC} branch -D ${shq(args.branch)}`
-    } else if (tipNow.exitCode === 0) {
-      branchDeleteRemediation = `${args.branch}'s tip moved past the landed state (${tipNow.stdout.trim().slice(0, 8)}) — inspect the branch before deleting anything`
+    if (args.featureId) {
+      branchDelete = `convoy close --feature ${shq(args.featureId)} --cleanup branch`
     } else {
-      branchDeleteRemediation = `${args.branch} no longer exists locally — nothing to delete`
+      const tipNow = await execFile("git", ["rev-parse", "--verify", "--quiet", `refs/heads/${args.branch}`], {
+        cwd: mainDir,
+        allowFailure: true,
+      })
+      if (tipNow.exitCode === 0 && tipNow.stdout.trim() === args.evidence.featureTip) {
+        // The final act is the atomic expected-tip ref deletion (task 7.6): the
+        // printed checks re-verify tip and reachability, and `update-ref -d`
+        // refuses if the branch moved between the check and the deletion.
+        branchDelete =
+          `${gitC} rev-parse --verify refs/heads/${shq(args.branch)} | grep -qx ${shq(args.evidence.featureTip)} && ` +
+          `${gitC} merge-base --is-ancestor ${shq(args.evidence.landingSha)} ${shq(args.baseRef)} && ` +
+          `! ${gitC} worktree list --porcelain | grep -qx ${shq(`branch refs/heads/${args.branch}`)} && ` +
+          `${gitC} update-ref -d refs/heads/${shq(args.branch)} ${shq(args.evidence.featureTip)}`
+      } else if (tipNow.exitCode === 0) {
+        branchDeleteRemediation = `${args.branch}'s tip moved past the landed state (${tipNow.stdout.trim().slice(0, 8)}) — inspect the branch before deleting anything`
+      } else {
+        branchDeleteRemediation = `${args.branch} no longer exists locally — nothing to delete`
+      }
     }
   } else {
     branchDeleteRemediation =
@@ -309,11 +357,13 @@ export async function runCloseInteractive(input: CloseInput, io: CloseIO = {}, r
       resolveMessage: (proposal) => tui.confirmMessage(proposal),
     })
     const evidence = await verifiedCloseReceipt(input.targetDir, result.branch, result.changeID)
+    const featureId = result.featureId ?? input.featureId
     const followUps = await resolveCloseFollowUps({
       targetDir: input.targetDir,
       baseRef: result.baseRef,
       branch: result.branch,
       worktreeDir: result.worktreeDir,
+      ...(featureId ? { featureId } : {}),
       ...(evidence ? { evidence: { landingSha: evidence.landingSha, featureTip: evidence.postArchiveTip } } : {}),
     })
     await offerCloseFollowUpsTui(tui, {
@@ -322,6 +372,7 @@ export async function runCloseInteractive(input: CloseInput, io: CloseIO = {}, r
       branch: result.branch,
       worktreeDir: result.worktreeDir,
       targetDir: input.targetDir,
+      ...(featureId ? { featureId } : {}),
     })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -374,6 +425,8 @@ export type FollowUpOffers = CloseFollowUps & {
   targetDir: string
   /** The verified receipt the deletion offer is gated on, when present. */
   evidence?: CloseLandingEvidence
+  /** The resolved feature: present for every close the adoption gate lets through. */
+  featureId?: string
 }
 
 /**
@@ -393,6 +446,34 @@ async function assertLandingEvidenceIntact(mainDir: string, followUps: FollowUpO
   const reachable = await execFile("git", ["merge-base", "--is-ancestor", evidence.landingSha, followUps.baseRef], { cwd: mainDir, allowFailure: true })
   if (reachable.exitCode !== 0) {
     throw new Error(`the landing commit ${evidence.landingSha.slice(0, 8)} is no longer reachable from ${followUps.baseRef} — inspect the history before deleting anything`)
+  }
+  await assertNoRegisteredWorktree(mainDir, followUps.branch)
+}
+
+/**
+ * No registered worktree may have the branch checked out (design D9, task
+ * 7.6): Git's worktree inventory — never a path guess — decides, so a reused
+ * branch name at a surviving worktree is never deleted under anyone.
+ */
+async function assertNoRegisteredWorktree(mainDir: string, branch: string): Promise<void> {
+  const list = await execFile("git", ["worktree", "list", "--porcelain"], { cwd: mainDir, allowFailure: true })
+  if (list.exitCode !== 0) throw new Error("couldn't read the worktree inventory — refusing to delete the branch while registration is unverifiable")
+  if (list.stdout.split("\n").includes(`branch refs/heads/${branch}`)) {
+    throw new Error(`${branch} is checked out in a registered worktree — remove that worktree before deleting the branch`)
+  }
+}
+
+/**
+ * The guarded branch deletion (task 7.6): an expected-tip ref deletion —
+ * `git update-ref -d refs/heads/<branch> <expectedTip>` — is atomic, so a
+ * branch that moved between the tip check and the deletion makes the
+ * expected-old value refuse. Never `branch -D` after a separate tip test.
+ */
+async function guardedBranchDeletion(mainDir: string, followUps: FollowUpOffers): Promise<void> {
+  await assertLandingEvidenceIntact(mainDir, followUps)
+  const result = await execFile("git", ["update-ref", "-d", `refs/heads/${followUps.branch}`, followUps.evidence!.featureTip], { cwd: mainDir, allowFailure: true })
+  if (result.exitCode !== 0) {
+    throw new Error((result.stderr || `the expected-tip deletion of ${followUps.branch} was refused`).trim())
   }
 }
 
@@ -522,14 +603,19 @@ async function offerCloseFollowUpsTui(tui: CloseTui, followUps: FollowUpOffers):
         await tui.withTerminal(() => pushRefspec(followUps.push!.remote, followUps.push!.refspec, mainDir))
       } else if (id === "worktree") {
         if (!followUps.worktreeRemoval) continue
-        await removeWorktree(followUps.worktreeDir, mainDir)
+        // A resolved feature runs the feature-keyed guarded operation — the
+        // same identity-aware checks the printed command executes (design
+        // D9); the legacy direct removal remains only for synthetic offers
+        // without one.
+        if (followUps.featureId) await runCloseCleanup({ targetDir: followUps.targetDir, featureId: followUps.featureId, cleanup: "worktree" })
+        else await removeWorktree(followUps.worktreeDir, mainDir)
       } else {
-        // Evidence is rechecked at action time (design D7), then the
-        // evidence-gated force delete runs: the squash landing left no
-        // merge ancestry, so plain `branch -d` would refuse a landed branch.
-        await assertLandingEvidenceIntact(mainDir, followUps)
-        const result = await execFile("git", ["branch", "-D", followUps.branch], { cwd: mainDir, allowFailure: true })
-        if (result.exitCode !== 0) throw new Error(result.stderr || `git branch -D ${followUps.branch} failed`)
+        // Evidence is rechecked at action time (task 7.6), then the guarded
+        // expected-tip deletion runs: the squash landing left no merge
+        // ancestry, so the receipt is the authority, and the atomic
+        // update-ref -d makes the tip check and the deletion one operation.
+        if (followUps.featureId) await runCloseCleanup({ targetDir: followUps.targetDir, featureId: followUps.featureId, cleanup: "branch" })
+        else await guardedBranchDeletion(mainDir, followUps)
       }
       state[id] = { status: "completed" }
     } catch (error) {
@@ -569,7 +655,10 @@ export async function offerCloseFollowUps(followUps: FollowUpOffers, io: CloseIO
       worktreeRemoved = await offerAction(
         "worktree removal",
         `Remove the worktree at ${followUps.worktreeDir}? [y/N] `,
-        () => removeWorktree(followUps.worktreeDir, mainDir),
+        async () => {
+          if (followUps.featureId) await runCloseCleanup({ targetDir: followUps.targetDir, featureId: followUps.featureId, cleanup: "worktree" })
+          else await removeWorktree(followUps.worktreeDir, mainDir)
+        },
         io,
       )
       if (worktreeRemoved) out.write("worktree removed\n")
@@ -593,9 +682,8 @@ export async function offerCloseFollowUps(followUps: FollowUpOffers, io: CloseIO
       "branch deletion",
       `Delete the branch ${followUps.branch}? [y/N] `,
       async () => {
-        await assertLandingEvidenceIntact(mainDir, followUps)
-        const result = await execFile("git", ["branch", "-D", followUps.branch], { cwd: mainDir, allowFailure: true })
-        if (result.exitCode !== 0) throw new Error(result.stderr || `git branch -D ${followUps.branch} failed`)
+        if (followUps.featureId) await runCloseCleanup({ targetDir: followUps.targetDir, featureId: followUps.featureId, cleanup: "branch" })
+        else await guardedBranchDeletion(mainDir, followUps)
       },
       io,
     )
@@ -640,9 +728,10 @@ export async function runArchiveOnMain(input: { targetDir: string; changeID: str
     const result = await archiveChangeOnMain(input)
     stdout.write(
       result.committed
-        ? `archived ${input.changeID} in the main checkout and committed on the base branch\n`
-        : `openspec archived ${input.changeID} with nothing to commit\n`,
+        ? `archived ${input.changeID} in the main checkout and committed on the base branch${result.archiveSource ? ` (archive source: ${result.archiveSource})` : ""}\n`
+        : `openspec archived ${input.changeID} with nothing to commit${result.archiveSource ? ` (archive source: ${result.archiveSource})` : ""}\n`,
     )
+    stdout.write("integration remains probably merged or pending — archive-on-main never claims the feature landed\n")
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     log.error(message)
@@ -681,26 +770,39 @@ so saving an edit is not a confirmation.
 Once landed, current-session cleanup stays in that TUI as separate, deliberate
 actions — never automatic. Push is a normal push that names the configured
 remote and refspec explicitly, and is unavailable (with the setup step) when
-the base branch has no upstream; branch deletion is evidence-gated: it is
-offered only when close's verified landing receipt still names the branch's
-exact tip and a landing commit reachable from the base, the worktree has been
-removed first, and the printed command re-checks both facts immediately
-before the deletion runs. When close was
+the base branch has no upstream. Cleanup — worktree removal, then branch
+deletion — is evidence-gated and feature-keyed: the printed and deferred
+commands are \`convoy close --feature <id> --cleanup worktree|branch\`, which
+revalidate the association, the verified landing receipt (exact tip and a
+landing commit still reachable from the base), the worktree inventory, live
+runs, and the mutation lease at execution time before the guarded removal or
+the atomic expected-tip ref deletion runs. When close was
 launched from inside the feature worktree, worktree and branch cleanup are
 shown instead as deferred cleanup — the reason (a process cannot remove the
-directory its shell sits in) plus the exact git -C commands to run after
-leaving the worktree. Headless (piped) runs print the same facts as a stdout
-summary plus executable commands, and attempt nothing interactive.
+directory its shell sits in) plus those same feature-keyed commands to run
+after leaving the worktree. Headless (piped) runs print the same facts as a
+stdout summary plus the same executable commands, and attempt nothing
+interactive.
 
-The feature is resolved from the current worktree, or pass --branch <name> to
-target another feature's worktree.
+The feature is resolved through stable identity: running inside the worktree
+or passing --branch <name> still selects it, but an unassociated context
+refuses until the work is adopted explicitly (\`convoy feature adopt\`), and
+--feature <id> resolves, resumes, and cleans up by identity — including after
+the worktree was removed.
 
 Usage:
-  convoy close [--branch <name>] [--change <id>] [--resume] [--message <subject>]
+  convoy close [--branch <name>] [--change <id>] [--feature <id>] [--resume]
+               [--cleanup worktree|branch] [--message <subject>]
 
 Options:
   --branch <name>    Close the feature worktree carrying this branch
   --change <id>      Pin the OpenSpec change id (default: the branch's id)
+  --feature <id>     Resolve by stable feature id (see \`convoy feature show\`);
+                     permits resume and cleanup after the worktree is gone
+  --cleanup <what>   Cleanup-only continuation of a verified landing:
+                     \`worktree\` removes the feature worktree, \`branch\` then
+                     deletes the local branch at its landed tip (expected-tip
+                     guarded; requires --feature). Requires --feature.
   --resume           Continue a stopped sequence from the first incomplete step
   --message <text>   Exact message for the squashed commit; skips composition
                      and confirmation
@@ -721,12 +823,26 @@ export function parseCloseArgs(argv: string[]): CloseOptions {
     else if (arg.startsWith("--branch=")) options.branch = arg.slice("--branch=".length)
     else if (arg === "--change") options.changeID = value()
     else if (arg.startsWith("--change=")) options.changeID = arg.slice("--change=".length)
-    else if (arg === "--message") options.message = value()
+    else if (arg === "--feature") options.featureId = value()
+    else if (arg.startsWith("--feature=")) options.featureId = arg.slice("--feature=".length)
+    else if (arg === "--cleanup") {
+      const what = value()
+      if (what !== "worktree" && what !== "branch") {
+        throw new Error(`--cleanup expects "worktree" or "branch", got "${what}"`)
+      }
+      options.cleanup = what
+    } else if (arg.startsWith("--cleanup=")) {
+      const what = arg.slice("--cleanup=".length)
+      if (what !== "worktree" && what !== "branch") {
+        throw new Error(`--cleanup expects "worktree" or "branch", got "${what}"`)
+      }
+      options.cleanup = what
+    } else if (arg === "--message") options.message = value()
     else if (arg.startsWith("--message=")) options.message = arg.slice("--message=".length)
     else if (arg === "--resume") options.resume = true
     else if (arg === "--dry-run") options.dryRun = true
     else if (arg === "--worktree-dir") options.worktreeDir = value()
-    else throw new Error(`usage: convoy close [--branch <name>] [--change <id>] [--resume] [--message <subject>] (unexpected argument: ${arg})`)
+    else throw new Error(`usage: convoy close [--branch <name>] [--change <id>] [--feature <id>] [--resume] [--cleanup worktree|branch] [--message <subject>] (unexpected argument: ${arg})`)
   }
   return options
 }

--- a/src/feature-close.ts
+++ b/src/feature-close.ts
@@ -13,10 +13,29 @@ import {
   mainWorktreeDir,
   findWorktreeDirForBranch,
   mergeBase,
+  removeWorktree,
   resolveCommit,
   statusPorcelain,
 } from "./git"
 import { branchIdFromBranch, isOpenSpecChangeId, openspecDirName } from "./openspec"
+import { lifecycleCommonDir } from "./feature-lifecycle/store"
+import { resolveFeature, type FeatureResolution } from "./feature-lifecycle/resolver"
+import {
+  listAttemptIds,
+  listReceiptIds,
+  readAttemptJournal,
+  readFeatureRecord,
+  readReceipt,
+  writeAttemptJournal,
+  writeFeatureRecord,
+  writeReceiptIfAbsent,
+  type CloseAttemptJournal,
+  type FeatureRecord,
+  type LandingReceipt,
+} from "./feature-lifecycle/records"
+import { isLandingReachableFrom as featureLandingReachable, protectFeatureRef } from "./feature-lifecycle/refs"
+import { featureCandidateRef as featureCandidateRefName, featureTipRef as featureTipRefName } from "./feature-lifecycle/refs"
+import { withFeatureLock } from "./feature-lifecycle/store"
 import {
   clearCloseJournal,
   closeCommonDir,
@@ -37,6 +56,7 @@ import {
 } from "./commit-message"
 import { stripControlBytes } from "./commit-text"
 import { listRuns } from "./runs"
+import { acquireMutationLease, LeaseUnavailableError, type MutationLease } from "./finalization/lease"
 
 /**
  * `convoy close` — the death of a feature, one resumable sequence (capability
@@ -106,6 +126,14 @@ export type CloseInput = {
   branch?: string
   /** The change to archive; defaults to the branch's change id (the shared resolver rule). */
   changeID?: string
+  /** Explicit stable feature id (design D3): resolution is identity-keyed, never a heuristic fallback. */
+  featureId?: string
+  /**
+   * Cleanup-only continuation of a verified landing (design D9): the
+   * feature-keyed guarded commands the TUI and headless output print are
+   * this same executable surface. Requires `featureId`.
+   */
+  cleanup?: "worktree" | "branch"
   /** Continue a previously stopped sequence: completed steps are detected, not repeated. */
   resume?: boolean
   /** Override for the landing commit's message; wins verbatim and bypasses composition. */
@@ -148,12 +176,65 @@ export type CloseResult = {
   disposition: CloseDisposition
   /** Present when the disposition is "landed" or "already-landed". */
   landing?: { sha: string }
+  /**
+   * The resolved registered feature (task 7.1): the follow-up surface uses it
+   * to print the feature-keyed guarded cleanup commands (design D9) instead
+   * of display-only git recipes.
+   */
+  featureId?: string
 }
 
 export type CloseTarget = {
   worktreeDir: string
   branch: string
   changeID: string
+  /** The registered feature this close resolved to, when one is associated (task 7.1). */
+  feature?: FeatureRecord
+}
+
+/**
+ * Resolves the registered feature for this close through the shared resolver
+ * (task 7.1): the branch/change selectors must agree with the feature's
+ * verified association — a mistyped change selector refuses before mutation
+ * instead of checking or modifying another change. The tagged resolution is
+ * returned so `runClose` can refuse every unresolved shape before mutation
+ * (task 7.1 + the BREAKING proposal bullet: an unassociated close is an
+ * adoption decision, never a branch-name guess).
+ */
+async function resolveCloseFeature(input: CloseInput, target: CloseTarget): Promise<FeatureResolution | undefined> {
+  const commonDir = await lifecycleCommonDir(input.targetDir)
+  if (!commonDir) return undefined
+  return resolveFeature({ cwd: input.targetDir, commonDir, ...(input.featureId ? { featureId: input.featureId } : {}), branch: target.branch, changeId: target.changeID })
+}
+
+/**
+ * The adoption gate (task 7.1, the proposal's BREAKING bullet): an unresolved
+ * context is a consent decision, never a branch-name guess — close refuses
+ * before any mutation and names the exact explicit adoption (or rebinding)
+ * command the operator runs to establish the association. Interactive close
+ * surfaces the same review through its checklist instead of running sync or
+ * archive.
+ */
+function unassociatedCloseError(resolution: FeatureResolution, target: CloseTarget, baseRef: string): Error {
+  const adopt =
+    `convoy feature adopt --branch ${shq(target.branch)} --change ${shq(target.changeID)} --base ${shq(baseRef)}`
+  if (resolution.status === "unreadable") {
+    return new Error(
+      `close: registered feature evidence is unreadable — ${resolution.reason}. ` +
+        "Close refuses to mutate while identity cannot be verified; repair the records (see `convoy feature show`) and try again.",
+    )
+  }
+  if (resolution.status === "missing") {
+    return new Error(
+      `close: ${resolution.reason}. Close refuses before any mutation; resolve or adopt the work first (see \`convoy feature show\`).`,
+    )
+  }
+  const detail = resolution.status === "unassociated" && resolution.reason ? ` (${resolution.reason})` : ""
+  return new Error(
+    `close: ${target.branch} has no verified feature association${detail} — close refuses to guess ownership and performs no mutation. ` +
+      `Adopt the work explicitly, then close again:\n  ${adopt}\n` +
+      "(browsing never adopts; only the explicit command or an accepted review establishes the association)",
+  )
 }
 
 /**
@@ -180,7 +261,7 @@ export async function resolveCloseTarget(input: CloseInput): Promise<CloseTarget
   }
   if (!worktreeDir) {
     throw new Error(
-      "couldn't locate the feature worktree: pass --branch <name>, run inside the worktree, or continue from the specs board's row action",
+      "couldn't locate the feature worktree: pass --branch <name>, run inside the worktree, or — when the feature's context moved — rebind it with `convoy feature bind <feature-id> --branch <name> --worktree <path>`",
     )
   }
 
@@ -318,7 +399,12 @@ export async function closePreflightState(input: CloseInput, target: CloseTarget
     })
   }
 
-  const parts: string[] = [treeVerifiable ? "clean tree" : "tree unverifiable"]
+  const parts: string[] = [
+    // Verified feature/context identification (task 7.8): the checklist's
+    // preflight line names the registered feature it is about to act on.
+    ...(target.feature ? [`feature ${target.feature.displayName}`] : []),
+    treeVerifiable ? "clean tree" : "tree unverifiable",
+  ]
   if (taskSummary) parts.push(taskSummary)
   parts.push(liveCount === 0 ? "no live runs" : `${liveCount} live run${liveCount === 1 ? "" : "s"}`)
   // Factual remote disclosure (design D7): an upstream is reported, never
@@ -343,12 +429,39 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
   const mainDir = (await mainWorktreeDir(input.targetDir).catch(() => undefined)) ?? input.targetDir
   const commonDir = await closeCommonDir(input.targetDir)
 
+  // Identity-keyed resolution (design D3 rule 1, task 7.1): an explicit
+  // --feature resolves the record directly and cross-checks the selectors —
+  // before any worktree is demanded, so a worktree-less resume and the
+  // feature-keyed cleanup work by identity rather than branch spelling.
+  let explicitFeature: FeatureRecord | undefined
+  if (input.featureId !== undefined) {
+    if (!commonDir) throw new Error(`close: no git repository — feature ${input.featureId} cannot resolve`)
+    const read = await readFeatureRecord(commonDir, input.featureId)
+    if (read.status !== "found") {
+      const why = read.status === "corrupt" || read.status === "unreadable" ? `: ${read.reason}` : ""
+      throw new Error(
+        `close: feature ${input.featureId} could not be resolved (${read.status}${why}) — run \`convoy feature show\` to list the registered features.`,
+      )
+    }
+    explicitFeature = read.value
+    if (input.branch && explicitFeature.context?.branch !== input.branch) {
+      throw new Error(
+        `close: the selectors disagree with the registered association — feature ${input.featureId} is associated with branch "${explicitFeature.context?.branch ?? "(none)"}", not "${input.branch}". Close refuses before any mutation.`,
+      )
+    }
+    if (input.changeID && !explicitFeature.contracts.some((contract) => contract.changeId === input.changeID)) {
+      throw new Error(
+        `close: the selectors disagree with the registered association — change "${input.changeID}" is not one of feature ${input.featureId}'s contracts. Close refuses before any mutation.`,
+      )
+    }
+  }
+
   // Receipt fast path (design D7, task 5.1): a resume against a completed
   // receipt skips completed work before any worktree is demanded, even when
   // the worktree was already removed and cleanup is all that remains.
   if (input.resume && input.branch && commonDir) {
     const receipt = await readCloseJournal(commonDir, input.branch, input.changeID ?? branchIdFromBranch(input.branch) ?? "")
-    if (receipt?.phase === "landed" && receipt.landingSha && receipt.postArchiveTip) {
+    if (receipt?.phase === "landed" && receipt.landingSha && receipt.postArchiveTip && receipt.checkoutMaterialized !== false) {
       const reachable = await isLandingReachable(receipt.landingSha, baseRef, mainDir)
       const tip = await resolveCommit(receipt.branch, mainDir).catch(() => undefined)
       const tipUnchanged = tip === undefined || tip === receipt.postArchiveTip
@@ -365,6 +478,7 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
           baseRef,
           disposition: "already-landed",
           landing: { sha: receipt.landingSha },
+          ...(explicitFeature ? { featureId: explicitFeature.featureId } : {}),
         }
         emit({ type: "result", result })
         return result
@@ -382,7 +496,77 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
     }
   }
 
-  const target = await resolveCloseTarget(input)
+  // Identity-keyed receipt fast path (--feature, design D8): every close with
+  // an explicit feature id consults that feature's receipts BEFORE any
+  // worktree is demanded — a worktree-less resume, or a repeated close after
+  // cleanup, reports the recorded landing instead of guessing by branch.
+  if (explicitFeature && commonDir) {
+    const receipt = await latestVerifiedReceipt(commonDir, explicitFeature.featureId, mainDir)
+    if (receipt) {
+      const summary = `landing ${receipt.landingSha.slice(0, 8)} already recorded for ${receipt.branch} → ${receipt.baseRef}`
+      emit({ type: "preflight", summary: `${summary} · nothing to redo` })
+      for (const step of ["sync", "archive", "squash-merge"] as const) {
+        emit({ type: "step-skipped", step, reason: "a verified landing receipt covers this sequence" })
+      }
+      const result: CloseResult = {
+        changeID: input.changeID ?? explicitFeature.contracts[0]?.changeId ?? branchIdFromBranch(receipt.branch) ?? receipt.branch,
+        branch: receipt.branch,
+        worktreeDir: input.worktreeDir ?? (await findWorktreeDirForBranch(receipt.branch, input.targetDir)) ?? mainDir,
+        baseRef: receipt.baseRef,
+        disposition: "already-landed",
+        landing: { sha: receipt.landingSha },
+        featureId: explicitFeature.featureId,
+      }
+      emit({ type: "result", result })
+      return result
+    }
+  }
+
+  // An explicit feature id pins the branch: the feature's current context
+  // (or, failing that, its landing receipt's branch) supplies what a bare
+  // `--branch` would have, so identity — not branch spelling — selects the
+  // work (design D3 rule 1).
+  const branchHint = input.branch ?? explicitFeature?.context?.branch
+  const target = await resolveCloseTarget(branchHint ? { ...input, branch: branchHint } : input)
+  // Identity-keyed resolution (task 7.1): the selectors must agree with the
+  // registered association; a contradictory selector refuses before mutation.
+  const resolution = await resolveCloseFeature(input, target)
+  if (resolution) {
+    if (resolution.status === "verified") {
+      target.feature = resolution.feature
+    } else if (resolution.status === "ambiguous") {
+      throw new Error(
+        `close: the selectors disagree with the registered association — ${resolution.reason}. ` +
+          "Close refuses before any mutation; pass --feature <id> (see `convoy feature show`) or fix the selectors.",
+      )
+    } else {
+      throw unassociatedCloseError(resolution, target, baseRef)
+    }
+  }
+  // Every close — with or without --resume — consults identity-keyed landing
+  // receipts before new sync/archive work (task 7.3/D8: repeated close after
+  // success performs nothing).
+  if (target.feature && commonDir && !explicitFeature) {
+    const landing = await verifiedIdentityReceipt(commonDir, target.feature, baseRef, input.targetDir)
+    if (landing) {
+      const summary = `landing ${landing.landingSha.slice(0, 8)} already recorded for ${target.branch} → ${baseRef}`
+      emit({ type: "preflight", summary: `${summary} · nothing to redo` })
+      for (const step of ["sync", "archive", "squash-merge"] as const) {
+        emit({ type: "step-skipped", step, reason: "a verified landing receipt covers this sequence" })
+      }
+      const result: CloseResult = {
+        changeID: target.changeID,
+        branch: target.branch,
+        worktreeDir: input.worktreeDir ?? (await findWorktreeDirForBranch(target.branch, input.targetDir)) ?? mainDir,
+        baseRef,
+        disposition: "already-landed",
+        landing: { sha: landing.landingSha },
+        ...(target.feature ? { featureId: target.feature.featureId } : {}),
+      }
+      emit({ type: "result", result })
+      return result
+    }
+  }
 
   // Preflight: refuse to touch anything until the feature is ready to close.
   const preflight = await closePreflightState(input, target)
@@ -392,105 +576,258 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
   }
   emit({ type: "preflight", summary: preflight.summary })
 
-  const journalState = await openJournal(commonDir, target, baseRef, input)
-  const journal = journalState.record
-
-  // Sync: bring the base branch's tip in before archiving, so the canonical
-  // specs the archive produces land against a fresh base. The base revision
-  // is captured (pinned) here and revalidated before the landing (task 5.6).
-  const baseSha = journal.baseSha
-  let preSyncTip: string | undefined
-  if (await isAncestor(baseRef, target.branch, target.worktreeDir)) {
-    emit({ type: "step-skipped", step: "sync", reason: `${baseRef} is already an ancestor of ${target.branch}` })
-  } else {
-    emit({ type: "step-started", step: "sync" })
-    preSyncTip = (await resolveCommit(target.branch, target.worktreeDir)) ?? undefined
-    const merge = await execFile("git", ["merge", "--no-edit", baseSha], { cwd: target.worktreeDir, allowFailure: true })
-    if (merge.exitCode !== 0) {
-      const message = `sync: merging ${baseRef} into ${target.branch} conflicted — resolve the conflicts and commit inside the worktree, then run \`convoy close --resume\`\n${merge.stderr || merge.stdout}`
-      emit({ type: "step-failed", step: "sync", message })
-      throw new Error(message)
+  // Interrupted-landing reconciliation (task 7.5/D8): a journal whose landing
+  // already stands in the base but whose checkout was never materialized —
+  // every close invocation reconciles it from observed effects, without
+  // re-running sync/archive and without creating another commit.
+  const priorJournal = commonDir ? await readCloseJournal(commonDir, target.branch, target.changeID) : undefined
+  if (priorJournal?.phase === "landed" && priorJournal.landingSha && priorJournal.candidateSha && priorJournal.checkoutMaterialized === false) {
+    if (await isLandingReachable(priorJournal.landingSha, priorJournal.baseRef, mainDir)) {
+      const reconciling = priorJournal
+      const journalState: CloseJournalState = { record: reconciling, commonDir: commonDir ?? undefined, ...(target.feature ? { feature: target.feature } : {}) }
+      emit({ type: "step-started", step: "squash-merge" })
+      // The reconciliation mutates the base checkout and evidence (design D9):
+      // it is one lease-guarded mutation segment of its own.
+      const result = await withCloseLease(commonDir, async (): Promise<CloseResult> => {
+        try {
+          await materializeBaseCheckout(journalState, mainDir)
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          emit({ type: "step-failed", step: "squash-merge", message })
+          throw new Error(message)
+        }
+        await persistJournal(journalState, { checkoutMaterialized: true })
+        await writeLandingReceipt(journalState, target, reconciling.baseRef, reconciling.baseSha, reconciling.postArchiveTip ?? "", reconciling.preparedTree ?? "", reconciling.candidateSha ?? "", mainDir)
+        emit({ type: "step-completed", step: "squash-merge", detail: `reconciled the landing ${reconciling.landingSha!.slice(0, 8)} on ${reconciling.baseRef}` })
+        const result: CloseResult = {
+          changeID: target.changeID,
+          branch: target.branch,
+          worktreeDir: target.worktreeDir,
+          baseRef: reconciling.baseRef,
+          disposition: "landed",
+          landing: { sha: reconciling.landingSha! },
+          ...(target.feature ? { featureId: target.feature.featureId } : {}),
+        }
+        emit({ type: "result", result })
+        return result
+      })
+      return result
     }
-    emit({ type: "step-completed", step: "sync", detail: `merged ${baseSha.slice(0, 8)} into ${target.branch}` })
-    if (journal.phase === "prepared" && !journal.postArchiveTip) await persistJournal(journalState, { preSyncTip })
   }
 
-  // Snapshot the message inputs before the first archive mutation (design D6):
-  // the archive moves the live change, and the archive layout's naming is an
-  // implementation detail the message must never discover. A resume reuses the
-  // persisted context so a retry never degrades to archive-only text.
-  const archiveSubject = `chore(openspec): archive ${target.changeID}`
-  const snapshot: CloseContextSnapshot = journal.messageContext
-    ? { ...journal.messageContext, changeID: target.changeID }
-    : await snapshotCloseContext(target, baseSha, { archiveSubject })
-  if (!journal.messageContext) await persistJournal(journalState, { messageContext: snapshot })
+  // Prepare segment (design D9): the journal intent, the sync merge, the
+  // archive, and the tip protection are one lease-guarded mutation segment.
+  // The lease is released before message composition and review and the
+  // landing segment reacquires it with fresh revalidation.
+  type PreparedClose =
+    | { kind: "prepared"; journalState: CloseJournalState; baseSha: string; snapshot: CloseContextSnapshot; postArchiveTip: string; preparedTree: string }
+    | { kind: "no-content"; result: CloseResult }
+  const prepared = await withCloseLease(commonDir, async (): Promise<PreparedClose> => {
+    const journalState = await openJournal(commonDir, target, baseRef, input)
+    const journal = journalState.record
 
-  // Archive: through the OpenSpec CLI only — convoy never edits openspec/.
-  const changeDir = join(target.worktreeDir, openspecDirName, "changes", target.changeID)
-  if (await exists(changeDir)) {
-    emit({ type: "step-started", step: "archive" })
-    const archive = await execFile("openspec", ["archive", target.changeID, "--yes"], { cwd: target.worktreeDir, allowFailure: true })
-    if (archive.exitCode !== 0) {
-      const message = `archive: openspec archive ${target.changeID} failed — the sequence stops before any squash-merge\n${archive.stderr || archive.stdout}`
-      emit({ type: "step-failed", step: "archive", message })
+    // Sync: bring the base branch's tip in before archiving, so the canonical
+    // specs the archive produces land against a fresh base. The base revision
+    // is captured (pinned) here and revalidated before the landing (task 5.6).
+    const baseSha = journal.baseSha
+    let preSyncTip: string | undefined
+    if (await isAncestor(baseRef, target.branch, target.worktreeDir)) {
+      emit({ type: "step-skipped", step: "sync", reason: `${baseRef} is already an ancestor of ${target.branch}` })
+    } else {
+      emit({ type: "step-started", step: "sync" })
+      preSyncTip = (await resolveCommit(target.branch, target.worktreeDir)) ?? undefined
+      const merge = await execFile("git", ["merge", "--no-edit", baseSha], { cwd: target.worktreeDir, allowFailure: true })
+      if (merge.exitCode !== 0) {
+        const message = `sync: merging ${baseRef} into ${target.branch} conflicted — resolve the conflicts and commit inside the worktree, then run \`convoy close --resume\`\n${merge.stderr || merge.stdout}`
+        emit({ type: "step-failed", step: "sync", message })
+        throw new Error(message)
+      }
+      emit({ type: "step-completed", step: "sync", detail: `merged ${baseSha.slice(0, 8)} into ${target.branch}` })
+      if (journal.phase === "prepared" && !journal.postArchiveTip) await persistJournal(journalState, { preSyncTip })
+    }
+
+    // Snapshot the message inputs before the first archive mutation (design D6):
+    // the archive moves the live change, and the archive layout's naming is an
+    // implementation detail the message must never discover. A resume reuses the
+    // persisted context so a retry never degrades to archive-only text.
+    const archiveSubject = `chore(openspec): archive ${target.changeID}`
+    const snapshot: CloseContextSnapshot = journal.messageContext
+      ? { ...journal.messageContext, changeID: target.changeID }
+      : await snapshotCloseContext(target, baseSha, { archiveSubject })
+    if (!journal.messageContext) await persistJournal(journalState, { messageContext: snapshot })
+
+    // Archive: through the OpenSpec CLI only — convoy never edits openspec/.
+    const changeDir = join(target.worktreeDir, openspecDirName, "changes", target.changeID)
+    if (await exists(changeDir)) {
+      emit({ type: "step-started", step: "archive" })
+      // Capture the delta effects the archive must prove BEFORE invoking the
+      // CLI (task 7.2/D7): the change's own delta specs are the contract the
+      // canonical specs must reflect once OpenSpec has archived.
+      const { readDeltaSpecs, effectsForDeltas, verifyEffects, toRequiredEffects } = await import("./feature-lifecycle/archive-verify")
+      const deltas = await readDeltaSpecs(changeDir)
+      const effects = effectsForDeltas(deltas.values())
+      // Persist the required effects BEFORE the archive mutation (task 7.2) —
+      // in the identity attempt journal for registered features, in the legacy
+      // journal otherwise — so resume validates against this snapshot, never
+      // against the archived copy. An empty snapshot is meaningful too: it
+      // records a legitimately no-delta change (D7 item 3).
+      const effectSnapshot = toRequiredEffects(effects)
+      if (effectSnapshot.length > 0) {
+        await persistRequiredEffects(journalState, target.changeID, effectSnapshot)
+        if (!journalState.feature) await persistJournal(journalState, { requiredEffects: effectSnapshot })
+      } else if (!journalState.feature) {
+        // Still record that the no-delta case was observed, so a later resume
+        // can distinguish it from a deleted delta.
+        await persistJournal(journalState, { requiredEffects: [] })
+      }
+      const archive = await execFile("openspec", ["archive", target.changeID, "--yes"], { cwd: target.worktreeDir, allowFailure: true })
+      if (archive.exitCode !== 0) {
+        const message = `archive: openspec archive ${target.changeID} failed — the sequence stops before any squash-merge\n${archive.stderr || archive.stdout}`
+        emit({ type: "step-failed", step: "archive", message })
+        throw new Error(message)
+      }
+      // Positive archive verification (task 7.2): the CLI's output must prove
+      // every delta effect in the canonical specs — ADDED/MODIFIED present with
+      // their scenarios, REMOVED absent — before the result is committed. A
+      // change with no delta specs needs no canonical comparison (D7 item 3).
+      if (effects.length > 0) {
+        const verification = await verifyEffects(target.worktreeDir, effects)
+        if (verification.unproven.length > 0) {
+          const reasons = verification.unproven.map((entry) => {
+            const name = entry.effect.kind === "no-effect" ? "(no canonical effect)" : entry.effect.name
+            const kind = entry.effect.kind === "no-effect" ? "effect" : entry.effect.kind === "requirement-absent" ? "absent" : "present"
+            return `  ${kind} ${entry.effect.capability}/${name}: ${entry.reason}`
+          })
+          const message =
+            `archive: the archived result does not prove every delta effect in the canonical specs — close stops before committing or landing\n` +
+            `${reasons.join("\n")}\n` +
+            `Reconcile the archive with the canonical specs through OpenSpec (never by editing specs inside Convoy), then run \`convoy close --resume\`.`
+          emit({ type: "step-failed", step: "archive", message })
+          throw new Error(message)
+        }
+      }
+      // The archive result is committed on the feature branch under the
+      // operator's identity (staged explicitly; commitAsUser adds nothing).
+      try {
+        await execFile("git", ["add", openspecDirName], { cwd: target.worktreeDir })
+        const commitArchive = () => commitAsUser(archiveSubject, target.worktreeDir)
+        if (input.withTerminal) await input.withTerminal(commitArchive)
+        else await commitArchive()
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error)
+        const message =
+          `archive: change ${target.changeID} was archived but committing the result failed — resolve the git error in the worktree, ` +
+          `commit the archive result, then run \`convoy close --resume\`\n${detail}`
+        emit({ type: "step-failed", step: "archive", message })
+        throw new Error(message)
+      }
+      emit({ type: "step-completed", step: "archive", detail: `archived ${target.changeID}` })
+    } else {
+      // The active directory is gone — that alone is never proof of a complete
+      // archive (task 7.2). The archived source must exist and its delta
+      // effects must still verify against the canonical specs before the
+      // sequence treats the archive as done; a resume after an incomplete or
+      // uncommitted archive refuses here instead of landing unproven work.
+      const archiveDir = join(target.worktreeDir, openspecDirName, "changes", "archive", target.changeID)
+      if (!(await exists(archiveDir))) {
+        const message =
+          `archive: change ${target.changeID} has neither an active directory nor an archived copy under ${openspecDirName}/changes/archive/ — ` +
+          "an absent active directory alone does not mean the change was archived. Locate or recreate the change's archive through OpenSpec, then run `convoy close --resume`."
+        emit({ type: "step-failed", step: "archive", message })
+        throw new Error(message)
+      }
+      const { readDeltaSpecs, effectsForDeltas, verifyEffects, toRequiredEffects, fromRequiredEffects } = await import("./feature-lifecycle/archive-verify")
+      // The required effects come, in order, from: the identity attempt
+      // journal's snapshot, the legacy journal's snapshot, and finally the
+      // archived copy itself (legacy journals written before snapshots
+      // existed). A journal snapshot of any length — including empty, the
+      // legitimate no-delta case — is authoritative; falling back to the
+      // archived copy when NO snapshot exists and finding no deltas there is
+      // fail-closed: a deleted delta must never make verification vacuous.
+      let requiredEffects: Array<{ kind: "present" | "absent"; capability: string; name: string; scenarios: string[] }> | undefined
+      let snapshotAuthoritative = false
+      if (journalState.feature) {
+        requiredEffects = await readAttemptRequiredEffects(journalState, target.changeID, commonDir)
+        if (requiredEffects !== undefined) snapshotAuthoritative = true
+      }
+      if (requiredEffects === undefined && journal.requiredEffects !== undefined) {
+        requiredEffects = journal.requiredEffects
+        snapshotAuthoritative = true
+      }
+      if (requiredEffects === undefined) {
+        const deltas = await readDeltaSpecs(archiveDir)
+        requiredEffects = toRequiredEffects(effectsForDeltas(deltas.values()))
+      }
+      const effects = fromRequiredEffects(requiredEffects)
+      if (effects.length > 0) {
+        const verification = await verifyEffects(target.worktreeDir, effects)
+        if (verification.unproven.length > 0) {
+          const reasons = verification.unproven.map((entry) => {
+            const name = entry.effect.kind === "no-effect" ? "(no canonical effect)" : entry.effect.name
+            const kind = entry.effect.kind === "no-effect" ? "effect" : entry.effect.kind === "requirement-absent" ? "absent" : "present"
+            return `  ${kind} ${entry.effect.capability}/${name}: ${entry.reason}`
+          })
+          const message =
+            `archive: the archived change ${target.changeID} does not prove every delta effect in the canonical specs — close stops before landing\n` +
+            `${reasons.join("\n")}\n` +
+            `Reconcile the archive with the canonical specs through OpenSpec, then run \`convoy close --resume\`.`
+          emit({ type: "step-failed", step: "archive", message })
+          throw new Error(message)
+        }
+      } else if (!snapshotAuthoritative) {
+        // No persisted snapshot and the archived copy carries no delta specs:
+        // there is no trustworthy evidence of what this archive must contain.
+        const message =
+          `archive: no persisted effect snapshot exists for ${target.changeID} and its archived copy carries no delta specs — ` +
+          "the archive cannot be verified. Locate the change's original delta specs through OpenSpec, then run `convoy close --resume`."
+        emit({ type: "step-failed", step: "archive", message })
+        throw new Error(message)
+      }
+      emit({ type: "step-skipped", step: "archive", reason: `change ${target.changeID} is archived and its canonical result verifies` })
+    }
+
+    // The post-archive feature tip is the squash-merge source (design D6): the
+    // candidate folds sync resolutions, archive output, and every author's
+    // feature content by tree, not by walking authors. Protect it create-only
+    // before anything else happens to the branch (design D7).
+    const postArchiveTip = (await resolveCommit(target.branch, target.worktreeDir)) ?? ""
+    if (!postArchiveTip) {
+      const message = `squash-merge: ${target.branch} has no commits — nothing to land`
+      emit({ type: "step-failed", step: "squash-merge", message })
       throw new Error(message)
     }
-    // The archive result is committed on the feature branch under the
-    // operator's identity (staged explicitly; commitAsUser adds nothing).
     try {
-      await execFile("git", ["add", openspecDirName], { cwd: target.worktreeDir })
-      const commitArchive = () => commitAsUser(archiveSubject, target.worktreeDir)
-      if (input.withTerminal) await input.withTerminal(commitArchive)
-      else await commitArchive()
+      await protectCloseRef(closeFeatureTipRef(target.branch, journal.attemptID), postArchiveTip, mainDir)
     } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error)
-      const message =
-        `archive: change ${target.changeID} was archived but committing the result failed — resolve the git error in the worktree, ` +
-        `commit the archive result, then run \`convoy close --resume\`\n${detail}`
-      emit({ type: "step-failed", step: "archive", message })
+      const message = `squash-merge: couldn't protect the feature tip ref (${error instanceof Error ? error.message : String(error)}) — the sequence stops before the landing`
+      emit({ type: "step-failed", step: "squash-merge", message })
       throw new Error(message)
     }
-    emit({ type: "step-completed", step: "archive", detail: `archived ${target.changeID}` })
-  } else {
-    emit({ type: "step-skipped", step: "archive", reason: `change ${target.changeID} is already archived` })
-  }
+    const preparedTree = (await treeOf(postArchiveTip, target.worktreeDir)) ?? ""
+    await persistJournal(journalState, { postArchiveTip, preparedTree })
 
-  // The post-archive feature tip is the squash-merge source (design D6): the
-  // candidate folds sync resolutions, archive output, and every author's
-  // feature content by tree, not by walking authors. Protect it create-only
-  // before anything else happens to the branch (design D7).
-  const postArchiveTip = (await resolveCommit(target.branch, target.worktreeDir)) ?? ""
-  if (!postArchiveTip) {
-    const message = `squash-merge: ${target.branch} has no commits — nothing to land`
-    emit({ type: "step-failed", step: "squash-merge", message })
-    throw new Error(message)
-  }
-  try {
-    await protectCloseRef(closeFeatureTipRef(target.branch, journal.attemptID), postArchiveTip, mainDir)
-  } catch (error) {
-    const message = `squash-merge: couldn't protect the feature tip ref (${error instanceof Error ? error.message : String(error)}) — the sequence stops before the landing`
-    emit({ type: "step-failed", step: "squash-merge", message })
-    throw new Error(message)
-  }
-  const preparedTree = (await treeOf(postArchiveTip, target.worktreeDir)) ?? ""
-  await persistJournal(journalState, { postArchiveTip, preparedTree })
+    // Squash-merge: stage the one-parent candidate on the captured base in a
+    // private detached integration worktree, then advance the base onto it. The
+    // main checkout's index is never left half-staged by a failed signature or
+    // hook, because the staging happens away from it (design D6, task 5.4).
+    emit({ type: "step-started", step: "squash-merge" })
+    await assertBaseUnchanged(baseSha, baseRef, mainDir)
 
-  // Squash-merge: stage the one-parent candidate on the captured base in a
-  // private detached integration worktree, then advance the base onto it. The
-  // main checkout's index is never left half-staged by a failed signature or
-  // hook, because the staging happens away from it (design D6, task 5.4).
-  emit({ type: "step-started", step: "squash-merge" })
-  await assertBaseUnchanged(baseSha, baseRef, mainDir)
+    if (preparedTree === (await treeOf(baseSha, mainDir))) {
+      // Identical trees: nothing to land, no empty commit, and no cleanup
+      // authorization from that fact alone (design D6/D7).
+      emit({ type: "step-skipped", step: "squash-merge", reason: "the archived feature's tree equals the captured base tree — no content to land" })
+      await clearCloseJournal(commonDir ?? "", target.branch, target.changeID)
+      const result: CloseResult = { changeID: target.changeID, branch: target.branch, worktreeDir: target.worktreeDir, baseRef, disposition: "no-content-to-land", ...(target.feature ? { featureId: target.feature.featureId } : {}) }
+      emit({ type: "result", result })
+      return { kind: "no-content", result }
+    }
 
-  if (preparedTree === (await treeOf(baseSha, mainDir))) {
-    // Identical trees: nothing to land, no empty commit, and no cleanup
-    // authorization from that fact alone (design D6/D7).
-    emit({ type: "step-skipped", step: "squash-merge", reason: "the archived feature's tree equals the captured base tree — no content to land" })
-    await clearCloseJournal(commonDir ?? "", target.branch, target.changeID)
-    const result: CloseResult = { changeID: target.changeID, branch: target.branch, worktreeDir: target.worktreeDir, baseRef, disposition: "no-content-to-land" }
-    emit({ type: "result", result })
-    return result
-  }
+    return { kind: "prepared", journalState, baseSha, snapshot, postArchiveTip, preparedTree }
+  })
+  if (prepared.kind === "no-content") return prepared.result
+  const { journalState, baseSha, snapshot, postArchiveTip, preparedTree } = prepared
+  const journal = journalState.record
 
   // A crash after candidate creation resumes the landing without a new
   // compose/review round-trip (design D6, task 5.7): the candidate is
@@ -504,7 +841,10 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
     if (message) emit({ type: "squash-phase", phase: "creating-commit" })
   }
 
-  if (!candidateSha) {
+  // The message gate runs WITHOUT the mutation lease (design D9: never hold
+  // it while waiting for message review — persist preparation, release, and
+  // reacquire/revalidate afterward).
+  if (!candidateSha && message === undefined) {
     // `--message ""` is still an explicit override and must win verbatim, so
     // presence is `!== undefined`, never truthiness (SC-8). The override
     // bypasses composition, normalization, and the review gate entirely.
@@ -529,66 +869,177 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
       await persistJournal(journalState, { message: undefined })
       throw new Error(stop)
     }
-    const confirmedMessage = message
-    await persistJournal(journalState, { message: confirmedMessage })
-    emit({ type: "squash-phase", phase: "creating-commit" })
-    try {
-      candidateSha = await createCandidate(journalState, target, confirmedMessage, baseSha, postArchiveTip, mainDir, input.withTerminal)
-    } catch (error) {
-      // A failed candidate (declined signature, rejected hook) must still mark
-      // the squash-merge row failed; the failed event carries the remediation (SC-5).
-      const detail = error instanceof Error ? error.message : String(error)
-      emit({ type: "step-failed", step: "squash-merge", message: `squash-merge: ${detail}` })
-      throw error
+  }
+
+  // Landing segment (design D9): the lease is reacquired after review and
+  // everything from the confirmed message through the immutable receipt —
+  // candidate creation, the guarded ref transaction, checkout
+  // materialization, and the receipt write — is one serialized mutation
+  // segment.
+  const result = await withCloseLease(commonDir, async (): Promise<CloseResult> => {
+    if (!candidateSha) {
+      const confirmedMessage = message
+      if (confirmedMessage === undefined) {
+        throw new Error("close: the landing message vanished before the candidate commit — rerun `convoy close --resume` to retry")
+      }
+      await persistJournal(journalState, { message: confirmedMessage })
+      emit({ type: "squash-phase", phase: "creating-commit" })
+      try {
+        candidateSha = await createCandidate(journalState, target, confirmedMessage, baseSha, postArchiveTip, mainDir, input.withTerminal)
+      } catch (error) {
+        // A failed candidate (declined signature, rejected hook) must still mark
+        // the squash-merge row failed; the failed event carries the remediation (SC-5).
+        const detail = error instanceof Error ? error.message : String(error)
+        emit({ type: "step-failed", step: "squash-merge", message: `squash-merge: ${detail}` })
+        throw error
+      }
     }
-  }
+    const landedSha = candidateSha
+    if (landedSha === undefined) {
+      throw new Error("close: the candidate commit vanished before the landing — rerun `convoy close --resume` to retry")
+    }
 
-  // Land: advance the base branch onto the verified candidate. The candidate's
-  // parent is the captured base, so this is a pure fast-forward of the base
-  // ref — guarded by the expected old value, so a base that moved after the
-  // candidate was built refuses instead of merging or forcing (task 5.5/5.6).
-  const baseNow = (await resolveCommit(baseRef, mainDir)) ?? ""
-  if (baseNow !== baseSha) {
-    const message = `squash-merge: ${baseRef} moved to ${baseNow.slice(0, 8)} while the close was in progress — run \`convoy close\` to re-sync against the new base`
-    emit({ type: "step-failed", step: "squash-merge", message })
-    throw new Error(message)
-  }
-  const mainStatus = await statusPorcelain(mainDir).catch(() => "unreadable")
-  if (mainStatus.trim() !== "") {
-    const message = "squash-merge: the main checkout has uncommitted changes — commit or stash them first, then run `convoy close --resume`"
-    emit({ type: "step-failed", step: "squash-merge", message })
-    throw new Error(message)
-  }
-  try {
-    // The guarded fast-forward-only update (design D6, task 5.5): the
-    // candidate's parent is the captured base, so this can only fast-forward
-    // the base branch — and it updates the main checkout's index and working
-    // tree together with the ref. A base that moved between candidate
-    // creation and landing makes this refuse (no merge, no force); the
-    // clean-tree preflight guarantees the checkout has nothing to lose.
-    const land = await execFile("git", ["merge", "--ff-only", candidateSha], { cwd: mainDir, allowFailure: true })
-    if (land.exitCode !== 0) throw new Error(land.stderr || land.stdout || "git merge --ff-only refused the landing")
-  } catch (error) {
-    const message = `squash-merge: landing ${baseRef} at ${candidateSha.slice(0, 8)} failed (${error instanceof Error ? error.message : String(error)}) — the base is unadvanced; run \`convoy close --resume\``
-    emit({ type: "step-failed", step: "squash-merge", message })
-    throw new Error(message)
-  }
-  await persistJournal(journalState, { phase: "landed", landingSha: candidateSha })
+    // Land (task 7.5): two distinct recorded stages. Stage 1 advances the base
+    // ref through an expected-old guarded ref transaction — the candidate's
+    // parent is the captured base, so only a pure fast-forward can succeed, and
+    // a base that moved after the candidate was built makes the expected-old
+    // value refuse instead of merging or forcing. Once the transaction
+    // succeeds, the landing has happened. Stage 2 materializes the base
+    // checkout with Git's guarded two-tree update — a separate stage whose
+    // failure is checkout recovery, never a claim that the base is unadvanced.
+    const baseNow = (await resolveCommit(baseRef, mainDir)) ?? ""
+    // Crash reconciliation: a ref that already carries this verified candidate
+    // is the interrupted attempt's own landing — never re-land, and never
+    // trust a foreign commit that merely shares the SHA spelling.
+    const refLanded = baseNow === landedSha && journal.candidateSha === landedSha
+    if (!refLanded && baseNow !== baseSha) {
+      const message = `squash-merge: ${baseRef} moved to ${baseNow.slice(0, 8)} while the close was in progress — run \`convoy close\` to re-sync against the new base`
+      emit({ type: "step-failed", step: "squash-merge", message })
+      throw new Error(message)
+    }
+    const mainStatus = await statusPorcelain(mainDir).catch(() => "unreadable")
+    if (mainStatus.trim() !== "") {
+      const message = "squash-merge: the main checkout has uncommitted changes — commit or stash them first, then run `convoy close --resume`"
+      emit({ type: "step-failed", step: "squash-merge", message })
+      throw new Error(message)
+    }
 
-  emit({ type: "step-completed", step: "squash-merge", detail: `landed ${candidateSha.slice(0, 8)} on ${baseRef}` })
-  const result: CloseResult = {
-    changeID: target.changeID,
-    branch: target.branch,
-    worktreeDir: target.worktreeDir,
-    baseRef,
-    disposition: "landed",
-    landing: { sha: candidateSha },
-  }
-  emit({ type: "result", result })
+    // Stage 1: the landing ref transaction.
+    if (!refLanded) {
+      try {
+        const land = await execFile("git", ["update-ref", "-m", "convoy: close landing", `refs/heads/${baseRef}`, landedSha, baseSha], { cwd: mainDir, allowFailure: true })
+        if (land.exitCode !== 0) {
+          throw new Error((land.stderr || land.stdout || "git update-ref refused the landing") + ` — the expected-old value ${baseSha.slice(0, 8)} no longer matches ${baseRef}`)
+        }
+      } catch (error) {
+        const message = `squash-merge: landing ${baseRef} at ${landedSha.slice(0, 8)} failed (${error instanceof Error ? error.message : String(error)}) — the base is unadvanced; run \`convoy close --resume\``
+        emit({ type: "step-failed", step: "squash-merge", message })
+        throw new Error(message)
+      }
+    }
+    // The landing stands as of the ref transaction; record it before
+    // materialization so a crash here reconciles the checkout, never re-lands.
+    await persistJournal(journalState, { phase: "landed", landingSha: landedSha, checkoutMaterialized: false })
+
+    // Stage 2: materialize the base checkout (guarded two-tree update — Git
+    // refuses to clobber any local change that differs between the trees; the
+    // clean-tree preflight guarantees there is nothing to lose).
+    try {
+      await materializeBaseCheckout(journalState, mainDir)
+    } catch (error) {
+      const message =
+        `squash-merge: the base ref ${baseRef} now carries the landing ${landedSha.slice(0, 8)}, but materializing the checkout failed ` +
+        `(${error instanceof Error ? error.message : String(error)}) — the landing stands; reconcile the main checkout, then run \`convoy close --resume\`. ` +
+        "Cleanup stays blocked until the checkout is reconciled."
+      emit({ type: "step-failed", step: "squash-merge", message })
+      throw new Error(message)
+    }
+    await persistJournal(journalState, { checkoutMaterialized: true })
+    await writeLandingReceipt(journalState, target, baseRef, baseSha, postArchiveTip, preparedTree, landedSha, mainDir)
+
+    emit({ type: "step-completed", step: "squash-merge", detail: `landed ${landedSha.slice(0, 8)} on ${baseRef}` })
+    const result: CloseResult = {
+      changeID: target.changeID,
+      branch: target.branch,
+      worktreeDir: target.worktreeDir,
+      baseRef,
+      disposition: "landed",
+      landing: { sha: landedSha },
+      ...(target.feature ? { featureId: target.feature.featureId } : {}),
+    }
+    emit({ type: "result", result })
+    return result
+  })
   return result
 }
 
 // --- journal handling ---------------------------------------------------------
+
+/**
+ * Stage 2 of the landing (task 7.5): materializes the base checkout onto the
+ * landed ref with Git's guarded two-tree update — it refuses to clobber any
+ * local change that differs between the trees — then verifies the checkout's
+ * tree is exactly the prepared feature tree and the checkout is clean.
+ */
+async function materializeBaseCheckout(journalState: CloseJournalState, mainDir: string): Promise<void> {
+  const materialize = await execFile("git", ["read-tree", "-u", "-m", "HEAD"], { cwd: mainDir, allowFailure: true })
+  if (materialize.exitCode !== 0) {
+    throw new Error((materialize.stderr || materialize.stdout || "git read-tree refused the checkout update").trim())
+  }
+  const headTree = await treeOf("HEAD", mainDir)
+  if (journalState.record.preparedTree && headTree !== journalState.record.preparedTree) {
+    throw new Error(`the base checkout's tree (${headTree?.slice(0, 8) ?? "?"}) does not match the prepared feature tree (${journalState.record.preparedTree.slice(0, 8)})`)
+  }
+  const afterStatus = await statusPorcelain(mainDir).catch(() => "unreadable")
+  if (afterStatus.trim() !== "") {
+    throw new Error("the base checkout reports uncommitted changes after the update")
+  }
+}
+
+/**
+ * The immutable identity-keyed receipt (task 7.3/D8): create-only, tied to
+ * the stable feature identity, the exact prepared feature tip, and the
+ * landing commit. Later attempts and cleanup consult it — never the branch
+ * spelling. Protected refs are created alongside (create-only).
+ */
+async function writeLandingReceipt(
+  journalState: CloseJournalState,
+  target: CloseTarget,
+  baseRef: string,
+  baseSha: string,
+  postArchiveTip: string,
+  preparedTree: string,
+  candidateSha: string,
+  mainDir: string,
+): Promise<void> {
+  if (!journalState.feature || !journalState.commonDir) return
+  const feature = journalState.feature
+  const receipt: LandingReceipt = {
+    schemaVersion: 1,
+    attemptId: journalState.record.attemptID,
+    featureId: feature.featureId,
+    repositoryId: feature.repositoryId,
+    associationRevision: feature.associationRevision,
+    branch: target.branch,
+    baseRef,
+    baseSha,
+    featureTip: postArchiveTip,
+    preparedTree,
+    candidateSha,
+    landingSha: candidateSha,
+    landingAt: Date.now(),
+  }
+  const created = await writeReceiptIfAbsent(journalState.commonDir, receipt)
+  if (!created) {
+    // An existing receipt for this attempt is verified, not overwritten.
+    const existing = await import("./feature-lifecycle/records").then((records) => records.readReceipt(journalState.commonDir!, feature.featureId, receipt.attemptId))
+    if (existing.status === "found" && existing.value.landingSha !== candidateSha) {
+      throw new Error(`close: receipt for attempt ${receipt.attemptId} already records landing ${existing.value.landingSha.slice(0, 8)} — refusing to overwrite immutable evidence`)
+    }
+  }
+  await protectFeatureRef(featureTipRefName(feature.featureId, receipt.attemptId), postArchiveTip, mainDir)
+  await protectFeatureRef(featureCandidateRefName(feature.featureId, receipt.attemptId), candidateSha, mainDir)
+}
 
 /**
  * Opens (or starts) the close journal for this attempt. A fresh close starts
@@ -597,7 +1048,7 @@ export async function runClose(input: CloseInput): Promise<CloseResult> {
  * base differs stops — the base moved, and the sequence must re-sync against
  * the new base rather than land a stale candidate (task 5.6).
  */
-type CloseJournalState = { record: CloseJournal; commonDir?: string }
+type CloseJournalState = { record: CloseJournal; commonDir?: string; feature?: FeatureRecord; repositoryId?: string }
 
 async function openJournal(
   commonDir: string | undefined,
@@ -613,16 +1064,26 @@ async function openJournal(
     const existing = await readCloseJournal(commonDir, target.branch, target.changeID)
     if (existing) {
       if (existing.baseSha !== baseSha) {
-        throw new Error(
-          `close resume: the base moved since this attempt was recorded (${existing.baseSha.slice(0, 8)} → ${baseSha.slice(0, 8)}) — ` +
-            "run `convoy close` without --resume to re-sync against the new base",
-        )
+        // The landing itself advances the base: a recorded landed candidate
+        // reachable from the new base reconciles instead of refusing (task
+        // 7.5/D8 — "even if the base advanced afterward"). Anything else is
+        // a genuine base move and must re-sync.
+        const landingStands =
+          existing.phase === "landed" && existing.candidateSha
+            ? await isLandingReachable(existing.candidateSha, baseRef, mainDir)
+            : false
+        if (!landingStands) {
+          throw new Error(
+            `close resume: the base moved since this attempt was recorded (${existing.baseSha.slice(0, 8)} → ${baseSha.slice(0, 8)}) — ` +
+              "run `convoy close` without --resume to re-sync against the new base",
+          )
+        }
       }
-      return { record: existing, commonDir }
+      return { record: existing, commonDir, ...(target.feature ? { feature: target.feature } : {}) }
     }
   }
 
-  const attemptID = `${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`
+  const attemptID = target.feature ? crypto.randomUUID() : `${Date.now().toString(36)}-${crypto.randomUUID().slice(0, 8)}`
   const journal: CloseJournal = {
     schemaVersion: 1,
     attemptID,
@@ -645,13 +1106,121 @@ async function openJournal(
     recordedAt: Date.now(),
     updatedAt: Date.now(),
   }
-  return { record, commonDir }
+  // The identity-keyed attempt journal is persisted before the first mutation
+  // (task 7.3): a fresh attempt under the feature's stable identity, so the
+  // intent survives crashes regardless of later renames or cleanup.
+  if (commonDir && target.feature) {
+    const attempt = attemptJournalFrom(record, target.feature, baseSha, attemptID)
+    await writeAttemptJournal(commonDir, attempt)
+    await recordCloseAttemptOnFeature(commonDir, target.feature, attemptID)
+  }
+  return { record, commonDir, ...(target.feature ? { feature: target.feature } : {}) }
+}
+
+/** Converts the legacy journal shape into its identity-keyed attempt form. */
+function attemptJournalFrom(journal: CloseJournal, feature: FeatureRecord, baseSha: string, attemptID: string): CloseAttemptJournal {
+  return {
+    schemaVersion: 1,
+    attemptId: attemptID,
+    featureId: feature.featureId,
+    repositoryId: feature.repositoryId,
+    associationRevision: feature.associationRevision,
+    phase: "prepared",
+    contracts: [{ changeId: journal.changeID, sourcePath: `openspec/changes/${journal.changeID}`, archiveCommitted: false }],
+    baseRef: journal.baseRef,
+    baseSha,
+    branch: journal.branch,
+    recordedAt: journal.recordedAt,
+    updatedAt: journal.updatedAt,
+  }
+}
+
+/** Appends the attempt id to the feature record's close-attempt pointers. */
+async function recordCloseAttemptOnFeature(commonDir: string, feature: FeatureRecord, attemptId: string): Promise<void> {
+  await withFeatureLock(join(commonDir, "convoy", "features", feature.featureId), async () => {
+    const current = await readFeatureRecord(commonDir, feature.featureId)
+    if (current.status !== "found") return
+    if (current.value.closeAttemptIds.includes(attemptId)) return
+    const updated: FeatureRecord = {
+      ...current.value,
+      closeAttemptIds: [...current.value.closeAttemptIds, attemptId],
+      updatedAt: Date.now(),
+    }
+    await writeFeatureRecord(commonDir, updated, current.value.associationRevision)
+  }).catch(() => {
+    // The attempt journal is the durable evidence; the pointer is best-effort.
+  })
 }
 
 async function persistJournal(state: CloseJournalState, patch: Partial<CloseJournal>): Promise<void> {
   Object.assign(state.record, patch, { updatedAt: Date.now() })
   if (!state.commonDir) return
   await writeCloseJournal(state.commonDir, { ...state.record })
+  // Mirror the transition into the identity-keyed attempt journal (task 7.3),
+  // so recovery reads current Git/artifact state plus the durable intent.
+  if (state.feature) {
+    const current = await readAttemptJournal(state.commonDir, state.feature.featureId, state.record.attemptID).catch(() => undefined)
+    const existing = current && current.status === "found" ? current.value : undefined
+    const attempt = existing
+      ? { ...existing, ...attemptPatchFrom(state.record), updatedAt: Date.now() }
+      : attemptJournalFrom(state.record, state.feature, state.record.baseSha, state.record.attemptID)
+    await writeAttemptJournal(state.commonDir, attempt).catch(() => {
+      // A failed mirror keeps the legacy journal authoritative for this phase;
+      // the landing receipt below is the immutable record that matters.
+    })
+  }
+}
+
+/** Maps legacy journal fields onto the attempt journal's phase/evidence fields. */
+function attemptPatchFrom(journal: CloseJournal): Partial<CloseAttemptJournal> {
+  const phaseMap: Record<CloseJournal["phase"], CloseAttemptJournal["phase"]> = {
+    prepared: "prepared",
+    candidate: "candidate",
+    landed: "landed",
+  }
+  return {
+    phase: phaseMap[journal.phase],
+    ...(journal.preSyncTip ? { preSyncTip: journal.preSyncTip } : {}),
+    ...(journal.postArchiveTip ? { postArchiveTip: journal.postArchiveTip } : {}),
+    ...(journal.preparedTree ? { preparedTree: journal.preparedTree } : {}),
+    ...(journal.messageContext ? { messageContext: journal.messageContext } : {}),
+    ...(journal.message ? { message: journal.message } : {}),
+    ...(journal.candidateSha ? { candidateSha: journal.candidateSha } : {}),
+    ...(journal.landingSha ? { landingSha: journal.landingSha } : {}),
+    ...(journal.checkoutMaterialized !== undefined ? { checkoutMaterialized: journal.checkoutMaterialized } : {}),
+  }
+}
+
+/**
+ * Persists the required canonical effects for a contract BEFORE the archive
+ * mutation (task 7.2): the snapshot survives later edits to the archived
+ * copy, so resume verification cannot be made vacuous.
+ */
+async function persistRequiredEffects(state: CloseJournalState, changeId: string, effects: Array<{ kind: "present" | "absent"; capability: string; name: string; scenarios: string[] }>): Promise<void> {
+  if (!state.commonDir || !state.feature) return
+  const current = await readAttemptJournal(state.commonDir, state.feature.featureId, state.record.attemptID).catch(() => undefined)
+  const attempt = current && current.status === "found" ? current.value : attemptJournalFrom(state.record, state.feature, state.record.baseSha, state.record.attemptID)
+  const updated: CloseAttemptJournal = {
+    ...attempt,
+    contracts: attempt.contracts.map((contract) =>
+      contract.changeId === changeId && !contract.requiredEffects ? { ...contract, requiredEffects: effects } : contract,
+    ),
+    updatedAt: Date.now(),
+  }
+  await writeAttemptJournal(state.commonDir, updated).catch(() => {
+    // A failed snapshot write blocks nothing here — the archive verification
+    // below still runs against the live effects; resume falls back to the
+    // archived copy's own deltas when no snapshot exists.
+  })
+}
+
+/** Reads the persisted required-effect snapshot for a contract. `[]` (the legitimate no-delta case) is distinct from `undefined` (no snapshot). */
+async function readAttemptRequiredEffects(state: CloseJournalState, changeId: string, commonDir: string | undefined): Promise<Array<{ kind: "present" | "absent"; capability: string; name: string; scenarios: string[] }> | undefined> {
+  if (!state.feature || !commonDir) return undefined
+  const current = await readAttemptJournal(commonDir, state.feature.featureId, state.record.attemptID).catch(() => undefined)
+  if (!current || current.status !== "found") return undefined
+  const contract = current.value.contracts.find((entry) => entry.changeId === changeId)
+  return contract?.requiredEffects
 }
 
 /**
@@ -867,8 +1436,15 @@ async function featureCommitSubjects(target: CloseTarget, baseSha: string): Prom
  * The remediation for a probably-merged-but-unarchived change: archive in the
  * main checkout, commit on the base branch, and nothing else — there is
  * nothing left to sync, squash-merge, or land (design D7).
+ *
+ * Task 7.9: the base-checkout copy is verified to correspond to the selected
+ * contract (a real change tree, never a husk; its delta effects must prove
+ * against the canonical specs, same as close) and the recorded archive source
+ * is persisted for registered features, so discovery prefers the archive over
+ * any unarchived copy the feature worktree still carries. Integration stays
+ * probably merged or pending — archive-on-main never claims integration.
  */
-export async function archiveChangeOnMain(input: { targetDir: string; changeID: string }): Promise<{ committed: boolean }> {
+export async function archiveChangeOnMain(input: { targetDir: string; changeID: string }): Promise<{ committed: boolean; archiveSource?: string }> {
   const { changeID } = input
   // Archive always lands on the base branch's checkout — the repo's main
   // worktree, not whatever directory the board happened to be launched from.
@@ -885,19 +1461,78 @@ export async function archiveChangeOnMain(input: { targetDir: string; changeID: 
   if (!(await exists(changeDir))) {
     throw new Error(`archive on main: change ${changeID} is not present under ${openspecDirName}/changes/ — nothing to archive`)
   }
+  // The base-checkout copy must be the real contract: a husk (no markdown)
+  // is not the operator's change and must not be archived as one.
+  const { collectDirRelativeMarkdown } = await import("./openspec")
+  const changeFiles = await collectDirRelativeMarkdown(changeDir, ".")
+  if (changeFiles.length === 0) {
+    throw new Error(`archive on main: ${openspecDirName}/changes/${changeID} carries no markdown artifacts (a husk) — locate the real change before archiving`)
+  }
+
+  // Capture the delta effects before the CLI runs and prove them against the
+  // canonical specs after it, exactly like close's archive step.
+  const { readDeltaSpecs, effectsForDeltas, verifyEffects } = await import("./feature-lifecycle/archive-verify")
+  const deltas = await readDeltaSpecs(changeDir)
+  const effects = effectsForDeltas(deltas.values())
 
   const archive = await execFile("openspec", ["archive", changeID, "--yes"], { cwd: targetDir, allowFailure: true })
   if (archive.exitCode !== 0) {
     throw new Error(`archive on main: openspec archive ${changeID} failed\n${archive.stderr || archive.stdout}`)
   }
 
+  if (effects.length > 0) {
+    const verification = await verifyEffects(targetDir, effects)
+    if (verification.unproven.length > 0) {
+      const reasons = verification.unproven.map((entry) => {
+        const name = entry.effect.kind === "no-effect" ? "(no canonical effect)" : entry.effect.name
+        const kind = entry.effect.kind === "no-effect" ? "effect" : entry.effect.kind === "requirement-absent" ? "absent" : "present"
+        return `  ${kind} ${entry.effect.capability}/${name}: ${entry.reason}`
+      })
+      throw new Error(
+        `archive on main: the archived result does not prove every delta effect in the canonical specs — reconcile through OpenSpec before committing\n${reasons.join("\n")}`,
+      )
+    }
+  }
+
   await execFile("git", ["add", openspecDirName], { cwd: targetDir })
   const staged = await execFile("git", ["diff", "--cached", "--quiet"], { cwd: targetDir, allowFailure: true })
   if (staged.exitCode === 0) {
-    return { committed: false }
+    return { committed: false, archiveSource: join(openspecDirName, "changes", "archive", changeID) }
   }
   await commitAsUser(`chore(openspec): archive ${changeID}`, targetDir)
-  return { committed: true }
+
+  // Record the archive source for a registered feature (task 7.9): the
+  // contract's source becomes the verified archive, so discovery stops
+  // reporting the feature worktree's stale active copy as current work.
+  const commonDir = await lifecycleCommonDir(input.targetDir)
+  if (commonDir) {
+    const resolution = await resolveFeature({ cwd: input.targetDir, commonDir, changeId: changeID }).catch(() => undefined)
+    if (resolution?.status === "verified") {
+      const feature = resolution.feature
+      await withFeatureLock(join(commonDir, "convoy", "features", feature.featureId), async () => {
+        const current = await readFeatureRecord(commonDir, feature.featureId)
+        if (current.status !== "found") return
+        const revision = current.value.associationRevision + 1
+        const updated: FeatureRecord = {
+          ...current.value,
+          associationRevision: revision,
+          contracts: current.value.contracts.map((contract) =>
+            contract.changeId === changeID && contract.kind === "active"
+              ? { ...contract, kind: "archive" as const, sourcePath: join(openspecDirName, "changes", "archive", changeID), selectedAtRevision: revision }
+              : contract,
+          ),
+          history: [...current.value.history, { at: Date.now(), kind: "revised" as const, summary: `archive on main recorded for ${changeID}`, revision }],
+          updatedAt: Date.now(),
+        }
+        await writeFeatureRecord(commonDir, updated, current.value.associationRevision)
+      }).catch(() => {
+        // The archive commit is durable; a conflicting association update is
+        // surfaced as a warning rather than failing the completed archive.
+      })
+    }
+  }
+
+  return { committed: true, archiveSource: join(openspecDirName, "changes", "archive", changeID) }
 }
 
 /** The base ref the close sequence syncs and lands against. */
@@ -908,10 +1543,49 @@ export async function closeBaseRef(targetDir: string): Promise<string> {
 }
 
 /**
+ * The verified identity-keyed receipt for a feature (task 7.3/D8): counts
+ * only when the landing commit is still reachable from the intended base and
+ * the feature tip is unchanged. Everything else is no evidence at all.
+ */
+async function verifiedIdentityReceipt(
+  commonDir: string,
+  feature: FeatureRecord,
+  baseRef: string,
+  cwd: string,
+): Promise<{ landingSha: string; featureTip: string } | undefined> {
+  const receipt = await latestVerifiedReceipt(commonDir, feature.featureId, cwd)
+  return receipt ? { landingSha: receipt.landingSha, featureTip: receipt.featureTip } : undefined
+}
+
+/**
+ * The latest verified identity-keyed receipt (task 7.3/D8): full receipt
+ * evidence for surfaces that must name the branch and base it recorded —
+ * the worktree-less resume and cleanup. Counts only when the landing commit
+ * is still reachable from the receipt's base and the feature tip is
+ * unchanged (a deleted branch counts as unchanged: the landing already
+ * happened and the tip cannot move).
+ */
+async function latestVerifiedReceipt(commonDir: string, featureId: string, cwd: string): Promise<LandingReceipt | undefined> {
+  let verified: LandingReceipt | undefined
+  for (const attemptId of await listReceiptIds(commonDir, featureId)) {
+    const read = await readReceipt(commonDir, featureId, attemptId)
+    if (read.status !== "found") continue
+    const receipt = read.value
+    if (!(await featureLandingReachable(receipt.landingSha, receipt.baseRef, cwd))) continue
+    const tip = (await resolveCommit(receipt.branch, cwd).catch(() => undefined)) ?? undefined
+    if (tip !== undefined && tip !== receipt.featureTip) continue
+    verified = receipt
+  }
+  return verified
+}
+
+/**
  * The verified landing receipt for a branch/change, resolved by callers that
- * gate cleanup on evidence (design D7, task 6.3): a receipt counts only when
- * its landing commit is still reachable from the base branch. Everything else
- * (no receipt, stale tip, unreachable landing) is no evidence at all.
+ * gate cleanup on evidence (design D7, task 6.3): identity-keyed receipts are
+ * consulted first (they survive renames and reused branch names); the legacy
+ * branch/change journal remains readable for unassociated work (design D10).
+ * A receipt counts only when its landing commit is still reachable from the
+ * base branch.
  */
 export async function verifiedCloseReceipt(
   targetDir: string,
@@ -920,9 +1594,18 @@ export async function verifiedCloseReceipt(
 ): Promise<{ landingSha: string; postArchiveTip: string } | undefined> {
   const commonDir = await closeCommonDir(targetDir)
   if (!commonDir) return undefined
+  const mainDir = (await mainWorktreeDir(targetDir).catch(() => undefined)) ?? targetDir
+
+  // Identity-keyed first: resolve the feature by branch+change through the
+  // shared resolver and verify its receipts against current Git evidence.
+  const resolution = await resolveFeature({ cwd: targetDir, commonDir, branch, changeId: changeID }).catch(() => undefined)
+  if (resolution?.status === "verified") {
+    const identity = await verifiedIdentityReceipt(commonDir, resolution.feature, resolution.feature.intendedBaseRef, mainDir)
+    if (identity) return { landingSha: identity.landingSha, postArchiveTip: identity.featureTip }
+  }
+
   const journal = await readCloseJournal(commonDir, branch, changeID)
   if (!journal || journal.phase !== "landed" || !journal.landingSha || !journal.postArchiveTip) return undefined
-  const mainDir = (await mainWorktreeDir(targetDir).catch(() => undefined)) ?? targetDir
   if (!(await isLandingReachable(journal.landingSha, journal.baseRef, mainDir))) return undefined
   return { landingSha: journal.landingSha, postArchiveTip: journal.postArchiveTip }
 }
@@ -933,6 +1616,174 @@ async function exists(path: string): Promise<boolean> {
     return true
   } catch {
     return false
+  }
+}
+
+/** Quotes a token for the shell only when it would otherwise break out of a bare word. */
+function shq(value: string): string {
+  return /^[A-Za-z0-9_./:=@-]+$/.test(value) ? value : `'${value.replace(/'/g, `'\\''`)}'`
+}
+
+// ── the repository mutation lease (design D9, SC-5) ────────────────────────
+
+/**
+ * Runs one close mutation segment under the repository mutation lease. Close
+ * never holds the lease while waiting for message review — the prepare
+ * segment persists its journal and releases, the message gate runs unlocked,
+ * and the landing segment reacquires with fresh revalidation. An unavailable
+ * lease fails the segment closed (the operator retries once the other convoy
+ * operation finishes); an unresolvable common dir refuses entirely, because
+ * there would be no shared lock location to serialize against.
+ */
+async function withCloseLease<T>(commonDir: string | undefined, fn: () => Promise<T>): Promise<T> {
+  if (!commonDir) {
+    throw new Error("close: couldn't resolve the repository's git common dir — refusing to mutate without the repository mutation lease")
+  }
+  let lease: MutationLease
+  try {
+    lease = await acquireMutationLease(commonDir)
+  } catch (error) {
+    const reason = error instanceof LeaseUnavailableError ? error.message : `couldn't acquire the repository mutation lease: ${String(error)}`
+    throw new Error(`close: ${reason}`)
+  }
+  try {
+    return await fn()
+  } finally {
+    await lease.release()
+  }
+}
+
+// ── cleanup-only continuation (design D9, task 7.7) ────────────────────────
+
+/**
+ * The feature-keyed cleanup executor: `convoy close --feature <id> --cleanup
+ * worktree|branch`. This is the same guarded operation the TUI follow-ups and
+ * the headless printed commands perform — never an unprotected check-then-
+ * force-delete recipe. Every fact is revalidated at action time from current
+ * Git evidence:
+ *
+ * - a verified identity receipt must name the feature (landing reachable from
+ *   its recorded base, feature tip unchanged);
+ * - no unresolved close attempt may be pending;
+ * - worktree removal requires an existing, clean, non-main worktree with no
+ *   live run, and Git's non-forced removal protections stay effective;
+ * - branch deletion requires no registered worktree to check the branch out
+ *   and runs the atomic expected-tip ref deletion, so a branch that moved
+ *   between the check and the deletion refuses.
+ *
+ * Returns the human-readable outcome; throws with the concrete blocker when
+ * any guard refuses.
+ */
+export async function runCloseCleanup(input: CloseInput): Promise<string> {
+  if (!input.featureId) throw new Error("cleanup requires --feature <feature-id> — cleanup is feature-keyed, never branch-keyed (design D9)")
+  if (input.cleanup !== "worktree" && input.cleanup !== "branch") throw new Error(`cleanup must be "worktree" or "branch"`)
+  const mainDir = (await mainWorktreeDir(input.targetDir).catch(() => undefined)) ?? input.targetDir
+  const commonDir = await closeCommonDir(input.targetDir)
+  if (!commonDir) throw new Error("cleanup: no git repository — no landing evidence can resolve")
+
+  const read = await readFeatureRecord(commonDir, input.featureId)
+  if (read.status !== "found") throw new Error(`cleanup: feature ${input.featureId} could not be resolved (${read.status}) — run \`convoy feature show\``)
+  const feature = read.value
+
+  // Unresolved attempts block cleanup until reconciled (design D9: "verify no
+  // live run/recovery").
+  for (const attemptId of await listAttemptIds(commonDir, feature.featureId)) {
+    const journal = await readAttemptJournal(commonDir, feature.featureId, attemptId)
+    if (journal.status === "found" && journal.value.phase !== "landed") {
+      throw new Error(`cleanup: close attempt ${attemptId.slice(0, 8)} is still unresolved — run \`convoy close --feature ${input.featureId} --resume\` to reconcile it first`)
+    }
+  }
+
+  const receipt = await latestVerifiedReceipt(commonDir, feature.featureId, mainDir)
+  if (!receipt) {
+    throw new Error(await cleanupReceiptBlocker(commonDir, feature.featureId, mainDir))
+  }
+  const branch = receipt.branch
+  const tipNow = (await resolveCommit(branch, mainDir).catch(() => undefined)) ?? undefined
+  if (tipNow !== undefined && tipNow !== receipt.featureTip) {
+    throw new Error(`cleanup: ${branch}'s tip moved past the landed state (${receipt.featureTip.slice(0, 8)}) — inspect the branch before removing anything`)
+  }
+
+  // The execution is a repository mutation (design D9): it runs under the
+  // mutation lease, with the final context checks re-read inside the lease
+  // window so the last-read-then-mutate gap is serialized against every
+  // other convoy operation.
+  return withCloseLease(commonDir, async () => {
+    if (input.cleanup === "worktree") {
+      const worktreeDir = input.worktreeDir ?? (await findWorktreeDirForBranch(branch, input.targetDir)) ?? undefined
+      if (!worktreeDir) throw new Error(`cleanup: ${branch} has no registered worktree left — nothing to remove (branch cleanup is the remaining step)`)
+      const isMain = (await resolveSame(mainDir, worktreeDir)) === true
+      if (isMain) throw new Error(`cleanup: ${worktreeDir} is the main checkout — it is never removed`)
+      const status = await statusPorcelain(worktreeDir).catch(() => "unreadable")
+      if (status.trim() !== "") {
+        throw new Error(`cleanup: the worktree at ${worktreeDir} has uncommitted changes — commit or stash them first; removal refuses dirty contexts`)
+      }
+      const live = await liveRunsAt(worktreeDir)
+      if (live.kind === "unknown") throw new Error(`cleanup: couldn't verify live runs (${live.reason}) — refusing removal while run state is unreadable`)
+      if (live.value > 0) throw new Error(`cleanup: ${live.value} live run${live.value === 1 ? " is" : "s are"} attached to ${worktreeDir} — wait for or stop ${live.value === 1 ? "it" : "them"} first`)
+      await removeWorktree(worktreeDir, mainDir)
+      return `removed the feature worktree at ${worktreeDir} (landing ${receipt.landingSha.slice(0, 8)} verified) — branch deletion is the remaining step: convoy close --feature ${input.featureId} --cleanup branch`
+    }
+
+    // Branch deletion: no registered worktree may have the branch checked out
+    // (Git's inventory decides — never a path guess), then the atomic
+    // expected-tip ref deletion.
+    const list = await execFile("git", ["worktree", "list", "--porcelain"], { cwd: mainDir, allowFailure: true })
+    if (list.exitCode !== 0) throw new Error("cleanup: couldn't read the worktree inventory — refusing to delete the branch while registration is unverifiable")
+    if (list.stdout.split("\n").includes(`branch refs/heads/${branch}`)) {
+      throw new Error(`cleanup: ${branch} is checked out in a registered worktree — remove that worktree first (convoy close --feature ${input.featureId} --cleanup worktree)`)
+    }
+    if (tipNow === undefined) {
+      return `${branch} no longer exists locally — nothing to delete (feature ${feature.featureId}'s landing evidence is retained)`
+    }
+    const result = await execFile("git", ["update-ref", "-d", `refs/heads/${branch}`, receipt.featureTip], { cwd: mainDir, allowFailure: true })
+    if (result.exitCode !== 0) {
+      throw new Error((result.stderr || `the expected-tip deletion of ${branch} was refused`).trim())
+    }
+    return `deleted the local ${branch} branch at its landed tip ${receipt.featureTip.slice(0, 8)} (landing ${receipt.landingSha.slice(0, 8)} verified)`
+  })
+}
+
+/**
+ * Diagnoses why no verified receipt authorizes cleanup, so the refusal names
+ * the actual fact (stale tip, unreachable landing, or no receipt at all)
+ * instead of a generic "unauthorized".
+ */
+async function cleanupReceiptBlocker(commonDir: string, featureId: string, mainDir: string): Promise<string> {
+  const receipts: LandingReceipt[] = []
+  for (const attemptId of await listReceiptIds(commonDir, featureId)) {
+    const read = await readReceipt(commonDir, featureId, attemptId)
+    if (read.status === "found") receipts.push(read.value)
+  }
+  if (receipts.length === 0) {
+    return (
+      `cleanup: no verified landing receipt names feature ${featureId} — cleanup requires the receipt a completed close recorded ` +
+      "(landing commit reachable from the base and an unchanged feature tip)"
+    )
+  }
+  for (const receipt of receipts) {
+    const tip = (await resolveCommit(receipt.branch, mainDir).catch(() => undefined)) ?? undefined
+    if (tip !== undefined && tip !== receipt.featureTip) {
+      return `cleanup: ${receipt.branch}'s tip moved past the landed state (${receipt.featureTip.slice(0, 8)}) — inspect the branch before removing anything`
+    }
+    if (!(await featureLandingReachable(receipt.landingSha, receipt.baseRef, mainDir))) {
+      return `cleanup: the recorded landing ${receipt.landingSha.slice(0, 8)} is no longer reachable from ${receipt.baseRef} — inspect the history before removing anything`
+    }
+  }
+  return `cleanup: feature ${featureId}'s landing evidence does not authorize cleanup — inspect \`convoy feature show\``
+}
+
+/** The live-run count at a checkout, typed so unreadable state is never "none". */
+async function liveRunsAt(worktreeDir: string): Promise<{ kind: "known"; value: number } | { kind: "unknown"; reason: string }> {
+  try {
+    const runs = await listRuns()
+    let count = 0
+    for (const run of runs) {
+      if (run.live && run.targetDir && (await resolveSame(run.targetDir, worktreeDir))) count += 1
+    }
+    return { kind: "known", value: count }
+  } catch (error) {
+    return { kind: "unknown", reason: error instanceof Error ? error.message : String(error) }
   }
 }
 

--- a/src/feature-lifecycle/adapters.ts
+++ b/src/feature-lifecycle/adapters.ts
@@ -1,0 +1,144 @@
+import { readFile, realpath } from "node:fs/promises"
+import { isAbsolute, join, relative, resolve } from "node:path"
+
+import { branchUpstream, execFile, findWorktreeDirForBranch, statusPorcelain } from "../git"
+import { listRuns, type RunEntry } from "../runs"
+import { openspecDirName, collectDirRelativeMarkdown } from "../openspec"
+
+/**
+ * Structured read adapters (capability `feature-lifecycle`, design D5, task
+ * 2.2): thin wrappers around Git, run-history, and artifact reads that return
+ * typed observations — including explicit unknown/unreadable states. A
+ * run-discovery failure is `unknown`, never an empty live-run set; a Git
+ * status failure is unreadable, never "clean". Everything above the adapters
+ * reasons over the typed results, so no consumer can accidentally treat a
+ * read failure as a negative fact.
+ */
+
+export type Observation<T> = { kind: "known"; value: T } | { kind: "unknown"; reason: string }
+
+export function known<T>(value: T): Observation<T> {
+  return { kind: "known", value }
+}
+
+export function unknown<T = never>(reason: string): Observation<T> {
+  return { kind: "unknown", reason }
+}
+
+export function isKnown<T>(observation: Observation<T>): observation is { kind: "known"; value: T } {
+  return observation.kind === "known"
+}
+
+/** Run history with liveness; `unknown` when the history cannot be read. */
+export async function observeRuns(): Promise<Observation<RunEntry[]>> {
+  try {
+    return known(await listRuns())
+  } catch (error) {
+    return unknown(error instanceof Error ? error.message : String(error))
+  }
+}
+
+/** Live run IDs attached to a worktree path (realpath-compared). */
+export async function observeLiveRunsAt(targetDir: string): Promise<Observation<string[]>> {
+  const entries = await observeRuns()
+  if (entries.kind === "unknown") return entries
+  let resolvedTarget: string
+  try {
+    resolvedTarget = await realpath(targetDir)
+  } catch {
+    resolvedTarget = resolve(targetDir)
+  }
+  const live: string[] = []
+  for (const entry of entries.value) {
+    if (!entry.live || !entry.targetDir) continue
+    let same = false
+    try {
+      same = (await realpath(entry.targetDir)) === resolvedTarget
+    } catch {
+      same = resolve(entry.targetDir) === resolvedTarget
+    }
+    if (same) live.push(entry.runID)
+  }
+  return known(live)
+}
+
+/** Git status porcelain; `unknown` when unreadable (never the empty string). */
+export async function observeStatus(dir: string): Promise<Observation<string>> {
+  try {
+    return known(await statusPorcelain(dir))
+  } catch (error) {
+    return unknown(error instanceof Error ? error.message : String(error))
+  }
+}
+
+/** The branch checked out at `dir`; unknown on a detached/unreadable HEAD is surfaced. */
+export async function observeBranch(dir: string): Promise<Observation<string | undefined>> {
+  const result = await execFile("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd: dir, allowFailure: true })
+  if (result.exitCode !== 0) return unknown(result.stderr || "git rev-parse failed")
+  const branch = result.stdout.trim()
+  return known(branch === "HEAD" ? undefined : branch)
+}
+
+/** Where a branch is checked out, via Git's own inventory (never a path guess). */
+export async function observeWorktreeForBranch(branch: string, cwd: string): Promise<Observation<string | undefined>> {
+  try {
+    return known((await findWorktreeDirForBranch(branch, cwd)) ?? undefined)
+  } catch (error) {
+    return unknown(error instanceof Error ? error.message : String(error))
+  }
+}
+
+/**
+ * Task counts for one change: from the OpenSpec CLI when it answers, from
+ * checkbox parsing otherwise, `unknown` when neither can read the tree
+ * (design D5 — the fallback chain stays; failure is never "0 tasks").
+ */
+export async function observeTaskCounts(dir: string): Promise<Observation<ReadonlyMap<string, { done: number; total: number }>>> {
+  const { openspecTaskCounts } = await import("../control-board")
+  try {
+    return known(await openspecTaskCounts(dir))
+  } catch (error) {
+    return unknown(error instanceof Error ? error.message : String(error))
+  }
+}
+
+/** Reads a change's markdown files relative to its root. */
+export async function observeChangeFiles(checkoutDir: string, changeId: string): Promise<Observation<string[]>> {
+  try {
+    return known(await collectDirRelativeMarkdown(join(checkoutDir, openspecDirName, "changes", changeId), "."))
+  } catch (error) {
+    return unknown(error instanceof Error ? error.message : String(error))
+  }
+}
+
+/** Reads one file as text, typed. */
+export async function observeFileText(path: string): Promise<Observation<string>> {
+  try {
+    return known(await readFile(path, "utf8"))
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code
+    if (code === "ENOENT") return unknown("file does not exist")
+    return unknown(error instanceof Error ? error.message : String(error))
+  }
+}
+
+/**
+ * Whether a candidate path resolves inside `root` without escaping through
+ * `..` (symlink escape is checked by the caller via realpath where it
+ * matters — archive verification resolves real paths before reading).
+ */
+export function relativeWithin(root: string, candidate: string): string | undefined {
+  if (candidate === "" || isAbsolute(candidate)) return undefined
+  const rel = relative(resolve(root), resolve(join(root, candidate)))
+  if (rel === "" || rel.startsWith("..")) return undefined
+  return rel.split("\\").join("/")
+}
+
+/** The upstream of a branch, factually observed (never interpreted). */
+export async function observeUpstream(branch: string, cwd: string): Promise<Observation<string | undefined>> {
+  try {
+    return known(await branchUpstream(branch, cwd).catch(() => undefined))
+  } catch (error) {
+    return unknown(error instanceof Error ? error.message : String(error))
+  }
+}

--- a/src/feature-lifecycle/archive-verify.ts
+++ b/src/feature-lifecycle/archive-verify.ts
@@ -1,0 +1,309 @@
+import { readFile } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
+
+import type { RequiredEffect } from "./records"
+
+/**
+ * Deterministic archive-effect verification (capability `feature-lifecycle`,
+ * design D7, task 2.4): proves that a change's delta specs are represented in
+ * the canonical specs — ADDED/MODIFIED requirement blocks present with their
+ * scenarios, REMOVED blocks absent, RENAMED sources gone and destinations
+ * present — over full capability paths, by structural Markdown comparison
+ * only. No LLM guesses, no "looks archived" heuristics: unprovable effects
+ * are reported, never assumed.
+ *
+ * This is verification only; the OpenSpec CLI remains the artifact writer.
+ */
+
+export type DeltaOperation = "ADDED" | "MODIFIED" | "REMOVED" | "RENAMED"
+
+export type DeltaRequirement = {
+  operation: DeltaOperation
+  /** The full requirement name, e.g. `Worktree location resolution order`. */
+  name: string
+  /** The requirement's `#### Scenario:` names, for ADDED/MODIFIED presence checks. */
+  scenarios: string[]
+  /** RENAMED only: the requirement's former name. */
+  renamedFrom?: string
+  /** The whole requirement block, normalized for comparison. */
+  body: string
+}
+
+export type DeltaSpec = {
+  /** The capability path relative to the change's specs/ dir, e.g. `control-board`. */
+  capability: string
+  operations: DeltaRequirement[]
+}
+
+/** A canonical-spec effect a delta demands (design D7 item 3). */
+export type CanonicalEffect =
+  | { kind: "requirement-present"; capability: string; name: string; scenarios: readonly string[] }
+  | { kind: "requirement-absent"; capability: string; name: string }
+  | { kind: "no-effect"; capability: string }
+
+/**
+ * Parses one delta spec body into its requirement operations. Recognizes the
+ * OpenSpec delta layout: `## ADDED Requirements`, `## MODIFIED Requirements`,
+ * `## REMOVED Requirements`, `## RENAMED Requirements`, each containing
+ * `### Requirement: <name>` blocks with `#### Scenario:` subsections. RENAMED
+ * blocks may carry `- FROM: <old>` / `- TO: <new>` lines.
+ */
+export function parseDeltaSpec(body: string): DeltaRequirement[] {
+  const operations: DeltaRequirement[] = []
+  const sectionPattern = /^##\s+(ADDED|MODIFIED|REMOVED|RENAMED)\s+Requirements\s*$/gim
+  const sections: Array<{ operation: DeltaOperation; start: number; headerEnd: number }> = []
+  let match: RegExpExecArray | null
+  while ((match = sectionPattern.exec(body)) !== null) {
+    sections.push({ operation: match[1] as DeltaOperation, start: match.index, headerEnd: match.index + match[0].length })
+  }
+  for (let index = 0; index < sections.length; index += 1) {
+    const section = sections[index]!
+    const nextStart = index + 1 < sections.length ? sections[index + 1]!.start : body.length
+    const sectionBody = body.slice(section.headerEnd, nextStart)
+    const requirementPattern = /^###\s+Requirement:\s*(.+)$/gm
+    const requirements: Array<{ name: string; start: number; headerEnd: number }> = []
+    let requirementMatch: RegExpExecArray | null
+    while ((requirementMatch = requirementPattern.exec(sectionBody)) !== null) {
+      requirements.push({ name: requirementMatch[1]!.trim(), start: requirementMatch.index, headerEnd: requirementMatch.index + requirementMatch[0].length })
+    }
+    // RENAMED sections may declare the FROM/TO bullets in the section
+    // preamble, before the first requirement header (OpenSpec's layout).
+    const preamble = sectionBody.slice(0, requirements[0]?.start ?? sectionBody.length)
+    const preambleFrom = section.operation === "RENAMED" ? preamble.match(/^[-*]\s+FROM:\s*(.+)$/m)?.[1] : undefined
+    for (let rIndex = 0; rIndex < requirements.length; rIndex += 1) {
+      const requirement = requirements[rIndex]!
+      const rNextStart = rIndex + 1 < requirements.length ? requirements[rIndex + 1]!.start : sectionBody.length
+      const requirementBody = sectionBody.slice(requirement.headerEnd, rNextStart)
+      const scenarios = [...requirementBody.matchAll(/^#{2,4}\s+Scenario:\s*(.+)$/gm)].map((entry) => entry[1]!.trim())
+      let renamedFrom: string | undefined
+      if (section.operation === "RENAMED") {
+        const from = requirementBody.match(/^[-*]\s+FROM:\s*(.+)$/m)?.[1] ?? preambleFrom
+        if (from) renamedFrom = normalizeRenamedName(from.trim())
+      }
+      operations.push({
+        operation: section.operation,
+        name: requirement.name,
+        scenarios,
+        ...(renamedFrom ? { renamedFrom } : {}),
+        body: normalizeBlock(requirementBody),
+      })
+    }
+  }
+  return operations
+}
+
+/** `- FROM: \`### Requirement: Old name\`` → `Old name` (backticks and heading prefix stripped). */
+function normalizeRenamedName(raw: string): string {
+  return raw
+    .replace(/^`+|`+$/g, "")
+    .replace(/^#+\s*Requirement:\s*/i, "")
+    .trim()
+}
+
+/** Normalizes a block for structural comparison: strip headings, blank runs, trailing space. */
+function normalizeBlock(block: string): string {
+  return block
+    .split("\n")
+    .filter((line) => !/^#{2,4}\s+(Requirement:|Scenario:)/i.test(line))
+    .map((line) => line.replace(/\s+$/g, ""))
+    .join("\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
+}
+
+/** Splits a canonical spec's requirements into named blocks with their raw bodies (scenario headings intact). */
+export function parseCanonicalRequirements(body: string): Map<string, string> {
+  const out = new Map<string, string>()
+  const pattern = /^###\s+Requirement:\s*(.+)$/gm
+  const requirements: Array<{ name: string; headerEnd: number; start: number }> = []
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(body)) !== null) {
+    requirements.push({ name: match[1]!.trim(), start: match.index, headerEnd: match.index + match[0].length })
+  }
+  for (let index = 0; index < requirements.length; index += 1) {
+    const requirement = requirements[index]!
+    const nextStart = index + 1 < requirements.length ? requirements[index + 1]!.start : body.length
+    // Raw slice: scenario headings must survive so presence checks can read them.
+    out.set(requirement.name, body.slice(requirement.headerEnd, nextStart).trim())
+  }
+  return out
+}
+
+/** Reads a change's delta specs into parsed operations, walking `specs/<capability>/spec.md`. */
+export async function readDeltaSpecs(changeDir: string): Promise<Map<string, DeltaSpec>> {
+  const { collectDirRelativeMarkdown } = await import("../openspec")
+  const specsRoot = join(changeDir, "specs")
+  const files = await collectDirRelativeMarkdown(specsRoot, ".")
+  const out = new Map<string, DeltaSpec>()
+  for (const file of files) {
+    const capability = capabilityFromDeltaPath(file)
+    if (!capability) continue
+    const body = await readFile(join(specsRoot, file), "utf8").catch(() => undefined)
+    if (body === undefined) continue
+    const existing = out.get(capability)
+    const operations = parseDeltaSpec(body)
+    out.set(capability, { capability, operations: existing ? [...existing.operations, ...operations] : operations })
+  }
+  return out
+}
+
+/** `specs/<capability>/spec.md` (possibly nested) → the capability path. */
+export function capabilityFromDeltaPath(relativePath: string): string | undefined {
+  const normalized = relativePath.split("\\").join("/")
+  const match = normalized.match(/^(.+)\/spec\.md$/)
+  if (!match) return undefined
+  return match[1]!
+}
+
+/**
+ * Expands parsed deltas into the canonical effects they demand, per
+ * capability, in the order the deltas declare them (design D7: ADDED /
+ * MODIFIED blocks and scenarios must appear; REMOVED must be absent; RENAMED
+ * must have the source absent and destination present).
+ */
+export function effectsForDeltas(deltas: Iterable<DeltaSpec>): CanonicalEffect[] {
+  const effects: CanonicalEffect[] = []
+  for (const delta of deltas) {
+    for (const operation of delta.operations) {
+      if (operation.operation === "ADDED" || operation.operation === "MODIFIED") {
+        effects.push({ kind: "requirement-present", capability: delta.capability, name: operation.name, scenarios: operation.scenarios })
+      } else if (operation.operation === "REMOVED") {
+        effects.push({ kind: "requirement-absent", capability: delta.capability, name: operation.name })
+      } else if (operation.operation === "RENAMED") {
+        if (operation.renamedFrom) effects.push({ kind: "requirement-absent", capability: delta.capability, name: operation.renamedFrom })
+        effects.push({ kind: "requirement-present", capability: delta.capability, name: operation.name, scenarios: operation.scenarios })
+      }
+    }
+  }
+  return effects
+}
+
+export type EffectVerification = {
+  proven: CanonicalEffect[]
+  unproven: Array<{ effect: CanonicalEffect; reason: string }>
+}
+
+/**
+ * Verifies effects against the canonical spec files under
+ * `<targetDir>/openspec/specs/` (task 2.4): a present-effect is proven when
+ * the canonical spec carries the requirement with every declared scenario
+ * name; an absent-effect is proven when the requirement is gone (or the
+ * whole capability file is gone). Structural only — body text differences
+ * within a requirement are not proof of anything either way.
+ */
+export async function verifyEffects(targetDir: string, effects: readonly CanonicalEffect[]): Promise<EffectVerification> {
+  const { stripYamlFrontmatter } = await import("../openspec")
+  const canonicalCache = new Map<string, Map<string, string> | undefined>()
+  const loadCanonical = async (capability: string): Promise<Map<string, string> | undefined> => {
+    const cached = canonicalCache.get(capability)
+    if (cached) return cached
+    const path = join(targetDir, "openspec", "specs", capability, "spec.md")
+    const body = await readFile(path, "utf8").catch(() => undefined)
+    if (body === undefined) {
+      canonicalCache.set(capability, undefined)
+      return undefined
+    }
+    const parsed = parseCanonicalRequirements(stripYamlFrontmatter(body))
+    canonicalCache.set(capability, parsed)
+    return parsed
+  }
+
+  const proven: CanonicalEffect[] = []
+  const unproven: EffectVerification["unproven"] = []
+  for (const effect of effects) {
+    if (effect.kind === "no-effect") {
+      proven.push(effect)
+      continue
+    }
+    const canonical = await loadCanonical(effect.capability)
+    if (effect.kind === "requirement-absent") {
+      if (canonical === undefined || !canonical.has(effect.name)) proven.push(effect)
+      else unproven.push({ effect, reason: `canonical spec ${effect.capability} still contains requirement "${effect.name}"` })
+      continue
+    }
+    if (canonical === undefined) {
+      unproven.push({ effect, reason: `canonical spec ${effect.capability}/spec.md is missing` })
+      continue
+    }
+    const block = canonical.get(effect.name)
+    if (block === undefined) {
+      unproven.push({ effect, reason: `canonical spec ${effect.capability} lacks requirement "${effect.name}"` })
+      continue
+    }
+    const canonicalScenarios = new Set([...block.matchAll(/^#{2,4}\s+Scenario:\s*(.+)$/gm)].map((entry) => entry[1]!.trim()))
+    const missing = effect.scenarios.filter((scenario) => !canonicalScenarios.has(scenario))
+    if (missing.length > 0) {
+      unproven.push({ effect, reason: `canonical requirement "${effect.name}" is missing scenario(s): ${missing.join(", ")}` })
+      continue
+    }
+    proven.push(effect)
+  }
+  return { proven, unproven }
+}
+
+/**
+ * Composes overlapping contracts' effects (design D7: when several contracts
+ * touch the same requirement, verification is applied over the ordered
+ * composed effect with retained per-contract evidence). Composition rule:
+ * for one capability+requirement key, later contracts' operations dominate —
+ * REMOVED after MODIFIED wins (absent), MODIFIED/ADDED after REMOVED wins
+ * (present with scenarios). Composition happens per key; the caller keeps
+ * the per-contract evidence for the receipt.
+ */
+export function composeContractEffects(ordered: Array<{ changeId: string; deltas: Map<string, DeltaSpec> }>): { composed: CanonicalEffect[]; perContract: Array<{ changeId: string; effects: CanonicalEffect[] }> } {
+  const perContract = ordered.map(({ changeId, deltas }) => ({ changeId, effects: effectsForDeltas(deltas.values()) }))
+  const composedByKey = new Map<string, CanonicalEffect>()
+  for (const { effects } of perContract) {
+    for (const effect of effects) {
+      if (effect.kind === "no-effect") continue
+      // One key per requirement identity (capability + name): a later
+      // contract's operation — present or absent — replaces the earlier
+      // contract's effect on the same requirement.
+      const key = `${effect.capability}\0${effect.name}`
+      composedByKey.set(key, effect)
+    }
+  }
+  return { composed: [...composedByKey.values()], perContract }
+}
+
+/** Reads the canonical requirement block for inspection surfaces (remediation text). */
+export async function canonicalRequirementExcerpt(targetDir: string, capability: string, name: string): Promise<string | undefined> {
+  const path = join(resolve(targetDir), "openspec", "specs", capability, "spec.md")
+  const body = await readFile(path, "utf8").catch(() => undefined)
+  if (body === undefined) return undefined
+  const requirements = parseCanonicalRequirements(body)
+  const block = requirements.get(name)
+  return block ? block.split("\n").slice(0, 8).join("\n") : undefined
+}
+
+/** The directory a capability's canonical spec lives in (for remediation hints). */
+export function canonicalSpecDir(targetDir: string, capability: string): string {
+  return dirname(join(targetDir, "openspec", "specs", capability, "spec.md"))
+}
+
+/**
+ * Converts canonical effects into the persistable required-effect snapshot
+ * the attempt journal records before the archive mutation (task 7.2): resume
+ * validates against this snapshot, never against the archived copy.
+ */
+export function toRequiredEffects(effects: readonly CanonicalEffect[]): RequiredEffect[] {
+  const out: RequiredEffect[] = []
+  for (const effect of effects) {
+    if (effect.kind === "no-effect") continue
+    if (effect.kind === "requirement-present") {
+      out.push({ kind: "present", capability: effect.capability, name: effect.name, scenarios: [...effect.scenarios] })
+    } else {
+      out.push({ kind: "absent", capability: effect.capability, name: effect.name, scenarios: [] })
+    }
+  }
+  return out
+}
+
+/** The inverse of `toRequiredEffects`: a persisted snapshot back into verifiable canonical effects. */
+export function fromRequiredEffects(required: readonly RequiredEffect[]): CanonicalEffect[] {
+  return required.map((effect) =>
+    effect.kind === "present"
+      ? { kind: "requirement-present" as const, capability: effect.capability, name: effect.name, scenarios: effect.scenarios }
+      : { kind: "requirement-absent" as const, capability: effect.capability, name: effect.name },
+  )
+}

--- a/src/feature-lifecycle/assessment.ts
+++ b/src/feature-lifecycle/assessment.ts
@@ -1,0 +1,295 @@
+import type { FeatureRecord } from "./records"
+
+/**
+ * The pure lifecycle assessment (capability `feature-lifecycle`, design D5):
+ * a function over typed observations that derives orthogonal facts, the
+ * human summary, and the applicable actions. No I/O, no clocks, no mutation —
+ * every input is an observation the adapters gathered, so the same assessment
+ * serves the board, the specs viewer, the launcher, publication, and close
+ * (task 2.1/2.5).
+ *
+ * Facts are orthogonal and evidence-based (design D5): association validity,
+ * artifact state per contract, task completion, execution/liveness, local
+ * integration certainty, remote publication observations, and cleanup
+ * progress never imply one another. Unknown/unreadable evidence is modeled
+ * explicitly — it must never be flattened into "none" or "clean" (design D5:
+ * missing evidence is not success).
+ */
+
+/** Artifact/lifecycle state of one contract (design D5). */
+export type ContractState = "active" | "verified-archived" | "missing" | "ambiguous" | "unreadable"
+
+export type ContractObservation = {
+  changeId: string
+  state: ContractState
+  tasks?: { done: number; total: number } | "unknown"
+  /** Why the state is degraded, when it is. */
+  reason?: string
+}
+
+/** How the feature's implementation context verified (design D5). */
+export type ContextVerification = "verified" | "unassociated" | "ambiguous" | "missing" | "unreadable"
+
+export type ExecutionObservation =
+  | { kind: "known"; liveRunIds: readonly string[]; totalRuns: number }
+  | { kind: "unknown"; reason: string }
+
+export type IntegrationObservation = "pending" | "probable" | "verified" | "stale" | "unknown"
+
+export type PublicationObservation =
+  | { kind: "known"; upstream?: string; published: boolean }
+  | { kind: "unknown"; reason: string }
+
+export type CleanupObservation =
+  | { kind: "known"; worktreePresent: boolean; branchPresent: boolean }
+  | { kind: "unknown"; reason: string }
+
+export type LifecycleObservations = {
+  feature?: FeatureRecord
+  context: { verification: ContextVerification; branch?: string; checkoutPath?: string; reason?: string }
+  contracts: readonly ContractObservation[]
+  execution: ExecutionObservation
+  integration: IntegrationObservation
+  publication: PublicationObservation
+  cleanup: CleanupObservation
+}
+
+/** One applicable lifecycle action with its blockers and remediation (design D5). */
+export type LifecycleAction = {
+  id: "close" | "continue" | "adopt" | "bind" | "archive-on-main" | "push" | "cleanup-worktree" | "cleanup-branch" | "history" | "spin"
+  label: string
+  applicable: boolean
+  enabled: boolean
+  blockers: readonly string[]
+  remediation: readonly string[]
+  target?: { featureId: string }
+}
+
+export type LifecycleAssessment = {
+  /** The derived summary (design D5's table). */
+  summary: string
+  tasks?: { done: number; total: number } | "unknown"
+  liveRuns: number
+  contracts: readonly ContractObservation[]
+  integration: IntegrationObservation
+  actions: readonly LifecycleAction[]
+  /** True when the close-start prerequisites all pass (never implied by tasks alone). */
+  closeStartPrerequisitesPass: boolean
+  blockers: readonly string[]
+}
+
+/** A task count is only known when both numbers are non-negative integers. */
+function totalTasks(contracts: readonly ContractObservation[]): { done: number; total: number } | "unknown" {
+  let done = 0
+  let total = 0
+  let known = false
+  for (const contract of contracts) {
+    if (contract.tasks === "unknown" || contract.tasks === undefined) continue
+    known = true
+    done += contract.tasks.done
+    total += contract.tasks.total
+  }
+  return known ? { done, total } : "unknown"
+}
+
+function contractProblems(contracts: readonly ContractObservation[]): string[] {
+  const problems: string[] = []
+  for (const contract of contracts) {
+    if (contract.state === "missing") problems.push(`contract ${contract.changeId}: source missing${contract.reason ? ` (${contract.reason})` : ""}`)
+    else if (contract.state === "ambiguous") problems.push(`contract ${contract.changeId}: ambiguous sources${contract.reason ? ` (${contract.reason})` : ""}`)
+    else if (contract.state === "unreadable") problems.push(`contract ${contract.changeId}: source unreadable${contract.reason ? ` (${contract.reason})` : ""}`)
+  }
+  return problems
+}
+
+/**
+ * The close-start prerequisites (design D5: "Ready to close" requires the
+ * shared close-start prerequisites, complete tasks alone are "implementation
+ * complete"): verified context, every contract readable (active or
+ * verified-archived), all known tasks complete, no live runs, and no
+ * unknowns where the close preflight needs evidence.
+ */
+export function closeStartPrerequisites(observations: LifecycleObservations): { pass: boolean; blockers: string[] } {
+  const blockers: string[] = []
+  if (!observations.feature) blockers.push("no registered feature: adopt or spin before closing")
+  if (observations.context.verification !== "verified") {
+    blockers.push(
+      observations.context.verification === "missing"
+        ? "implementation context is missing (worktree removed) — rebind or recover"
+        : `implementation context is ${observations.context.verification}${observations.context.reason ? `: ${observations.context.reason}` : ""}`,
+    )
+  }
+  for (const problem of contractProblems(observations.contracts)) blockers.push(problem)
+  for (const contract of observations.contracts) {
+    if (contract.state === "active" && contract.tasks === "unknown") blockers.push(`contract ${contract.changeId}: task completion unknown`)
+    else if (contract.state === "active" && contract.tasks !== "unknown" && contract.tasks !== undefined) {
+      if (contract.tasks.total === 0) blockers.push(`contract ${contract.changeId}: no task list`)
+      else if (contract.tasks.done < contract.tasks.total) {
+        blockers.push(`contract ${contract.changeId}: ${contract.tasks.total - contract.tasks.done} of ${contract.tasks.total} tasks incomplete`)
+      }
+    }
+  }
+  if (observations.execution.kind === "unknown") blockers.push(`live-run state unknown: ${observations.execution.reason}`)
+  else if (observations.execution.liveRunIds.length > 0) blockers.push(`${observations.execution.liveRunIds.length} live run(s) attached`)
+  return { pass: blockers.length === 0, blockers }
+}
+
+/**
+ * The summary, in design D5's precedence order: recovery/unknown blockers are
+ * favored over claimed readiness, and "ready to close" is only derived from
+ * the shared prerequisites — never from task counts alone.
+ */
+export function summarize(observations: LifecycleObservations): { summary: string; blockers: string[]; closeStartPrerequisitesPass: boolean } {
+  const blockers: string[] = []
+
+  if (!observations.feature) {
+    blockers.push("not associated with a registered feature")
+    return { summary: "Association needed", blockers, closeStartPrerequisitesPass: false }
+  }
+  if (observations.context.verification === "missing") {
+    blockers.push("implementation context missing (worktree removed)")
+    return { summary: "Context missing", blockers, closeStartPrerequisitesPass: false }
+  }
+  if (observations.context.verification === "unreadable" || observations.context.verification === "ambiguous") {
+    blockers.push(observations.context.reason ?? `context ${observations.context.verification}`)
+    return { summary: "Context needs review", blockers, closeStartPrerequisitesPass: false }
+  }
+
+  const problems = contractProblems(observations.contracts)
+  if (problems.length > 0) {
+    blockers.push(...problems)
+    return { summary: "Contract sources need review", blockers, closeStartPrerequisitesPass: false }
+  }
+
+  const tasks = totalTasks(observations.contracts)
+  const archived = observations.contracts.length > 0 && observations.contracts.every((contract) => contract.state === "verified-archived")
+  const prerequisites = closeStartPrerequisites(observations)
+
+  if (observations.integration === "stale") {
+    blockers.push("landing evidence is stale (feature tip advanced or landing unreachable)")
+    return { summary: "Integration evidence stale", blockers, closeStartPrerequisitesPass: false }
+  }
+  if (observations.integration === "verified") {
+    const cleanupPending =
+      observations.cleanup.kind === "known" && (observations.cleanup.worktreePresent || observations.cleanup.branchPresent)
+    return {
+      summary: cleanupPending ? "Integrated locally · cleanup pending" : "Completed",
+      blockers,
+      closeStartPrerequisitesPass: false,
+    }
+  }
+  if (archived) {
+    // Past archiving, not yet integrated: close review stays applicable
+    // (landing work), but "ready to close" would misstate the lifecycle.
+    blockers.push(...prerequisites.blockers.filter((blocker) => blocker.includes("live run")))
+    return { summary: "Implementation complete · archive verified", blockers, closeStartPrerequisitesPass: false }
+  }
+  if (observations.integration === "probable") {
+    blockers.push("integration is only probable (patch equivalence, no verified receipt)")
+    return { summary: "Probably merged", blockers, closeStartPrerequisitesPass: false }
+  }
+  // A live run keeps the feature in implementation (design D5's table: tasks
+  // incomplete OR a run live → In implementation), even with tasks complete.
+  const liveRun = observations.execution.kind === "known" && observations.execution.liveRunIds.length > 0
+  if (liveRun) {
+    blockers.push(...prerequisites.blockers)
+    return { summary: "In implementation", blockers, closeStartPrerequisitesPass: false }
+  }
+  if (tasks !== "unknown" && tasks.total > 0 && tasks.done >= tasks.total) {
+    if (prerequisites.pass) return { summary: "Ready to close", blockers, closeStartPrerequisitesPass: true }
+    blockers.push(...prerequisites.blockers)
+    return { summary: "Implementation complete · blocked", blockers, closeStartPrerequisitesPass: false }
+  }
+  // Tasks incomplete, unknown, or runs live: implementation in progress.
+  blockers.push(...prerequisites.blockers)
+  return { summary: "In implementation", blockers, closeStartPrerequisitesPass: false }
+}
+
+/**
+ * The shared assessment (design D5): every consumer of lifecycle facts —
+ * board rows, specs viewer menus, launcher review, publication, close —
+ * renders these actions and reasons, so eligibility rules have exactly one
+ * definition (task 2.5).
+ */
+export function assessLifecycle(observations: LifecycleObservations): LifecycleAssessment {
+  const { summary, blockers, closeStartPrerequisitesPass } = summarize(observations)
+  const tasks = totalTasks(observations.contracts)
+  const liveRuns = observations.execution.kind === "known" ? observations.execution.liveRunIds.length : 0
+  const featureId = observations.feature?.featureId
+  const actions: LifecycleAction[] = []
+
+  const canClose = closeStartPrerequisitesPass
+  actions.push({
+    id: "close",
+    label: "Close review",
+    applicable: observations.feature !== undefined,
+    enabled: canClose,
+    blockers: canClose ? [] : blockers,
+    remediation: canClose
+      ? []
+      : blockers.map((blocker) => `resolve: ${blocker}`),
+    ...(featureId ? { target: { featureId } } : {}),
+  })
+  actions.push({
+    id: "continue",
+    label: "Continue implementation",
+    applicable: observations.feature !== undefined && observations.context.verification === "verified",
+    enabled: observations.feature !== undefined && observations.context.verification === "verified",
+    blockers: observations.context.verification === "verified" ? [] : [observations.context.reason ?? "context not verified"],
+    remediation: [],
+    ...(featureId ? { target: { featureId } } : {}),
+  })
+  actions.push({
+    id: "adopt",
+    label: "Adopt this work",
+    applicable: observations.feature === undefined,
+    enabled: observations.feature === undefined,
+    blockers: observations.feature === undefined ? [] : ["already associated with a registered feature"],
+    remediation: [],
+  })
+  actions.push({
+    id: "bind",
+    label: "Rebind context",
+    applicable: observations.feature !== undefined && observations.context.verification !== "verified",
+    enabled: observations.feature !== undefined && observations.context.verification !== "missing",
+    blockers: observations.context.verification === "missing" ? ["the recorded context is gone; rebind requires an existing checkout"] : [],
+    remediation: observations.context.verification === "missing" ? ["run `convoy feature bind <feature-id> --branch <name> --worktree <path>` from the surviving checkout"] : [],
+    ...(featureId ? { target: { featureId } } : {}),
+  })
+  actions.push({
+    id: "archive-on-main",
+    label: "Archive on main",
+    applicable: observations.integration === "probable" && observations.contracts.some((contract) => contract.state === "active"),
+    enabled: true,
+    blockers: [],
+    remediation: [],
+    ...(featureId ? { target: { featureId } } : {}),
+  })
+  actions.push({
+    id: "push",
+    label: "Push base",
+    applicable: observations.integration === "verified",
+    enabled: observations.publication.kind === "known" ? observations.publication.upstream !== undefined : false,
+    blockers: observations.publication.kind === "known" && observations.publication.upstream === undefined ? ["the base branch has no configured upstream"] : [],
+    remediation: observations.publication.kind === "known" && observations.publication.upstream === undefined ? ["configure an upstream for the base branch (`git push -u <remote> <base>`)"] : [],
+    ...(featureId ? { target: { featureId } } : {}),
+  })
+  actions.push({
+    id: "history",
+    label: "Open history",
+    applicable: true,
+    enabled: true,
+    blockers: [],
+    remediation: [],
+  })
+  actions.push({
+    id: "spin",
+    label: "Spin out",
+    applicable: observations.feature === undefined && observations.contracts.some((contract) => contract.state === "active"),
+    enabled: true,
+    blockers: [],
+    remediation: [],
+  })
+
+  return { summary, ...(tasks === "unknown" ? { tasks: "unknown" as const } : { tasks }), liveRuns, contracts: observations.contracts, integration: observations.integration, actions, closeStartPrerequisitesPass, blockers }
+}

--- a/src/feature-lifecycle/command-cli.ts
+++ b/src/feature-lifecycle/command-cli.ts
@@ -1,0 +1,176 @@
+import { lifecycleCommonDir, readRepositoryRecord } from "./store"
+import { featureAdopt, featureBind, featureNewWork, featureRecover, featureRevise, featureShow, operationError } from "./commands"
+
+/**
+ * The CLI surface of `convoy feature <subcommand>` (design D3's planned
+ * commands, tasks 3.1–3.6). Argv parsing stays here; the operations live in
+ * `commands.ts` so the TUI and tests consume the same functions.
+ */
+
+export function featureHelp(): string {
+  return `convoy feature — stable feature lifecycle operations
+
+Usage:
+  convoy feature show [<feature-id>] [--json]
+  convoy feature adopt --branch <name> --change <id> [--change <id> ...] --base <local-ref>
+                      [--archive-path <path>] [--archive-source <change-id>=<path>]...
+  convoy feature bind <feature-id> --branch <name> --worktree <path>
+  convoy feature revise <feature-id> --change <id> [--change <id> ...] --base <local-ref>
+  convoy feature recover <feature-id> [--legacy]
+  convoy feature new-work --branch <name> --worktree <path> [--change <id> ...] --base <local-ref>
+
+Feature identities are opaque ids shown by \`convoy feature show\`. Adoption and
+rebinding are explicit consent operations; browsing never creates records.
+`
+}
+
+export type FeatureCommandSpec =
+  | { action: "show"; featureId?: string; json: boolean }
+  | { action: "adopt"; branch: string; changes: string[]; base: string; displayName?: string; archivePath?: string; archiveSources: Array<{ changeId: string; path: string }> }
+  | { action: "bind"; featureId: string; branch: string; worktree: string }
+  | { action: "revise"; featureId: string; changes: string[]; base: string }
+  | { action: "recover"; featureId?: string; legacy: boolean; changeId?: string }
+  | { action: "new-work"; branch: string; worktree: string; changes: string[]; base: string }
+
+export function parseFeatureArgs(argv: string[]): FeatureCommandSpec {
+  const sub = argv[0]
+  const rest = argv.slice(1)
+  if (sub === undefined || sub === "--help" || sub === "-h") throw new Error(featureHelp())
+
+  const flags = new Map<string, string[]>()
+  let positionals: string[] = []
+  for (let index = 0; index < rest.length; index += 1) {
+    const arg = rest[index]!
+    if (arg === "--json") {
+      flags.set("--json", [])
+      continue
+    }
+    if (arg.startsWith("--")) {
+      const name = arg
+      const value = rest[index + 1]
+      if (value === undefined || value.startsWith("--")) {
+        flags.set(name, flags.get(name) ?? [])
+        continue
+      }
+      flags.set(name, [...(flags.get(name) ?? []), value])
+      index += 1
+      continue
+    }
+    positionals = [...positionals, arg]
+  }
+
+  const repeated = (name: string): string[] => flags.get(name) ?? []
+  const single = (name: string): string | undefined => flags.get(name)?.[0]
+  const requireSingle = (name: string): string => {
+    const value = single(name)
+    if (value === undefined) throw operationError(`missing required flag ${name}`, "missing")
+    return value
+  }
+
+  switch (sub) {
+    case "show": {
+      if (flags.has("--json") === false && rest.length > 1 && !positionals.length) throw operationError(`usage: convoy feature show [<feature-id>] [--json]`, "missing")
+      return { action: "show", ...(positionals[0] ? { featureId: positionals[0] } : {}), json: flags.has("--json") }
+    }
+    case "adopt": {
+      const changes = repeated("--change")
+      const archiveSources = repeated("--archive-source").map((entry) => {
+        const eq = entry.indexOf("=")
+        if (eq <= 0) throw operationError(`--archive-source expects <change-id>=<path>, got "${entry}"`, "missing")
+        return { changeId: entry.slice(0, eq), path: entry.slice(eq + 1) }
+      })
+      if (changes.length === 0) throw operationError("adopt requires at least one --change <id>", "missing")
+      return {
+        action: "adopt",
+        branch: requireSingle("--branch"),
+        changes,
+        base: requireSingle("--base"),
+        ...(single("--name") ? { displayName: single("--name") } : {}),
+        ...(single("--archive-path") ? { archivePath: single("--archive-path") } : {}),
+        archiveSources,
+      }
+    }
+    case "bind": {
+      const featureId = positionals[0]
+      if (!featureId) throw operationError("usage: convoy feature bind <feature-id> --branch <name> --worktree <path>", "missing")
+      return { action: "bind", featureId, branch: requireSingle("--branch"), worktree: requireSingle("--worktree") }
+    }
+    case "revise": {
+      const featureId = positionals[0]
+      if (!featureId) throw operationError("usage: convoy feature revise <feature-id> --change <id> [--change <id> ...] --base <local-ref>", "missing")
+      const changes = repeated("--change")
+      if (changes.length === 0) throw operationError("revise requires at least one --change <id>", "missing")
+      return { action: "revise", featureId, changes, base: requireSingle("--base") }
+    }
+    case "recover": {
+      return { action: "recover", ...(positionals[0] ? { featureId: positionals[0] } : {}), legacy: flags.has("--legacy"), ...(single("--change") ? { changeId: single("--change") } : {}) }
+    }
+    case "new-work": {
+      const changes = repeated("--change")
+      return {
+        action: "new-work",
+        branch: requireSingle("--branch"),
+        worktree: requireSingle("--worktree"),
+        changes,
+        base: requireSingle("--base"),
+      }
+    }
+    default:
+      throw new Error(featureHelp())
+  }
+}
+
+/** Executes a parsed feature command; returns process exit code semantics via thrown errors. */
+export async function runFeatureCommand(spec: FeatureCommandSpec): Promise<void> {
+  const cwd = process.cwd()
+  switch (spec.action) {
+    case "show": {
+      const { output, text } = await featureShow({ cwd, ...(spec.featureId ? { featureId: spec.featureId } : {}), json: spec.json })
+      process.stdout.write(`${spec.json ? JSON.stringify(output, null, 2) : text}\n`)
+      return
+    }
+    case "adopt": {
+      const { feature } = await featureAdopt({
+        cwd,
+        branch: spec.branch,
+        changeIds: spec.changes,
+        base: spec.base,
+        ...(spec.displayName ? { displayName: spec.displayName } : {}),
+        ...(spec.archivePath ? { archivePath: spec.archivePath } : {}),
+        ...(spec.archiveSources.length > 0 ? { archiveSources: spec.archiveSources } : {}),
+      })
+      process.stdout.write(`adopted feature ${feature.displayName} (${feature.featureId})\n`)
+      process.stdout.write(`  branch ${feature.context?.branch ?? spec.branch} · base ${feature.intendedBaseRef}\n`)
+      for (const contract of feature.contracts) process.stdout.write(`  contract ${contract.changeId} (${contract.kind})\n`)
+      return
+    }
+    case "bind": {
+      const feature = await featureBind({ cwd, featureId: spec.featureId, branch: spec.branch, worktree: spec.worktree })
+      process.stdout.write(`bound feature ${feature.displayName} (${feature.featureId}) to ${feature.context?.branch}\n`)
+      return
+    }
+    case "revise": {
+      const feature = await featureRevise({ cwd, featureId: spec.featureId, changeIds: spec.changes, base: spec.base })
+      process.stdout.write(`revised feature ${feature.displayName} (${feature.featureId}) to revision ${feature.associationRevision}\n`)
+      for (const contract of feature.contracts) process.stdout.write(`  contract ${contract.changeId} (${contract.kind})\n`)
+      return
+    }
+    case "recover": {
+      const feature = await featureRecover({ cwd, ...(spec.featureId ? { featureId: spec.featureId } : {}), legacy: spec.legacy, ...(spec.changeId ? { changeId: spec.changeId } : {}) })
+      process.stdout.write(`recovered feature ${feature.displayName} (${feature.featureId}) from landing evidence\n`)
+      return
+    }
+    case "new-work": {
+      const feature = await featureNewWork({ cwd, branch: spec.branch, worktree: spec.worktree, changeIds: spec.changes, base: spec.base })
+      process.stdout.write(`created new feature ${feature.displayName} (${feature.featureId}) on ${feature.context?.branch}\n`)
+      return
+    }
+  }
+}
+
+/** True when the store has never been initialized (helps CLI diagnostics). */
+export async function storeIsUninitialized(cwd: string): Promise<boolean> {
+  const commonDir = await lifecycleCommonDir(cwd)
+  if (!commonDir) return true
+  return (await readRepositoryRecord(commonDir)).status === "missing"
+}

--- a/src/feature-lifecycle/commands.ts
+++ b/src/feature-lifecycle/commands.ts
@@ -1,0 +1,811 @@
+import { readdir, realpath } from "node:fs/promises"
+import { join } from "node:path"
+
+import { currentBranch, execFile, findWorktreeDirForBranch, mainWorktreeDir, resolveCommit } from "../git"
+import { isOpenSpecChangeId, listChangeIds, openspecDirName } from "../openspec"
+import { observeLiveRunsAt } from "./adapters"
+import { assessLifecycle, type LifecycleAssessment } from "./assessment"
+import { discoverLifecycle } from "./discovery"
+import {
+  ensureRepositoryRecord,
+  isFound,
+  lifecycleCommonDir,
+  withFeatureLock,
+  type StoreRead,
+} from "./store"
+import { acquireMutationLease, LeaseUnavailableError, type MutationLease } from "../finalization/lease"
+import {
+  isCompletedFeature,
+  listAttemptIds,
+  listFeatureRecords,
+  listReceiptIds,
+  readAttemptJournal,
+  readFeatureRecord,
+  readReceipt,
+  writeFeatureRecord,
+  writeReceiptIfAbsent,
+  type AssociationEvent,
+  type FeatureContract,
+  type FeatureRecord,
+} from "./records"
+import { isLandingReachableFrom } from "./refs"
+import { planningPathWithin, resolveFeature } from "./resolver"
+
+/**
+ * The explicit feature identity operations (capability `feature-lifecycle`,
+ * design D3, tasks 3.1–3.6): show, adopt, bind, revise, recover, new-work.
+ * Adoption/rebinding are the consent gates that replace naming authority:
+ * every operation validates repository membership, the actual checked-out
+ * branch, worktree registration, and the selected sources before persisting
+ * a new association revision. None of them mark tasks, archives, or
+ * integration complete, and none rename a branch (design D3).
+ */
+
+export type FeatureOperationError = Error & { code?: "missing" | "ambiguous" | "unreadable" | "conflict" }
+
+export function operationError(message: string, code: FeatureOperationError["code"]): FeatureOperationError {
+  const error = new Error(message) as FeatureOperationError
+  error.code = code
+  return error
+}
+
+// ── show (task 3.1) ──────────────────────────────────────────────────────
+
+export type FeatureShowOutput = {
+  featureId?: string
+  displayName?: string
+  associationRevision?: number
+  intendedBaseRef?: string
+  context?: { branch: string; checkoutPath?: string }
+  contracts?: FeatureContract[]
+  runIds?: string[]
+  closeAttemptIds?: string[]
+  receipts?: Array<{ attemptId: string; landingSha: string; landingReachable: boolean }>
+  assessment?: Pick<LifecycleAssessment, "summary" | "blockers" | "closeStartPrerequisitesPass">
+  resolution?: { status: string; reason?: string }
+  /** Unresolved discovery evidence for the current context (task 3.1). */
+  discovery?: { candidates: Array<{ changeId: string; dir: string; hasMarkdown: boolean }>; unreadableFeatures: Array<{ featureId: string; reason: string }> }
+  /** Rendered text form, present when `json` was not requested. */
+  text?: string
+}
+
+/**
+ * Read-only inspection of a feature (by ID) or of the current context. Never
+ * mutates: no repository UUID is created, no record is adopted or migrated
+ * (task 3.1; design D1: reads do not create).
+ */
+export async function featureShow(input: { cwd: string; featureId?: string; json?: boolean }): Promise<{ output: FeatureShowOutput; text?: string }> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) throw operationError("not a git repository", "missing")
+
+  const resolution = await resolveFeature({ cwd: input.cwd, commonDir, featureId: input.featureId })
+  const output: FeatureShowOutput = { resolution: { status: resolution.status, ...(resolution.status !== "verified" && "reason" in resolution ? { reason: resolution.reason } : {}) } }
+
+  if (resolution.status === "verified") {
+    const feature = resolution.feature
+    const receipts: FeatureShowOutput["receipts"] = []
+    for (const { attemptId, receipt } of (await discoverLifecycle({ cwd: input.cwd, commonDir })).features.find((entry) => entry.featureId === feature.featureId)?.receipts ?? []) {
+      if (!receipt) continue
+      receipts.push({ attemptId, landingSha: receipt.landingSha, landingReachable: await isLandingReachableFrom(receipt.landingSha, receipt.baseRef, input.cwd) })
+    }
+    output.featureId = feature.featureId
+    output.displayName = feature.displayName
+    output.associationRevision = feature.associationRevision
+    output.intendedBaseRef = feature.intendedBaseRef
+    output.context = { branch: resolution.context.branch, ...(resolution.context.checkoutPath ? { checkoutPath: resolution.context.checkoutPath } : {}) }
+    output.contracts = feature.contracts
+    output.runIds = feature.runIds
+    output.closeAttemptIds = feature.closeAttemptIds
+    output.receipts = receipts
+    const assessment = await assessCurrentFeature({ cwd: input.cwd, commonDir, feature })
+    output.assessment = { summary: assessment.summary, blockers: assessment.blockers, closeStartPrerequisitesPass: assessment.closeStartPrerequisitesPass }
+  } else if (input.featureId) {
+    // An explicitly named record renders even without a verified context
+    // (e.g. a recovered completed feature whose worktree is gone).
+    const read = await readFeatureRecord(commonDir, input.featureId)
+    if (isFound(read)) {
+      const feature = read.value
+      const receipts: FeatureShowOutput["receipts"] = []
+      for (const attemptId of await listReceiptIds(commonDir, feature.featureId)) {
+        const receiptRead = await readReceipt(commonDir, feature.featureId, attemptId)
+        if (receiptRead.status !== "found") continue
+        const receipt = receiptRead.value
+        receipts.push({ attemptId, landingSha: receipt.landingSha, landingReachable: await isLandingReachableFrom(receipt.landingSha, receipt.baseRef, input.cwd) })
+      }
+      output.featureId = feature.featureId
+      output.displayName = feature.displayName
+      output.associationRevision = feature.associationRevision
+      output.intendedBaseRef = feature.intendedBaseRef
+      if (feature.context) {
+        output.context = { branch: feature.context.branch, ...(feature.context.checkoutPath ? { checkoutPath: feature.context.checkoutPath } : {}) }
+      }
+      output.contracts = feature.contracts
+      output.runIds = feature.runIds
+      output.closeAttemptIds = feature.closeAttemptIds
+      output.receipts = receipts
+    } else {
+      const discovery = await discoverLifecycle({ cwd: input.cwd, commonDir })
+      output.discovery = {
+        candidates: discovery.candidates.map((candidate) => ({ changeId: candidate.changeId, dir: candidate.dir, hasMarkdown: candidate.hasMarkdown })),
+        unreadableFeatures: discovery.unreadableFeatures.map((entry) => ({ featureId: entry.featureId, reason: entry.reason })),
+      }
+    }
+  } else {
+    // Unresolved: include discovery evidence so the operator can decide what
+    // to adopt (task 3.1: show unresolved discovery evidence).
+    const discovery = await discoverLifecycle({ cwd: input.cwd, commonDir })
+    output.discovery = {
+      candidates: discovery.candidates.map((candidate) => ({ changeId: candidate.changeId, dir: candidate.dir, hasMarkdown: candidate.hasMarkdown })),
+      unreadableFeatures: discovery.unreadableFeatures.map((entry) => ({ featureId: entry.featureId, reason: entry.reason })),
+    }
+  }
+
+  if (!input.json) output.text = renderFeatureShow(output)
+  return { output, text: output.text }
+}
+
+function renderFeatureShow(output: FeatureShowOutput): string {
+  const lines: string[] = []
+  if (output.featureId) {
+    lines.push(`feature  ${output.displayName} (${output.featureId})`)
+    lines.push(`revision ${output.associationRevision}`)
+    lines.push(`base     ${output.intendedBaseRef}`)
+    if (output.context) lines.push(`context  ${output.context.branch}${output.context.checkoutPath ? ` at ${output.context.checkoutPath}` : ""}`)
+    for (const contract of output.contracts ?? []) {
+      lines.push(`contract ${contract.changeId} (${contract.kind}) ← ${contract.sourcePath}`)
+    }
+    for (const receipt of output.receipts ?? []) {
+      lines.push(`receipt  ${receipt.attemptId.slice(0, 8)} landing ${receipt.landingSha.slice(0, 8)}${receipt.landingReachable ? " (reachable)" : " (unreachable)"}`)
+    }
+    if (output.assessment) {
+      lines.push(`status   ${output.assessment.summary}`)
+      for (const blocker of output.assessment.blockers) lines.push(`blocker  ${blocker}`)
+    }
+  } else {
+    lines.push(`no verified feature for this context (${output.resolution?.status})`)
+    if (output.resolution?.reason) lines.push(output.resolution.reason)
+    for (const candidate of output.discovery?.candidates ?? []) {
+      lines.push(`candidate ${candidate.changeId}${candidate.hasMarkdown ? "" : " (husk)"} in ${candidate.dir}`)
+    }
+    for (const unreadable of output.discovery?.unreadableFeatures ?? []) {
+      lines.push(`unreadable feature record ${unreadable.featureId}: ${unreadable.reason}`)
+    }
+  }
+  return lines.join("\n")
+}
+
+// ── adopt (task 3.2) ─────────────────────────────────────────────────────
+
+export type AdoptInput = {
+  cwd: string
+  branch: string
+  changeIds: string[]
+  base: string
+  displayName?: string
+  /** Single-contract shorthand: the archive path for one archived contract. */
+  archivePath?: string
+  /** Headless multi-contract form: `--archive-source <change-id>=<path>`, mutually exclusive with `--archive-path`. */
+  archiveSources?: Array<{ changeId: string; path: string }>
+}
+
+export type AdoptResult = { feature: FeatureRecord }
+
+/**
+ * Explicit adoption of existing work (task 3.2): associates `changeIds` with
+ * `branch` (any Git-valid name — the branch is never renamed) and `base`.
+ * Validates repository membership, worktree registration, the actual
+ * checked-out branch, and each selected source (active tree or archive
+ * path). Adoption records intent; it never marks tasks, archives, or
+ * integration complete (design D3).
+ */
+export async function featureAdopt(input: AdoptInput): Promise<AdoptResult> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) throw operationError("not a git repository", "missing")
+  if (input.branch.startsWith("-") || input.branch.includes(" ")) throw operationError(`"${input.branch}" is not a valid branch name`, "missing")
+  if (input.changeIds.length === 0) throw operationError("adopt requires at least one --change <id>", "missing")
+  for (const changeId of input.changeIds) {
+    if (!isOpenSpecChangeId(changeId)) throw operationError(`"${changeId}" is not a valid change id`, "missing")
+  }
+  if (input.archivePath !== undefined && input.archiveSources !== undefined && input.archiveSources.length > 0) {
+    throw operationError("use either --archive-path (single contract) or --archive-source <change>=<path> (multi-contract), not both", "missing")
+  }
+
+  const repoRecord = await ensureRepositoryRecord(commonDir)
+  if (!isFound(repoRecord)) throw operationError(`couldn't initialize the lifecycle store: ${repoRecord.status === "unreadable" ? repoRecord.reason : repoRecord.status}`, "unreadable")
+
+  // Context uniqueness: a context SHALL NOT be silently claimed by two
+  // features (design D2) — adoption refuses an already-claimed branch.
+  for (const entry of await listFeatureRecords(commonDir)) {
+    if (isFound(entry.read) && entry.read.value.context?.branch === input.branch) {
+      throw operationError(`branch "${input.branch}" is already claimed by feature ${entry.read.value.featureId}`, "conflict")
+    }
+  }
+
+  // The branch must be checked out somewhere (worktree registration) and the
+  // named branch must be the checkout's actual branch (design D3: validate
+  // the actual checked-out branch, not the requested spelling).
+  const worktreeDir = await findWorktreeDirForBranch(input.branch, input.cwd)
+  if (!worktreeDir) throw operationError(`branch "${input.branch}" is not checked out in any worktree of this repository`, "missing")
+  const actual = await currentBranch(worktreeDir)
+  if (actual !== input.branch) throw operationError(`worktree ${worktreeDir} has branch "${actual ?? "(detached)"}" checked out, not "${input.branch}"`, "conflict")
+
+  const mainDir = (await mainWorktreeDir(input.cwd).catch(() => undefined)) ?? input.cwd
+  const baseSha = await resolveCommit(input.base, mainDir).catch(() => undefined)
+  if (!baseSha) throw operationError(`base ref "${input.base}" does not resolve in this repository`, "missing")
+
+  const planningRoot = worktreeDir
+  const archiveSources = new Map<string, string>()
+  if (input.archivePath !== undefined) {
+    if (input.changeIds.length !== 1) throw operationError("--archive-path applies to exactly one --change", "missing")
+    archiveSources.set(input.changeIds[0]!, input.archivePath)
+  }
+  for (const source of input.archiveSources ?? []) {
+    if (!archiveSources.has(source.changeId)) archiveSources.set(source.changeId, source.path)
+  }
+
+  const contracts: FeatureContract[] = []
+  for (const changeId of input.changeIds) {
+    const archivePath = archiveSources.get(changeId)
+    if (archivePath !== undefined) {
+      const rel = planningPathWithin(join(planningRoot, openspecDirName), archivePath)
+      if (!rel || !rel.startsWith("archive/") || !rel.endsWith(`/${changeId}`)) {
+        throw operationError(`archive source "${archivePath}" must be a path under ${openspecDirName}/archive/ ending in /${changeId}`, "missing")
+      }
+      // Symlink escape check: the real path must stay inside the planning root.
+      const realArchive = await realpathSafe(join(planningRoot, openspecDirName, rel))
+      if (realArchive === undefined || !realArchive.startsWith(await realpathSafe(planningRoot) + "/")) {
+        throw operationError(`archive source "${archivePath}" escapes the planning root`, "conflict")
+      }
+      contracts.push({ changeId, kind: "archive", sourcePath: join(openspecDirName, rel), provenance: "adopt", selectedAtRevision: 1 })
+    } else {
+      const idsHere = await listChangeIds(join(planningRoot, openspecDirName, "changes"))
+      if (!idsHere.includes(changeId)) {
+        throw operationError(`change "${changeId}" is not an active change in ${planningRoot} — pass --archive-path if it is archived`, "missing")
+      }
+      contracts.push({ changeId, kind: "active", sourcePath: join(openspecDirName, "changes", changeId), provenance: "adopt", selectedAtRevision: 1 })
+    }
+  }
+
+  const featureId = crypto.randomUUID()
+  const now = Date.now()
+  const record: FeatureRecord = {
+    schemaVersion: 1,
+    featureId,
+    repositoryId: repoRecord.value.repositoryId,
+    displayName: input.displayName ?? input.changeIds.join(" + "),
+    associationRevision: 1,
+    contracts,
+    intendedBaseRef: input.base,
+    context: { branch: input.branch, ...(await realpathSafe(worktreeDir) ? { checkoutPath: await realpathSafe(worktreeDir) } : {}) },
+    runIds: [],
+    closeAttemptIds: [],
+    history: [{ at: now, kind: "adopted", summary: `adopted ${contracts.map((contract) => contract.changeId).join(", ")} on ${input.branch}`, revision: 1 }],
+    createdAt: now,
+    updatedAt: now,
+  }
+  const written = await withAssociationLease(commonDir, () => withFeatureLock(featureDirPath(commonDir, featureId), () => writeFeatureRecord(commonDir, record, 0)))
+  if (!isFound(written)) throw operationError("adoption conflicted with a concurrent write — inspect and retry", "conflict")
+  return { feature: written.value }
+}
+
+function featureDirPath(commonDir: string, featureId: string): string {
+  return join(commonDir, "convoy", "features", featureId)
+}
+
+async function realpathSafe(path: string): Promise<string | undefined> {
+  try {
+    return await realpath(path)
+  } catch {
+    return undefined
+  }
+}
+
+
+/**
+ * The repository mutation lease around one association write (design D9,
+ * SC-5): the lease serializes Convoy's own repository mutations — close
+ * segments, run finalization, association writes — so an association record
+ * never lands underneath an in-flight close or compaction. It is acquired
+ * outside the per-feature lock (consistent ordering, no deadlock) and
+ * released even when the write fails.
+ */
+export async function withAssociationLease<T>(commonDir: string, fn: () => Promise<T>): Promise<T> {
+  let lease: MutationLease
+  try {
+    lease = await acquireMutationLease(commonDir)
+  } catch (error) {
+    const reason = error instanceof LeaseUnavailableError ? error.message : `couldn't acquire the repository mutation lease: ${String(error)}`
+    throw operationError(reason, "conflict")
+  }
+  try {
+    return await fn()
+  } finally {
+    await lease.release()
+  }
+}
+
+// ── bind (task 3.3) ──────────────────────────────────────────────────────
+
+export type BindInput = { cwd: string; featureId: string; branch: string; worktree: string }
+
+/**
+ * Explicit consent to update a feature's context (task 3.3). Not consent to
+ * change base/contracts, migrate a foreign receipt, rewrite a run boundary,
+ * or claim a landing. Validates Git common-directory membership (the
+ * worktree must belong to this repository), registered worktree root, actual
+ * branch, context uniqueness (no other feature claims it), and the absence
+ * of a live run on the new context before bumping the revision.
+ */
+export async function featureBind(input: BindInput): Promise<FeatureRecord> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) throw operationError("not a git repository", "missing")
+  const current = await readFeatureRecord(commonDir, input.featureId)
+  if (!isFound(current)) throw operationError(`feature ${input.featureId} not found (status: ${current.status})`, "missing")
+  const feature = current.value
+
+  const registered = await findWorktreeDirForBranch(input.branch, input.cwd)
+  if (!registered) throw operationError(`branch "${input.branch}" is not checked out in any registered worktree`, "missing")
+  const sameDir = (await realpathSafe(registered)) === (await realpathSafe(input.worktree))
+  if (!sameDir) throw operationError(`branch "${input.branch}" is checked out at ${registered}, not ${input.worktree}`, "conflict")
+
+  // Context uniqueness: at most one feature may claim a context (design D2).
+  const all = await listFeatureRecords(commonDir)
+  for (const entry of all) {
+    if (!isFound(entry.read) || entry.read.value.featureId === feature.featureId) continue
+    if (entry.read.value.context?.branch === input.branch) {
+      throw operationError(`branch "${input.branch}" is already claimed by feature ${entry.read.value.featureId}`, "conflict")
+    }
+  }
+
+  const liveRuns = await observeLiveRunsAt(registered)
+  if (liveRuns.kind === "known" && liveRuns.value.length > 0) {
+    throw operationError(`${liveRuns.value.length} live run(s) attached to "${input.branch}" — stop them before rebinding`, "conflict")
+  }
+  if (liveRuns.kind === "unknown") {
+    throw operationError(`couldn't verify live runs (${liveRuns.reason}) — refusing the rebind while run state is unreadable`, "unreadable")
+  }
+
+  // An unresolved close attempt targets the old context; rebinding marks the
+  // transition (the attempt's journal keeps its evidence, new work resumes
+  // fresh — capability feature-lifecycle: recovery after a context moves).
+  const attemptIds = await listAttemptIds(commonDir, feature.featureId)
+  for (const attemptId of attemptIds) {
+    const journal = await readAttemptJournal(commonDir, feature.featureId, attemptId)
+    if (isFound(journal) && journal.value.phase !== "landed") {
+      // Pending attempt: allowed, but the rebind supersedes its target. The
+      // journal's recorded state is preserved; the next close reconciles from
+      // observed effects rather than replaying the stale target.
+      continue
+    }
+  }
+
+  return await withAssociationLease(commonDir, () => withFeatureLock(featureDirPath(commonDir, feature.featureId), async () => {
+    const reread = await readFeatureRecord(commonDir, feature.featureId)
+    if (!isFound(reread)) throw operationError("feature record vanished during rebind", "missing")
+    const revision = reread.value.associationRevision + 1
+    const checkoutPath = (await realpathSafe(registered)) ?? registered
+    const event: AssociationEvent = { at: Date.now(), kind: "bound", summary: `bound context ${input.branch} at ${checkoutPath}`, revision }
+    const updated: FeatureRecord = {
+      ...reread.value,
+      associationRevision: revision,
+      context: { branch: input.branch, checkoutPath },
+      history: [...reread.value.history, event],
+      updatedAt: Date.now(),
+    }
+    const written = await writeFeatureRecord(commonDir, updated, reread.value.associationRevision)
+    if (!isFound(written)) throw operationError("rebind conflicted with a concurrent association update — inspect and retry", "conflict")
+    return written.value
+  }))
+}
+
+// ── revise (task 3.4) ────────────────────────────────────────────────────
+
+export type ReviseInput = { cwd: string; featureId: string; changeIds: string[]; base: string }
+
+/**
+ * Explicit reviewed consent to replace a live feature's contract set and
+ * intended base (task 3.4). Refused while a run is live on the context or an
+ * unresolved close attempt exists (capability feature-lifecycle: contract
+ * revision is blocked while running).
+ */
+export async function featureRevise(input: ReviseInput): Promise<FeatureRecord> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) throw operationError("not a git repository", "missing")
+  const current = await readFeatureRecord(commonDir, input.featureId)
+  if (!isFound(current)) throw operationError(`feature ${input.featureId} not found`, "missing")
+  const feature = current.value
+  if (feature.context?.checkoutPath) {
+    const liveRuns = await observeLiveRunsAt(feature.context.checkoutPath)
+    if (liveRuns.kind === "known" && liveRuns.value.length > 0) {
+      throw operationError(`a run is live on "${feature.context.branch}" — finish or stop it before revising contracts`, "conflict")
+    }
+    if (liveRuns.kind === "unknown") throw operationError(`couldn't verify live runs (${liveRuns.reason})`, "unreadable")
+  }
+  for (const attemptId of await listAttemptIds(commonDir, feature.featureId)) {
+    const journal = await readAttemptJournal(commonDir, feature.featureId, attemptId)
+    if (isFound(journal) && journal.value.phase !== "landed") {
+      throw operationError(`close attempt ${attemptId.slice(0, 8)} is unresolved — reconcile it before revising contracts`, "conflict")
+    }
+  }
+
+  const contracts: FeatureContract[] = []
+  // New contracts must be active in the feature's verified context checkout
+  // (revise operates on the live feature's own planning sources).
+  const reviseCheckout = feature.context?.checkoutPath ?? input.cwd
+  for (const changeId of input.changeIds) {
+    if (!isOpenSpecChangeId(changeId)) throw operationError(`"${changeId}" is not a valid change id`, "missing")
+    const prior = feature.contracts.find((contract) => contract.changeId === changeId)
+    if (prior) {
+      contracts.push({ ...prior, selectedAtRevision: feature.associationRevision + 1 })
+    } else {
+      const idsHere = await listChangeIds(join(reviseCheckout, openspecDirName, "changes"))
+      if (!idsHere.includes(changeId)) throw operationError(`change "${changeId}" is not active in ${reviseCheckout}`, "missing")
+      contracts.push({ changeId, kind: "active", sourcePath: join(openspecDirName, "changes", changeId), provenance: "revise", selectedAtRevision: feature.associationRevision + 1 })
+    }
+  }
+
+  return await withAssociationLease(commonDir, () => withFeatureLock(featureDirPath(commonDir, feature.featureId), async () => {
+    const reread = await readFeatureRecord(commonDir, feature.featureId)
+    if (!isFound(reread)) throw operationError("feature record vanished during revise", "missing")
+    const revision = reread.value.associationRevision + 1
+    const updated: FeatureRecord = {
+      ...reread.value,
+      associationRevision: revision,
+      contracts,
+      intendedBaseRef: input.base,
+      history: [...reread.value.history, { at: Date.now(), kind: "revised", summary: `revised contracts to ${contracts.map((contract) => contract.changeId).join(", ")}`, revision }],
+      updatedAt: Date.now(),
+    }
+    const written = await writeFeatureRecord(commonDir, updated, reread.value.associationRevision)
+    if (!isFound(written)) throw operationError("revise conflicted with a concurrent association update — inspect and retry", "conflict")
+    return written.value
+  }))
+}
+
+// ── recover (task 3.5) ───────────────────────────────────────────────────
+
+export type RecoverInput = { cwd: string; featureId?: string; legacy?: boolean; changeId?: string }
+
+/** One legacy close journal with its embedded identity fields, for adoption. */
+type LegacyLanding = {
+  branch: string
+  changeId: string
+  baseRef: string
+  baseSha: string
+  postArchiveTip: string
+  preparedTree?: string
+  candidateSha: string
+  landingSha: string
+}
+
+/**
+ * Reads every landed legacy close journal (branch/change-keyed, pre-identity)
+ * with its embedded evidence. The original files are never modified here.
+ */
+async function listLegacyLandings(commonDir: string): Promise<LegacyLanding[]> {
+  const legacyDir = join(commonDir, "convoy", "close")
+  let entries
+  try {
+    entries = await readdir(legacyDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const { readCloseJournal } = await import("../close-journal")
+  const out: LegacyLanding[] = []
+  for (const entry of entries.filter((candidate) => candidate.isFile() && candidate.name.endsWith(".json"))) {
+    const match = entry.name.match(/^(.+)__(.+)\.json$/)
+    if (!match) continue
+    const journal = await readCloseJournal(commonDir, match[1]!, match[2]!)
+    if (!journal || journal.phase !== "landed" || !journal.landingSha || !journal.postArchiveTip || !journal.candidateSha || !journal.preparedTree) continue
+    out.push({
+      branch: journal.branch,
+      changeId: journal.changeID,
+      baseRef: journal.baseRef,
+      baseSha: journal.baseSha,
+      postArchiveTip: journal.postArchiveTip,
+      ...(journal.preparedTree ? { preparedTree: journal.preparedTree } : {}),
+      candidateSha: journal.candidateSha,
+      landingSha: journal.landingSha,
+    })
+  }
+  return out
+}
+
+/**
+ * Evidence-only import of a completed feature whose worktree is gone
+ * (task 3.5): locates a landing receipt (identity-keyed, or legacy evidence
+ * with `--legacy`), validates embedded identity, repository membership, and
+ * landing reachability, then writes a stable feature record that grants only
+ * receipt-verified follow-up/cleanup eligibility — never new execution
+ * authority. Does not require the historical worktree or branch to exist.
+ */
+export async function featureRecover(input: RecoverInput): Promise<FeatureRecord> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) throw operationError("not a git repository", "missing")
+
+  if (input.legacy) {
+    return await recoverFromLegacy(commonDir, input)
+  }
+
+  const discovery = await discoverLifecycle({ cwd: input.cwd, commonDir })
+
+  // Identity-keyed path: find a receipt for the named feature (or a unique
+  // one across the store) and rebuild the record from that evidence.
+  const candidates = discovery.features.filter((entry) => entry.receipts.some(({ receipt }) => receipt !== undefined) && (input.featureId === undefined || entry.featureId === input.featureId))
+  if (candidates.length === 0) {
+    throw operationError(
+      input.featureId ? `no verified landing receipt found for feature ${input.featureId}` : "no completed feature with a verified landing receipt was found to recover",
+      "missing",
+    )
+  }
+  if (candidates.length > 1) {
+    throw operationError(`${candidates.length} completed features carry receipts; name one with --feature <id>`, "ambiguous")
+  }
+  const entry = candidates[0]!
+  const withReceipt = entry.receipts.find(({ receipt }) => receipt !== undefined)!
+  const receipt = withReceipt.receipt!
+  if (!(await isLandingReachableFrom(receipt.landingSha, receipt.baseRef, input.cwd))) {
+    throw operationError(`landing ${receipt.landingSha.slice(0, 8)} is no longer reachable from ${receipt.baseRef} — recovery refuses unverifiable evidence`, "missing")
+  }
+  if (receipt.repositoryId !== entry.record.repositoryId) {
+    throw operationError("receipt belongs to a different repository — refusing to import foreign evidence", "conflict")
+  }
+  // The record already exists and carries the receipt; recovery here means
+  // validating and returning it (its eligibility derives from the receipt).
+  return entry.record
+}
+
+/**
+ * Explicit legacy adoption (task 8.2): imports a completed legacy close
+ * journal (branch/change-keyed, pre-identity) into a stable feature record
+ * with a fresh identity-keyed receipt. Embedded identity fields are
+ * validated against the request and repository; the original journal bytes
+ * and refs are preserved untouched; a collision (the branch/change already
+ * claimed by a registered feature) or a mismatched journal is refused, never
+ * reassigned.
+ */
+async function recoverFromLegacy(commonDir: string, input: RecoverInput): Promise<FeatureRecord> {
+  const repoRecord = await ensureRepositoryRecord(commonDir)
+  if (!isFound(repoRecord)) throw operationError(`couldn't initialize the lifecycle store: ${repoRecord.status === "unreadable" ? repoRecord.reason : repoRecord.status}`, "unreadable")
+
+  // A requested change narrows the candidates; a requested featureId is not
+  // meaningful for legacy records (they have no ids) and is refused.
+  if (input.featureId) throw operationError("legacy evidence carries no feature ids; run `convoy feature recover --legacy` without --feature, narrowing with --change instead", "missing")
+  const landed = await listLegacyLandings(commonDir)
+  const filtered = input.changeId ? landed.filter((entry) => entry.changeId === input.changeId) : landed
+  if (filtered.length === 0) {
+    throw operationError("no landed legacy close journal matches — legacy adoption needs a completed legacy close record", "missing")
+  }
+  if (filtered.length > 1) {
+    throw operationError(`${filtered.length} landed legacy journals match; narrow with --change <id>`, "ambiguous")
+  }
+  const candidate = filtered[0]!
+
+  // Repository membership + landing reachability from current Git evidence.
+  if (!(await isLandingReachableFrom(candidate.landingSha, candidate.baseRef, input.cwd))) {
+    throw operationError(`legacy landing ${candidate.landingSha.slice(0, 8)} is no longer reachable from ${candidate.baseRef} — recovery refuses unverifiable evidence`, "missing")
+  }
+  // Collision: the branch/change must not already be claimed by a registered feature.
+  for (const entry of await listFeatureRecords(commonDir)) {
+    if (!isFound(entry.read)) continue
+    const feature = entry.read.value
+    if (feature.context?.branch === candidate.branch || feature.contracts.some((contract) => contract.changeId === candidate.changeId)) {
+      throw operationError(`legacy evidence for ${candidate.branch}/${candidate.changeId} collides with registered feature ${feature.featureId} — refusing to reassign`, "conflict")
+    }
+  }
+
+  // The stable identity + identity-keyed receipt, preserving the legacy
+  // journal bytes/refs untouched.
+  const featureId = crypto.randomUUID()
+  const attemptId = crypto.randomUUID()
+  const now = Date.now()
+  const record: FeatureRecord = {
+    schemaVersion: 1,
+    featureId,
+    repositoryId: repoRecord.value.repositoryId,
+    displayName: candidate.changeId,
+    associationRevision: 1,
+    contracts: [{ changeId: candidate.changeId, kind: "archive", sourcePath: `openspec/changes/archive/${candidate.changeId}`, provenance: "legacy-adoption", selectedAtRevision: 1 }],
+    intendedBaseRef: candidate.baseRef,
+    runIds: [],
+    closeAttemptIds: [attemptId],
+    history: [{ at: now, kind: "recovered", summary: `adopted legacy landing for ${candidate.changeId} on ${candidate.branch}`, revision: 1 }],
+    createdAt: now,
+    updatedAt: now,
+  }
+  const written = await withAssociationLease(commonDir, () => withFeatureLock(featureDirPath(commonDir, featureId), () => writeFeatureRecord(commonDir, record, 0)))
+  if (!isFound(written)) throw operationError("legacy adoption conflicted with a concurrent write — inspect and retry", "conflict")
+  await writeReceiptIfAbsent(commonDir, {
+    schemaVersion: 1,
+    attemptId,
+    featureId,
+    repositoryId: repoRecord.value.repositoryId,
+    associationRevision: 1,
+    branch: candidate.branch,
+    baseRef: candidate.baseRef,
+    baseSha: candidate.baseSha,
+    featureTip: candidate.postArchiveTip,
+    preparedTree: candidate.preparedTree ?? "",
+    candidateSha: candidate.candidateSha,
+    landingSha: candidate.landingSha,
+    landingAt: now,
+  })
+  return written.value
+}
+
+// ── new-work (task 3.6) ──────────────────────────────────────────────────
+
+export type NewWorkInput = { cwd: string; branch: string; worktree: string; changeIds: string[]; base: string }
+
+/**
+ * Explicit consent to start a new feature on a retained completed context
+ * (task 3.6): creates a fresh identity with the given contracts and does not
+ * reopen the completed feature's receipt or inherit its runs. The old
+ * feature's record is untouched.
+ */
+export async function featureNewWork(input: NewWorkInput): Promise<FeatureRecord> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) throw operationError("not a git repository", "missing")
+  const repoRecord = await ensureRepositoryRecord(commonDir)
+  if (!isFound(repoRecord)) throw operationError(`couldn't initialize the lifecycle store: ${repoRecord.status === "unreadable" ? repoRecord.reason : repoRecord.status}`, "unreadable")
+
+  const registered = await findWorktreeDirForBranch(input.branch, input.cwd)
+  if (!registered) throw operationError(`branch "${input.branch}" is not checked out in any registered worktree`, "missing")
+  if ((await realpathSafe(registered)) !== (await realpathSafe(input.worktree))) {
+    throw operationError(`branch "${input.branch}" is checked out at ${registered}, not ${input.worktree}`, "conflict")
+  }
+  // The context must be free: no other feature may claim it — except a
+  // completed feature (a verified landing receipt), whose claim is released
+  // by completion and whose reuse is exactly the explicit new-work decision
+  // being made here (capability feature-lifecycle, D2).
+  for (const entry of await listFeatureRecords(commonDir)) {
+    if (!isFound(entry.read)) continue
+    const claimant = entry.read.value
+    if (claimant.context?.branch !== input.branch) continue
+    if (await isCompletedFeature(commonDir, claimant)) continue
+    throw operationError(`branch "${input.branch}" is still claimed by feature ${claimant.featureId} — complete or explicitly release it first`, "conflict")
+  }
+
+  const contracts: FeatureContract[] = []
+  for (const changeId of input.changeIds) {
+    if (!isOpenSpecChangeId(changeId)) throw operationError(`"${changeId}" is not a valid change id`, "missing")
+    const idsHere = await listChangeIds(join(input.worktree, openspecDirName, "changes"))
+    if (!idsHere.includes(changeId)) throw operationError(`change "${changeId}" is not active in ${input.worktree}`, "missing")
+    contracts.push({ changeId, kind: "active", sourcePath: join(openspecDirName, "changes", changeId), provenance: "new-work", selectedAtRevision: 1 })
+  }
+
+  const featureId = crypto.randomUUID()
+  const now = Date.now()
+  const record: FeatureRecord = {
+    schemaVersion: 1,
+    featureId,
+    repositoryId: repoRecord.value.repositoryId,
+    displayName: input.changeIds.join(" + "),
+    associationRevision: 1,
+    contracts,
+    intendedBaseRef: input.base,
+    context: { branch: input.branch, ...(await realpathSafe(input.worktree) ? { checkoutPath: await realpathSafe(input.worktree) } : {}) },
+    runIds: [],
+    closeAttemptIds: [],
+    history: [{ at: now, kind: "new-work", summary: `new work on ${input.branch}: ${contracts.map((contract) => contract.changeId).join(", ")}`, revision: 1 }],
+    createdAt: now,
+    updatedAt: now,
+  }
+  const written = await withAssociationLease(commonDir, () => withFeatureLock(featureDirPath(commonDir, featureId), () => writeFeatureRecord(commonDir, record, 0)))
+  if (!isFound(written)) throw operationError("new-work conflicted with a concurrent write — inspect and retry", "conflict")
+  return written.value
+}
+
+// ── spin registration (task 4.1) ─────────────────────────────────────────
+
+export type SpinRegistration = { feature: FeatureRecord; resumed: boolean }
+
+/**
+ * Two-phase spin registration (design D4): an intent record is persisted
+ * before the proposal transfer, and the association is committed before
+ * success output. A retry after a partial failure adopts the recorded intent
+ * instead of creating a duplicate feature/context; refusals before any
+ * mutation never persist anything.
+ */
+export async function registerSpinFeature(input: { cwd: string; changeId: string; branch: string; worktreeDir: string; baseRef: string; phase: "intent" | "committed" }): Promise<SpinRegistration> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) throw operationError("not a git repository", "missing")
+  const repoRecord = await ensureRepositoryRecord(commonDir)
+  if (!isFound(repoRecord)) throw operationError(`couldn't initialize the lifecycle store: ${repoRecord.status === "unreadable" ? repoRecord.reason : repoRecord.status}`, "unreadable")
+
+  const existing = await findFeatureForBranchAndChange(commonDir, input.branch, input.changeId)
+  if (existing) {
+    if (input.phase === "committed") {
+      // Resume: finalize the recorded intent.
+      return await withAssociationLease(commonDir, () => withFeatureLock(featureDirPath(commonDir, existing.featureId), async () => {
+        const reread = await readFeatureRecord(commonDir, existing.featureId)
+        if (!isFound(reread)) throw operationError("spin intent record vanished", "missing")
+        const revision = reread.value.associationRevision + 1
+        const updated: FeatureRecord = {
+          ...reread.value,
+          associationRevision: revision,
+          history: [...reread.value.history, { at: Date.now(), kind: "created", summary: `spin registration committed for ${input.changeId}`, revision }],
+          updatedAt: Date.now(),
+        }
+        const written = await writeFeatureRecord(commonDir, updated, reread.value.associationRevision)
+        if (!isFound(written)) throw operationError("spin registration conflicted with a concurrent write", "conflict")
+        return { feature: written.value, resumed: true }
+      }))
+    }
+    return { feature: existing, resumed: true }
+  }
+
+  if (input.phase === "committed") {
+    // No intent was recorded (the intent phase failed or was skipped): the
+    // caller must not silently mint the association here — adopt explicitly.
+    throw operationError(`no spin intent is recorded for ${input.branch}/${input.changeId}; adopt the context explicitly with \`convoy feature adopt --branch ${input.branch} --change ${input.changeId} --base ${input.baseRef}\``, "missing")
+  }
+
+  // Context uniqueness: another feature must not already claim the branch.
+  for (const entry of await listFeatureRecords(commonDir)) {
+    if (isFound(entry.read) && entry.read.value.context?.branch === input.branch) {
+      throw operationError(`branch "${input.branch}" is already claimed by feature ${entry.read.value.featureId}`, "conflict")
+    }
+  }
+
+  const featureId = crypto.randomUUID()
+  const now = Date.now()
+  const checkoutPath = (await realpathSafe(input.worktreeDir)) ?? input.worktreeDir
+  const record: FeatureRecord = {
+    schemaVersion: 1,
+    featureId,
+    repositoryId: repoRecord.value.repositoryId,
+    displayName: input.changeId,
+    associationRevision: 1,
+    contracts: [{ changeId: input.changeId, kind: "active", sourcePath: join(openspecDirName, "changes", input.changeId), provenance: "spin", selectedAtRevision: 1 }],
+    intendedBaseRef: input.baseRef,
+    context: { branch: input.branch, checkoutPath },
+    runIds: [],
+    closeAttemptIds: [],
+    history: [{ at: now, kind: "created", summary: `spin intent: ${input.changeId} on ${input.branch} (pending transfer)`, revision: 1 }],
+    createdAt: now,
+    updatedAt: now,
+  }
+  const written = await withAssociationLease(commonDir, () => withFeatureLock(featureDirPath(commonDir, featureId), () => writeFeatureRecord(commonDir, record, 0)))
+  if (!isFound(written)) throw operationError("spin intent could not be persisted — the transfer must not proceed without durable evidence", "conflict")
+  return { feature: written.value, resumed: false }
+}
+
+async function findFeatureForBranchAndChange(commonDir: string, branch: string, changeId: string): Promise<FeatureRecord | undefined> {
+  for (const entry of await listFeatureRecords(commonDir)) {
+    if (!isFound(entry.read)) continue
+    const feature = entry.read.value
+    if (feature.context?.branch !== branch) continue
+    if (feature.contracts.some((contract) => contract.changeId === changeId)) return feature
+  }
+  return undefined
+}
+
+// ── shared assessment wiring (task 2.5) ──────────────────────────────────
+
+/** Builds the lifecycle assessment for one known feature record from live evidence. */
+export async function assessCurrentFeature(input: { cwd: string; commonDir: string; feature: FeatureRecord }): Promise<ReturnType<typeof assessLifecycle>> {
+  const { buildObservationsForFeature } = await import("./observe")
+  const observations = await buildObservationsForFeature({ cwd: input.cwd, commonDir: input.commonDir, feature: input.feature })
+  return assessLifecycle(observations)
+}
+
+/** Guards a ref against non-branch spellings used in CLI flags. */
+export async function refResolves(ref: string, cwd: string): Promise<string | undefined> {
+  return resolveCommit(ref, cwd).catch(() => undefined)
+}
+
+/** Git membership check used by every operation: same common dir ⇒ same repository. */
+export async function sharesCommonDir(cwdA: string, cwdB: string): Promise<boolean> {
+  const { gitCommonDir } = await import("../finalization/refs")
+  const [a, b] = await Promise.all([gitCommonDir(cwdA), gitCommonDir(cwdB)])
+  if (!a || !b) return false
+  const ra = await realpathSafe(a)
+  const rb = await realpathSafe(b)
+  return ra !== undefined && rb !== undefined && ra === rb
+}
+
+/** Runs one git command (helper for callers that need raw output). */
+export async function git(args: string[], cwd: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return execFile("git", args, { cwd, allowFailure: true })
+}

--- a/src/feature-lifecycle/discovery.ts
+++ b/src/feature-lifecycle/discovery.ts
@@ -1,0 +1,234 @@
+import { readdir } from "node:fs/promises"
+import { join } from "node:path"
+
+import { currentBranch, execFile, mainWorktreeDir } from "../git"
+import { collectDirRelativeMarkdown, isOpenSpecChangeId, listChangeIds, openspecDirName } from "../openspec"
+import { listRuns } from "../runs"
+import { isFound, lifecycleCommonDir, type StoreRead } from "./store"
+import {
+  listAttemptIds,
+  listFeatureIds,
+  listReceiptIds,
+  readAttemptJournal,
+  readFeatureRecord,
+  readReceipt,
+  type CloseAttemptJournal,
+  type FeatureRecord,
+  type LandingReceipt,
+} from "./records"
+
+/**
+ * Read-only lifecycle discovery (capability `feature-lifecycle`, design D6,
+ * task 1.5): combines registered features, active change candidates,
+ * referenced archive sources, legacy run/close evidence, and actual Git
+ * worktrees into one observation snapshot — without writing, adopting, or
+ * migrating anything. Browsing is never a mutation: the callers that change
+ * the world are the explicit operations (`adopt`, `bind`, close, spin), and
+ * this module has no write path by construction.
+ */
+
+export type DiscoveredWorktree = {
+  dir: string
+  branch?: string
+  main: boolean
+}
+
+export type DiscoveredCandidate = {
+  changeId: string
+  /** The checkout that lists the change. */
+  dir: string
+  branch?: string
+  main: boolean
+  /** Whether the change tree carries any markdown (a husk carries none). */
+  hasMarkdown: boolean
+}
+
+export type DiscoveredFeature = {
+  featureId: string
+  record: FeatureRecord
+  attempts: Array<{ attemptId: string; journal: CloseAttemptJournal | undefined; journalStatus: StoreRead<CloseAttemptJournal>["status"] }>
+  receipts: Array<{ attemptId: string; receipt: LandingReceipt | undefined }>
+}
+
+export type LegacyCloseEvidence = {
+  branch: string
+  changeId: string
+  phase: string
+}
+
+export type Discovery = {
+  /** True when the record set exists; false means nothing has ever been registered. */
+  storePresent: boolean
+  features: DiscoveredFeature[]
+  /** Feature records that exist but could not be validated — surfaced, never dropped. */
+  unreadableFeatures: Array<{ featureId: string; status: string; reason: string }>
+  candidates: DiscoveredCandidate[]
+  worktrees: DiscoveredWorktree[]
+  legacyCloseEvidence: LegacyCloseEvidence[]
+  /** Unknown when run history could not be read (design D5: failure ≠ empty). */
+  runs: Array<{ runID: string; targetDir?: string; live: boolean }> | "unknown"
+  runsError?: string
+}
+
+/** `git worktree list --porcelain`, parsed. */
+export async function listWorktrees(cwd: string): Promise<DiscoveredWorktree[]> {
+  const result = await execFile("git", ["worktree", "list", "--porcelain"], { cwd, allowFailure: true })
+  if (result.exitCode !== 0) return []
+  const out: DiscoveredWorktree[] = []
+  let dir: string | undefined
+  let branch: string | undefined
+  const flush = () => {
+    if (dir) out.push({ dir, ...(branch ? { branch } : {}), main: out.length === 0 })
+    dir = undefined
+    branch = undefined
+  }
+  for (const line of result.stdout.split("\n")) {
+    if (line.startsWith("worktree ")) dir = line.slice("worktree ".length)
+    else if (line.startsWith("branch refs/heads/")) branch = line.slice("branch refs/heads/".length)
+    else if (line === "") flush()
+  }
+  flush()
+  return out
+}
+
+/** Whether a change tree carries any markdown (shared husk rule). */
+export async function changeHasMarkdown(checkoutDir: string, changeId: string): Promise<boolean> {
+  const files = await collectDirRelativeMarkdown(join(checkoutDir, openspecDirName, "changes", changeId), ".")
+  return files.length > 0
+}
+
+/**
+ * One full discovery pass. Every read failure is represented (unknown runs,
+ * unreadable features) instead of silently producing emptiness (design D5:
+ * adapters surface unreadable evidence — task 2.2).
+ */
+export async function discoverLifecycle(input: { cwd: string; commonDir?: string }): Promise<Discovery> {
+  const commonDir = input.commonDir ?? (await lifecycleCommonDir(input.cwd))
+  const worktrees = await listWorktrees(input.cwd)
+  const mainDir = (await mainWorktreeDir(input.cwd).catch(() => undefined)) ?? worktrees.find((worktree) => worktree.main)?.dir ?? input.cwd
+
+  if (!commonDir) {
+    return {
+      storePresent: false,
+      features: [],
+      unreadableFeatures: [],
+      candidates: [],
+      worktrees,
+      legacyCloseEvidence: [],
+      runs: "unknown",
+      runsError: "not a git repository",
+    }
+  }
+
+  // Registered features first (design D6: discover registered features
+  // before unassociated candidates).
+  const ids = await listFeatureIds(commonDir)
+  const features: DiscoveredFeature[] = []
+  const unreadableFeatures: Discovery["unreadableFeatures"] = []
+  for (const featureId of ids) {
+    const read = await readFeatureRecord(commonDir, featureId)
+    if (isFound(read)) {
+      const attemptIds = await listAttemptIds(commonDir, featureId)
+      const attempts = await Promise.all(
+        attemptIds.map(async (attemptId) => {
+          const journal = await readAttemptJournal(commonDir, featureId, attemptId)
+          return { attemptId, journal: journal.status === "found" ? journal.value : undefined, journalStatus: journal.status }
+        }),
+      )
+      const receiptIds = await listReceiptIds(commonDir, featureId)
+      const receipts = await Promise.all(
+        receiptIds.map(async (attemptId) => {
+          const receipt = await readReceipt(commonDir, featureId, attemptId)
+          return { attemptId, receipt: receipt.status === "found" ? receipt.value : undefined }
+        }),
+      )
+      features.push({ featureId, record: read.value, attempts, receipts })
+    } else {
+      unreadableFeatures.push({
+        featureId,
+        status: read.status,
+        reason: read.status === "corrupt" || read.status === "unreadable" ? read.reason : "unsupported schema version",
+      })
+    }
+  }
+
+  // Active candidates: every worktree listing active change directories.
+  const candidates: DiscoveredCandidate[] = []
+  const seen = new Set<string>()
+  for (const worktree of worktrees) {
+    const idsHere = await listChangeIds(join(worktree.dir, openspecDirName, "changes"))
+    for (const changeId of idsHere) {
+      const key = `${worktree.dir}\0${changeId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      candidates.push({
+        changeId,
+        dir: worktree.dir,
+        ...(worktree.branch ? { branch: worktree.branch } : {}),
+        main: worktree.main,
+        hasMarkdown: await changeHasMarkdown(worktree.dir, changeId),
+      })
+    }
+  }
+
+  // Legacy close journals (the pre-identity branch/change-keyed records):
+  // listed as evidence only; adoption validates them explicitly (design D10).
+  const legacyCloseEvidence = await listLegacyCloseEvidence(commonDir)
+
+  // Run history: unknown on failure, never an empty set (design D5).
+  let runs: Discovery["runs"]
+  let runsError: string | undefined
+  try {
+    const entries = await listRuns()
+    runs = entries.map((entry) => ({
+      runID: entry.runID,
+      ...(entry.targetDir ? { targetDir: entry.targetDir } : {}),
+      live: entry.live,
+    }))
+  } catch (error) {
+    runs = "unknown"
+    runsError = error instanceof Error ? error.message : String(error)
+  }
+
+  return {
+    storePresent: true,
+    features,
+    unreadableFeatures,
+    candidates,
+    worktrees,
+    legacyCloseEvidence,
+    runs,
+    ...(runsError ? { runsError } : {}),
+  }
+}
+
+/** Reads the legacy branch/change-keyed close journals, if any. */
+async function listLegacyCloseEvidence(commonDir: string): Promise<LegacyCloseEvidence[]> {
+  const legacyDir = join(commonDir, "convoy", "close")
+  let entries
+  try {
+    entries = await readdir(legacyDir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  const { readCloseJournal } = await import("../close-journal")
+  const out: LegacyCloseEvidence[] = []
+  for (const entry of entries.filter((candidate) => candidate.isFile() && candidate.name.endsWith(".json"))) {
+    const match = entry.name.match(/^(.+)__(.+)\.json$/)
+    if (!match) continue
+    const journal = await readCloseJournal(commonDir, match[1]!, match[2]!)
+    if (!journal) continue
+    out.push({ branch: journal.branch, changeId: journal.changeID, phase: journal.phase })
+  }
+  return out
+}
+
+/** The current checkout's branch, typed for adapter reuse. */
+export async function branchAt(dir: string): Promise<string | undefined> {
+  return currentBranch(dir).catch(() => undefined)
+}
+
+/** True when a change id is a plausible OpenSpec change id (display filter). */
+export function plausibleChangeId(changeId: string): boolean {
+  return isOpenSpecChangeId(changeId)
+}

--- a/src/feature-lifecycle/launch.ts
+++ b/src/feature-lifecycle/launch.ts
@@ -1,0 +1,116 @@
+import { resolveFeature } from "./resolver"
+import { lifecycleCommonDir } from "./store"
+import { operationError } from "./commands"
+import type { FeaturePlanLink } from "../types"
+
+/**
+ * Launch-side lifecycle wiring (capability feature-lifecycle, capability
+ * run-launcher, tasks 4.3/4.4): resolve the reviewed feature/contract/context
+ * link for a launch, and revalidate it at execution time. A changed or
+ * unverifiable target stops with remediation rather than silently selecting
+ * another contract or branch (task 4.4). This check is additional to, not a
+ * replacement for, the existing dirty-tree consent and execution-time gate.
+ */
+
+export type ResolveLaunchFeatureInput = {
+  cwd: string
+  /** Explicit `--feature <id>`; invalid IDs refuse — no heuristic fallback. */
+  featureId?: string
+  /** The run's pinned change (`--change` or the Apply handoff), cross-checked against the feature's contracts. */
+  changeId?: string
+  /** A continue handoff's verified worktree/branch, cross-checked against the feature's context. */
+  branch?: string
+  worktreeDir?: string
+}
+
+/**
+ * Resolves the feature link a feature-backed launch freezes into its plan.
+ * `undefined` (no feature link) is valid: no-spec runs keep their existing
+ * flow without inventing a feature. When `--feature` does not resolve to a
+ * verified association, the error carries the explicit adoption/rebind
+ * command — unresolved headless requests never guess (design D3).
+ */
+export async function resolveFeatureForLaunch(input: ResolveLaunchFeatureInput): Promise<FeaturePlanLink | undefined> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) {
+    if (input.featureId) throw operationError("not a git repository", "missing")
+    return undefined
+  }
+  const resolution = await resolveFeature({
+    cwd: input.cwd,
+    commonDir,
+    ...(input.featureId ? { featureId: input.featureId } : {}),
+    ...(input.branch ? { branch: input.branch } : {}),
+    ...(input.changeId ? { changeId: input.changeId } : {}),
+  })
+  if (resolution.status === "verified") {
+    return {
+      featureId: resolution.feature.featureId,
+      repositoryId: resolution.feature.repositoryId,
+      associationRevision: resolution.context.associationRevision,
+      contracts: resolution.feature.contracts.map((contract) => contract.changeId),
+      baseRef: resolution.feature.intendedBaseRef,
+      branch: resolution.context.branch,
+      ...(resolution.context.checkoutPath ? { worktreeDir: resolution.context.checkoutPath } : {}),
+    }
+  }
+  if (!input.featureId) {
+    // No explicit feature request: an unassociated context launches without a
+    // link (the ordinary flow; review shows the proposed association).
+    return undefined
+  }
+  // An explicit --feature that does not verify refuses with the exact remediation.
+  const detail = "reason" in resolution ? resolution.reason : resolution.status
+  if (resolution.status === "unassociated") {
+    const branch = input.branch ?? resolution.candidates.find((candidate) => candidate.context)?.context?.branch
+    throw operationError(
+      `feature ${input.featureId} is not a verified association for this context` +
+        (detail ? ` (${detail})` : "") +
+        (branch ? ` — adopt it explicitly with \`convoy feature adopt --branch ${branch} --change <id> --base <local-ref>\`` : " — run `convoy feature show` to inspect it"),
+      "missing",
+    )
+  }
+  throw operationError(
+    `feature ${input.featureId}: ${detail} — run \`convoy feature show\` to list registered features, or adopt the work explicitly`,
+    resolution.status === "ambiguous" ? "ambiguous" : "missing",
+  )
+}
+
+/**
+ * Execution-time revalidation (task 4.4): the reviewed plan's feature link
+ * must still verify — same repository, same association revision, same
+ * branch/worktree/base. A changed target refuses; it never attaches the
+ * replacement context to the reviewed feature.
+ */
+export async function revalidateFeatureLink(input: { cwd: string; link: FeaturePlanLink }): Promise<void> {
+  const commonDir = await lifecycleCommonDir(input.cwd)
+  if (!commonDir) throw operationError(`the repository no longer resolves (feature ${input.link.featureId} cannot revalidate)`, "missing")
+  const resolution = await resolveFeature({ cwd: input.cwd, commonDir, featureId: input.link.featureId })
+  if (resolution.status !== "verified") {
+    const reason = "reason" in resolution ? resolution.reason : resolution.status
+    throw operationError(
+      `the reviewed feature context changed since review — the run refuses to start and attaches nothing to the new context (${reason}); ` +
+        "re-run the launcher for a fresh review, or rebind with `convoy feature bind` if the worktree moved",
+      "conflict" as never,
+    )
+  }
+  if (resolution.context.associationRevision !== input.link.associationRevision) {
+    throw operationError(
+      `the feature's association advanced (review ${input.link.associationRevision} → current ${resolution.context.associationRevision}) — ` +
+        "the run refuses to start with a stale reviewed contract set; re-run the launcher",
+      "conflict",
+    )
+  }
+  if (resolution.context.branch !== input.link.branch) {
+    throw operationError(
+      `the feature's branch changed since review (${input.link.branch} → ${resolution.context.branch}) — the run refuses to start and attaches nothing to the new branch`,
+      "conflict",
+    )
+  }
+  if (resolution.feature.intendedBaseRef !== input.link.baseRef) {
+    throw operationError(
+      `the feature's intended base changed since review (${input.link.baseRef} → ${resolution.feature.intendedBaseRef}) — re-run the launcher for a fresh review`,
+      "conflict",
+    )
+  }
+}

--- a/src/feature-lifecycle/observe.ts
+++ b/src/feature-lifecycle/observe.ts
@@ -1,0 +1,180 @@
+import { stat } from "node:fs/promises"
+import { join } from "node:path"
+
+import { currentBranch, execFile, findWorktreeDirForBranch, isAncestor, mainWorktreeDir, resolveCommit } from "../git"
+import { collectDirRelativeMarkdown, listChangeIds, openspecDirName } from "../openspec"
+import { observeLiveRunsAt, observeStatus, observeTaskCounts, observeUpstream } from "./adapters"
+import type { LifecycleObservations } from "./assessment"
+import { changeHasMarkdown, type Discovery } from "./discovery"
+import { listReceiptIds, readReceipt, type FeatureRecord } from "./records"
+import type { ContractObservation } from "./assessment"
+import { isLandingReachableFrom } from "./refs"
+
+/**
+ * Observation builders (task 2.2/2.5): assemble the typed observations the
+ * pure assessment consumes from live Git/run/artifact evidence for one
+ * feature record. Every failure is represented as unknown/unreadable — a
+ * failed read is never a negative fact (design D5).
+ */
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Builds observations for a feature: context verification (actual worktree,
+ * actual branch), per-contract artifact state and tasks, execution liveness,
+ * integration (verified receipt / probable patch-equivalence / pending),
+ * publication, and cleanup state.
+ */
+export async function buildObservationsForFeature(input: { cwd: string; commonDir: string; feature: FeatureRecord }): Promise<LifecycleObservations> {
+  const feature = input.feature
+  const mainDir = (await mainWorktreeDir(input.cwd).catch(() => undefined)) ?? input.cwd
+
+  // Context: verified only when Git currently reports the branch checked out
+  // at (or reconcilable with) the recorded checkout.
+  let context: LifecycleObservations["context"]
+  if (!feature.context) {
+    context = { verification: "unassociated" }
+  } else {
+    const registered = await findWorktreeDirForBranch(feature.context.branch, input.cwd).catch(() => undefined)
+    if (!registered) {
+      context = { verification: "missing", branch: feature.context.branch, reason: `branch "${feature.context.branch}" is not checked out anywhere` }
+    } else {
+      const actual = await currentBranch(registered).catch(() => undefined)
+      if (actual !== feature.context.branch) {
+        context = { verification: "ambiguous", branch: actual, reason: `worktree for "${feature.context.branch}" has "${actual ?? "a detached HEAD"}" checked out` }
+      } else if (feature.context.checkoutPath && registered.replace(/\/+$/, "") !== feature.context.checkoutPath.replace(/\/+$/, "")) {
+        context = { verification: "ambiguous", branch: actual, checkoutPath: registered, reason: `worktree moved from ${feature.context.checkoutPath} to ${registered}` }
+      } else {
+        context = { verification: "verified", branch: actual, checkoutPath: registered }
+      }
+    }
+  }
+  const checkout = context.verification === "verified" ? context.checkoutPath! : undefined
+
+  // Contracts: artifact state + tasks from the associated source.
+  const contracts: ContractObservation[] = []
+  for (const contract of feature.contracts) {
+    const sourceRoot = join(checkout ?? input.cwd, contract.sourcePath)
+    if (contract.kind === "active") {
+      const present = await exists(sourceRoot)
+      if (!present) {
+        contracts.push({ changeId: contract.changeId, state: "missing", reason: `${contract.sourcePath} is absent` })
+        continue
+      }
+      const hasMarkdown = await changeHasMarkdown(checkout ?? input.cwd, contract.changeId)
+      const counts = await observeTaskCounts(checkout ?? input.cwd)
+      const tasks = counts.kind === "known" ? counts.value.get(contract.changeId) ?? "unknown" : "unknown"
+      contracts.push({ changeId: contract.changeId, state: hasMarkdown ? "active" : "missing", ...(hasMarkdown ? {} : { reason: "no markdown artifacts (husk)" }), tasks })
+      continue
+    }
+    // Archived contract: positively verified only when the archive tree
+    // carries markdown at the recorded source path.
+    const archivePresent = await exists(sourceRoot)
+    const hasMarkdown = archivePresent ? (await collectDirRelativeMarkdown(sourceRoot, ".")).length > 0 : false
+    contracts.push({
+      changeId: contract.changeId,
+      state: archivePresent && hasMarkdown ? "verified-archived" : archivePresent ? "missing" : "missing",
+      reason: archivePresent && hasMarkdown ? undefined : `archive source ${contract.sourcePath} is ${archivePresent ? "a husk" : "absent"}`,
+    })
+  }
+
+  // Execution: live runs attached to the verified checkout.
+  let execution: LifecycleObservations["execution"]
+  if (checkout) {
+    const live = await observeLiveRunsAt(checkout)
+    execution = live.kind === "known" ? { kind: "known", liveRunIds: live.value, totalRuns: live.value.length } : { kind: "unknown", reason: live.reason }
+  } else {
+    execution = { kind: "known", liveRunIds: [], totalRuns: 0 }
+  }
+
+  // Integration: verified only through a receipt whose landing remains
+  // reachable and whose feature tip is unchanged (design D8); probable via
+  // patch equivalence (never upgraded); stale when evidence disagrees.
+  let integration: LifecycleObservations["integration"] = "pending"
+  if (feature.context?.branch) {
+    const tip = await resolveCommit(feature.context.branch, mainDir).catch(() => undefined)
+    const receiptId = (await listReceiptIds(input.commonDir, feature.featureId)).at(-1)
+    const receipt = receiptId ? await readReceipt(input.commonDir, feature.featureId, receiptId) : undefined
+    if (receipt && receipt.status === "found") {
+      const verified = receipt.value
+      const reachable = await isLandingReachableFrom(verified.landingSha, verified.baseRef, mainDir)
+      const tipUnchanged = tip === undefined || tip === verified.featureTip
+      integration = reachable && tipUnchanged ? "verified" : "stale"
+    } else if (tip && context.verification === "verified" && feature.intendedBaseRef) {
+      const synced = await isAncestor(feature.intendedBaseRef, feature.context.branch, mainDir).catch(() => false)
+      if (!synced) {
+        const cherry = await execFile("git", ["cherry", feature.intendedBaseRef, feature.context!.branch], { cwd: mainDir, allowFailure: true })
+        if (cherry.exitCode === 0) {
+          const lines = cherry.stdout.split("\n").filter((line) => line.trim() !== "")
+          if (lines.length > 0 && lines.every((line) => line.startsWith("-"))) integration = "probable"
+        }
+      }
+    }
+  }
+
+  // Publication: upstream observation only; never interpreted as PR state.
+  let publication: LifecycleObservations["publication"]
+  if (feature.context?.branch) {
+    const upstream = await observeUpstream(feature.context.branch, mainDir)
+    publication = upstream.kind === "known" ? { kind: "known", ...(upstream.value ? { upstream: upstream.value } : {}), published: upstream.value !== undefined } : { kind: "unknown", reason: upstream.reason }
+  } else {
+    publication = { kind: "known", published: false }
+  }
+
+  // Cleanup: worktree/branch presence relative to a verified landing.
+  let cleanup: LifecycleObservations["cleanup"]
+  if (integration === "verified") {
+    const worktreePresent = feature.context ? (await findWorktreeDirForBranch(feature.context.branch, input.cwd).catch(() => undefined)) !== undefined : false
+    const branchPresent = feature.context ? (await resolveCommit(feature.context.branch, mainDir).catch(() => undefined)) !== undefined : false
+    cleanup = { kind: "known", worktreePresent, branchPresent }
+  } else {
+    cleanup = { kind: "known", worktreePresent: false, branchPresent: false }
+  }
+
+  return {
+    feature,
+    context,
+    contracts,
+    execution,
+    integration,
+    publication,
+    cleanup,
+  }
+}
+
+/** Builds observations for the discovery-level candidates (unassociated work). */
+export async function buildObservationsForCandidate(input: { cwd: string; candidate: { changeId: string; dir: string; branch?: string; main: boolean } }): Promise<LifecycleObservations> {
+  const counts = await observeTaskCounts(input.candidate.dir)
+  const tasks = counts.kind === "known" ? counts.value.get(input.candidate.changeId) ?? "unknown" : "unknown"
+  return {
+    context: { verification: "unassociated" },
+    contracts: [{ changeId: input.candidate.changeId, state: "active", tasks }],
+    execution: { kind: "known", liveRunIds: [], totalRuns: 0 },
+    integration: "pending",
+    publication: { kind: "known", published: false },
+    cleanup: { kind: "known", worktreePresent: false, branchPresent: false },
+  }
+}
+
+/** Lists the active change ids of a checkout (shared adapter helper). */
+export async function activeChangeIdsAt(dir: string): Promise<string[]> {
+  return listChangeIds(join(dir, openspecDirName, "changes"))
+}
+
+/** Compact serializable snapshot of a discovery pass for JSON consumers. */
+export function summarizeDiscovery(discovery: Discovery): { features: number; candidates: number; unreadable: number } {
+  return { features: discovery.features.length, candidates: discovery.candidates.length, unreadable: discovery.unreadableFeatures.length }
+}
+
+/** Status observation shared with close preflights (typed wrapper). */
+export async function observeCheckoutStatus(dir: string): Promise<string | "unknown"> {
+  const status = await observeStatus(dir)
+  return status.kind === "known" ? status.value : "unknown"
+}

--- a/src/feature-lifecycle/records.ts
+++ b/src/feature-lifecycle/records.ts
@@ -1,0 +1,480 @@
+import { readdir, stat } from "node:fs/promises"
+import { join } from "node:path"
+
+import {
+  isSafePathSegment,
+  isSafeRelativePath,
+  isUuid,
+  lifecycleSchemaVersion,
+  readJsonFile,
+  writeJsonFile,
+  type StoreRead,
+} from "./store"
+
+/**
+ * The feature record (capability `feature-lifecycle`, design D1/D2): the
+ * durable association between one stable feature identity and its explicit
+ * change-contract set, intended base, and current implementation context —
+ * plus the history pointers that let discovery, close, and run history join
+ * on identity instead of branch spelling.
+ *
+ * The record stores associations and evidence references only. It never
+ * stores `ready`, `integrated`, or `clean` as authoritative facts: those are
+ * derived at read time from Git/OpenSpec/run evidence (design D5), so an
+ * external Git action can never be contradicted by a cached status.
+ */
+
+export type ContractSourceKind = "active" | "archive"
+
+/** One selected change contract within a feature's reviewed set (design D2). */
+export type FeatureContract = {
+  changeId: string
+  /** `active`: a live `openspec/changes/<id>/` tree; `archive`: an archived source. */
+  kind: ContractSourceKind
+  /**
+   * The repo-relative planning path the contract was selected from —
+   * `openspec/changes/<id>` for active sources, `openspec/archive/...` for
+   * archived ones. Paths are stored as given, resolved and validated
+   * (within the planning root) before use (design D7: never interpolate
+   * unchecked branch spelling into paths).
+   */
+  sourcePath: string
+  /** Where the selection came from (spin, adopt, revise, launch review). */
+  provenance: string
+  /** Association revision that selected this contract. */
+  selectedAtRevision: number
+}
+
+/** The current implementation context: one branch checked out in one worktree (design D2). */
+export type FeatureContext = {
+  branch: string
+  /** Absolute canonical checkout path, when known. */
+  checkoutPath?: string
+  /** Git's worktree administrative identity, when exposed. */
+  worktreeIdentity?: string
+}
+
+/** One historical association observation (rebinding, rename, move). */
+export type AssociationEvent = {
+  at: number
+  kind: "created" | "adopted" | "bound" | "revised" | "new-work" | "recovered"
+  summary: string
+  revision: number
+}
+
+/** The durable feature record (design D1). */
+export type FeatureRecord = {
+  schemaVersion: number
+  featureId: string
+  repositoryId: string
+  /** Operator-facing display name; never an identity key. */
+  displayName: string
+  /** Monotonically increasing; optimistic-concurrency token for association edits. */
+  associationRevision: number
+  contracts: FeatureContract[]
+  /** The intended local base ref (branch name), not a permanently frozen SHA (design D1). */
+  intendedBaseRef: string
+  /** The current context, when one is associated. */
+  context?: FeatureContext
+  /** Durable run IDs linked to this feature (written before execution). */
+  runIds: string[]
+  /** Close attempt IDs ever opened for this feature (completed or pending). */
+  closeAttemptIds: string[]
+  history: AssociationEvent[]
+  createdAt: number
+  updatedAt: number
+}
+
+export function validateFeatureRecord(value: unknown): FeatureRecord | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const record = value as Record<string, unknown>
+  if (record.schemaVersion !== lifecycleSchemaVersion) return undefined
+  if (typeof record.featureId !== "string" || !isUuid(record.featureId)) return undefined
+  if (typeof record.repositoryId !== "string" || !isUuid(record.repositoryId)) return undefined
+  if (typeof record.displayName !== "string" || record.displayName === "") return undefined
+  if (typeof record.associationRevision !== "number" || !Number.isInteger(record.associationRevision) || record.associationRevision < 1) return undefined
+  if (typeof record.intendedBaseRef !== "string" || record.intendedBaseRef === "") return undefined
+  if (typeof record.createdAt !== "number" || typeof record.updatedAt !== "number") return undefined
+  if (!Array.isArray(record.contracts) || !Array.isArray(record.runIds) || !Array.isArray(record.closeAttemptIds) || !Array.isArray(record.history)) return undefined
+  const contracts: FeatureContract[] = []
+  for (const entry of record.contracts) {
+    if (typeof entry !== "object" || entry === null) return undefined
+    const contract = entry as Record<string, unknown>
+    if (typeof contract.changeId !== "string" || contract.changeId === "" || !isSafePathSegment(contract.changeId)) return undefined
+    if (contract.kind !== "active" && contract.kind !== "archive") return undefined
+    if (typeof contract.sourcePath !== "string" || contract.sourcePath === "" || !isSafeRelativePath(contract.sourcePath)) return undefined
+    if (typeof contract.provenance !== "string" || typeof contract.selectedAtRevision !== "number") return undefined
+    contracts.push({
+      changeId: contract.changeId,
+      kind: contract.kind,
+      sourcePath: contract.sourcePath,
+      provenance: contract.provenance,
+      selectedAtRevision: contract.selectedAtRevision,
+    })
+  }
+  const events: AssociationEvent[] = []
+  for (const entry of record.history) {
+    if (typeof entry !== "object" || entry === null) return undefined
+    const event = entry as Record<string, unknown>
+    if (typeof event.at !== "number" || typeof event.kind !== "string" || typeof event.summary !== "string" || typeof event.revision !== "number") return undefined
+    events.push({ at: event.at, kind: event.kind as AssociationEvent["kind"], summary: event.summary, revision: event.revision })
+  }
+  let context: FeatureContext | undefined
+  if (record.context !== undefined) {
+    if (typeof record.context !== "object" || record.context === null) return undefined
+    const raw = record.context as Record<string, unknown>
+    if (typeof raw.branch !== "string" || raw.branch === "") return undefined
+    context = {
+      branch: raw.branch,
+      ...(typeof raw.checkoutPath === "string" ? { checkoutPath: raw.checkoutPath } : {}),
+      ...(typeof raw.worktreeIdentity === "string" ? { worktreeIdentity: raw.worktreeIdentity } : {}),
+    }
+  }
+  return {
+    schemaVersion: lifecycleSchemaVersion,
+    featureId: record.featureId,
+    repositoryId: record.repositoryId,
+    displayName: record.displayName,
+    associationRevision: record.associationRevision,
+    contracts,
+    intendedBaseRef: record.intendedBaseRef,
+    ...(context ? { context } : {}),
+    runIds: record.runIds.filter((entry): entry is string => typeof entry === "string"),
+    closeAttemptIds: record.closeAttemptIds.filter((entry): entry is string => typeof entry === "string"),
+    history: events,
+    createdAt: record.createdAt,
+    updatedAt: record.updatedAt,
+  }
+}
+
+export function featureDir(commonDir: string, featureId: string): string {
+  return join(commonDir, "convoy", "features", featureId)
+}
+
+function featureRecordPath(commonDir: string, featureId: string): string {
+  return join(featureDir(commonDir, featureId), "feature.json")
+}
+
+/** Reads one feature record; a foreign record (embedded IDs that disagree with its path) is corrupt. */
+export async function readFeatureRecord(commonDir: string, featureId: string): Promise<StoreRead<FeatureRecord>> {
+  const read = await readJsonFile(featureRecordPath(commonDir, featureId), validateFeatureRecord, {
+    unsupported: (value) => typeof value.schemaVersion === "number" && value.schemaVersion > lifecycleSchemaVersion,
+  })
+  if (read.status === "found" && (read.value.featureId !== featureId || !isUuid(featureId))) {
+    return { status: "corrupt", reason: "embedded identity disagrees with the record's location" }
+  }
+  return read
+}
+
+/**
+ * Lists every feature ID present in the store. A directory whose name is not
+ * a UUID is skipped — that is not a feature, and guessing otherwise would
+ * alias foreign data (design D10). Read-only: never creates anything.
+ */
+export async function listFeatureIds(commonDir: string): Promise<string[]> {
+  let entries
+  try {
+    entries = await readdir(join(commonDir, "convoy", "features"), { withFileTypes: true })
+  } catch {
+    return []
+  }
+  return entries.filter((entry) => entry.isDirectory() && isUuid(entry.name)).map((entry) => entry.name).sort()
+}
+
+/** Reads every feature record; unreadable/corrupt records are surfaced as typed failures, not dropped. */
+export async function listFeatureRecords(commonDir: string): Promise<Array<{ featureId: string; read: StoreRead<FeatureRecord> }>> {
+  const ids = await listFeatureIds(commonDir)
+  return Promise.all(ids.map(async (featureId) => ({ featureId, read: await readFeatureRecord(commonDir, featureId) })))
+}
+
+/**
+ * Persists a feature record, refusing a lost update: the caller names the
+ * revision it based its edit on, and a record already past that revision is
+ * left untouched (capability feature-lifecycle: concurrent association edits).
+ * `expectedRevision: 0` means "create new".
+ */
+export async function writeFeatureRecord(
+  commonDir: string,
+  record: FeatureRecord,
+  expectedRevision: number,
+): Promise<StoreRead<FeatureRecord>> {
+  const current = await readFeatureRecord(commonDir, record.featureId)
+  const onDisk = current.status === "found" ? current.value.associationRevision : 0
+  if (onDisk !== expectedRevision) return current.status === "found" ? current : { status: "corrupt", reason: "unexpected on-disk state" }
+  await writeJsonFile(featureRecordPath(commonDir, record.featureId), record)
+  return { status: "found", value: record }
+}
+
+// ── close attempts (journals) and receipts ───────────────────────────────
+
+/**
+ * The identity-keyed close attempt journal (design D8): a versioned record
+ * naming feature/attempt explicitly, capturing intent before each mutation
+ * and verified outcomes after it. Unlike the legacy branch/change-keyed
+ * journal (`close-journal.ts`), filenames are opaque attempt UUIDs, so
+ * renames, reused branch names, and multi-contract closes cannot collide or
+ * overwrite one another.
+ */
+/**
+ * One canonical-spec effect the archive must prove, snapshotted from the
+ * change's own delta specs BEFORE the OpenSpec CLI runs. Resume validates
+ * against this persisted snapshot — never against the archived copy, which
+ * the operator could edit after the fact (task 7.2).
+ */
+export type RequiredEffect = {
+  kind: "present" | "absent"
+  capability: string
+  name: string
+  scenarios: string[]
+}
+
+export type CloseAttemptPhase =
+  | "resolved"
+  | "sync-intent"
+  | "sync-verified"
+  | "archive-intent"
+  | "archive-verified"
+  | "prepared"
+  | "candidate"
+  | "landed"
+
+export type CloseAttemptJournal = {
+  schemaVersion: number
+  attemptId: string
+  featureId: string
+  repositoryId: string
+  /** The association revision the attempt validated against. */
+  associationRevision: number
+  phase: CloseAttemptPhase
+  contracts: Array<{ changeId: string; sourcePath: string; archiveCommitted: boolean; requiredEffects?: RequiredEffect[] }>
+  baseRef: string
+  baseSha: string
+  branch: string
+  worktreeDir?: string
+  preSyncTip?: string
+  postArchiveTip?: string
+  preparedTree?: string
+  messageContext?: { proposalExcerpt?: string; scopeCandidates: string[]; commitSubjects: string[] }
+  message?: string
+  candidateSha?: string
+  landingSha?: string
+  /** Whether the base checkout has been materialized onto the landed ref (task 7.5). */
+  checkoutMaterialized?: boolean
+  recordedAt: number
+  updatedAt: number
+}
+
+function attemptJournalPath(commonDir: string, featureId: string, attemptId: string): string {
+  return join(featureDir(commonDir, featureId), "attempts", attemptId, "journal.json")
+}
+
+export function validateAttemptJournal(value: unknown): CloseAttemptJournal | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const journal = value as Record<string, unknown>
+  if (journal.schemaVersion !== lifecycleSchemaVersion) return undefined
+  if (typeof journal.attemptId !== "string" || !isUuid(journal.attemptId)) return undefined
+  if (typeof journal.featureId !== "string" || !isUuid(journal.featureId)) return undefined
+  if (typeof journal.repositoryId !== "string" || !isUuid(journal.repositoryId)) return undefined
+  if (typeof journal.associationRevision !== "number") return undefined
+  const phase = journal.phase
+  const phases: readonly string[] = ["resolved", "sync-intent", "sync-verified", "archive-intent", "archive-verified", "prepared", "candidate", "landed"]
+  if (typeof phase !== "string" || !phases.includes(phase)) return undefined
+  if (typeof journal.baseRef !== "string" || typeof journal.baseSha !== "string" || typeof journal.branch !== "string") return undefined
+  if (!Array.isArray(journal.contracts)) return undefined
+  if (typeof journal.recordedAt !== "number" || typeof journal.updatedAt !== "number") return undefined
+  let messageContext: CloseAttemptJournal["messageContext"]
+  if (journal.messageContext !== undefined) {
+    if (typeof journal.messageContext !== "object" || journal.messageContext === null) return undefined
+    const raw = journal.messageContext as Record<string, unknown>
+    messageContext = {
+      ...(typeof raw.proposalExcerpt === "string" ? { proposalExcerpt: raw.proposalExcerpt } : {}),
+      scopeCandidates: Array.isArray(raw.scopeCandidates) ? raw.scopeCandidates.filter((entry): entry is string => typeof entry === "string") : [],
+      commitSubjects: Array.isArray(raw.commitSubjects) ? raw.commitSubjects.filter((entry): entry is string => typeof entry === "string") : [],
+    }
+  }
+  const optional = (key: keyof typeof journal): string | undefined => {
+    const value = journal[key]
+    return typeof value === "string" && value !== "" ? value : undefined
+  }
+  return {
+    schemaVersion: lifecycleSchemaVersion,
+    attemptId: journal.attemptId,
+    featureId: journal.featureId,
+    repositoryId: journal.repositoryId,
+    associationRevision: journal.associationRevision,
+    phase: phase as CloseAttemptPhase,
+    contracts: (journal.contracts as unknown[]).flatMap((entry) => {
+      if (typeof entry !== "object" || entry === null) return []
+      const contract = entry as Record<string, unknown>
+      if (typeof contract.changeId !== "string" || !isSafePathSegment(contract.changeId)) return []
+      if (typeof contract.sourcePath !== "string" || !isSafeRelativePath(contract.sourcePath)) return []
+      let requiredEffects: RequiredEffect[] | undefined
+      if (Array.isArray(contract.requiredEffects)) {
+        const parsed: RequiredEffect[] = []
+        for (const effect of contract.requiredEffects) {
+          if (typeof effect !== "object" || effect === null) continue
+          const raw = effect as Record<string, unknown>
+          if ((raw.kind !== "present" && raw.kind !== "absent") || typeof raw.capability !== "string" || !isSafePathSegment(raw.capability) || typeof raw.name !== "string") continue
+          parsed.push({
+            kind: raw.kind,
+            capability: raw.capability,
+            name: raw.name,
+            scenarios: Array.isArray(raw.scenarios) ? raw.scenarios.filter((scenario): scenario is string => typeof scenario === "string") : [],
+          })
+        }
+        requiredEffects = parsed
+      }
+      return [{
+        changeId: contract.changeId,
+        sourcePath: contract.sourcePath,
+        archiveCommitted: contract.archiveCommitted === true,
+        ...(requiredEffects ? { requiredEffects } : {}),
+      }]
+    }),
+    baseRef: journal.baseRef,
+    baseSha: journal.baseSha,
+    branch: journal.branch,
+    ...(optional("worktreeDir") ? { worktreeDir: optional("worktreeDir") } : {}),
+    ...(optional("preSyncTip") ? { preSyncTip: optional("preSyncTip") } : {}),
+    ...(optional("postArchiveTip") ? { postArchiveTip: optional("postArchiveTip") } : {}),
+    ...(optional("preparedTree") ? { preparedTree: optional("preparedTree") } : {}),
+    ...(messageContext ? { messageContext } : {}),
+    ...(optional("message") ? { message: optional("message") } : {}),
+    ...(optional("candidateSha") ? { candidateSha: optional("candidateSha") } : {}),
+    ...(optional("landingSha") ? { landingSha: optional("landingSha") } : {}),
+    ...(typeof journal.checkoutMaterialized === "boolean" ? { checkoutMaterialized: journal.checkoutMaterialized } : {}),
+    recordedAt: journal.recordedAt,
+    updatedAt: journal.updatedAt,
+  }
+}
+
+export async function readAttemptJournal(
+  commonDir: string,
+  featureId: string,
+  attemptId: string,
+): Promise<StoreRead<CloseAttemptJournal>> {
+  const read = await readJsonFile(attemptJournalPath(commonDir, featureId, attemptId), validateAttemptJournal, {
+    unsupported: (value) => typeof value.schemaVersion === "number" && value.schemaVersion > lifecycleSchemaVersion,
+  })
+  if (read.status === "found" && (read.value.featureId !== featureId || read.value.attemptId !== attemptId)) {
+    return { status: "corrupt", reason: "embedded identity disagrees with the record's location" }
+  }
+  return read
+}
+
+export async function writeAttemptJournal(commonDir: string, journal: CloseAttemptJournal): Promise<void> {
+  await writeJsonFile(attemptJournalPath(commonDir, journal.featureId, journal.attemptId), journal)
+}
+
+/** Lists a feature's attempt IDs (read-only). */
+export async function listAttemptIds(commonDir: string, featureId: string): Promise<string[]> {
+  try {
+    const entries = await readdir(join(featureDir(commonDir, featureId), "attempts"), { withFileTypes: true })
+    return entries.filter((entry) => entry.isDirectory() && isUuid(entry.name)).map((entry) => entry.name).sort()
+  } catch {
+    return []
+  }
+}
+
+// ── receipts ──────────────────────────────────────────────────────────────
+
+/**
+ * The immutable verified landing receipt (design D8/D9): written once, after
+ * the landing is verified, and never overwritten — later attempts and
+ * no-change outcomes must not clobber it (capability feature-lifecycle:
+ * completed landing receipts are durable).
+ */
+export type LandingReceipt = {
+  schemaVersion: number
+  attemptId: string
+  featureId: string
+  repositoryId: string
+  associationRevision: number
+  branch: string
+  baseRef: string
+  baseSha: string
+  /** The exact prepared feature tip the landing was built from. */
+  featureTip: string
+  preparedTree: string
+  candidateSha: string
+  landingSha: string
+  landingAt: number
+}
+
+function receiptPath(commonDir: string, featureId: string, attemptId: string): string {
+  return join(featureDir(commonDir, featureId), "receipts", `${attemptId}.json`)
+}
+
+export function validateReceipt(value: unknown): LandingReceipt | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const receipt = value as Record<string, unknown>
+  if (receipt.schemaVersion !== lifecycleSchemaVersion) return undefined
+  for (const key of ["attemptId", "featureId", "repositoryId", "branch", "baseRef", "baseSha", "featureTip", "preparedTree", "candidateSha", "landingSha"] as const) {
+    if (typeof receipt[key] !== "string" || receipt[key] === "") return undefined
+  }
+  if (!isUuid(receipt.attemptId as string) || !isUuid(receipt.featureId as string) || !isUuid(receipt.repositoryId as string)) return undefined
+  if (typeof receipt.associationRevision !== "number" || typeof receipt.landingAt !== "number") return undefined
+  return {
+    schemaVersion: lifecycleSchemaVersion,
+    attemptId: receipt.attemptId as string,
+    featureId: receipt.featureId as string,
+    repositoryId: receipt.repositoryId as string,
+    associationRevision: receipt.associationRevision,
+    branch: receipt.branch as string,
+    baseRef: receipt.baseRef as string,
+    baseSha: receipt.baseSha as string,
+    featureTip: receipt.featureTip as string,
+    preparedTree: receipt.preparedTree as string,
+    candidateSha: receipt.candidateSha as string,
+    landingSha: receipt.landingSha as string,
+    landingAt: receipt.landingAt,
+  }
+}
+
+export async function readReceipt(commonDir: string, featureId: string, attemptId: string): Promise<StoreRead<LandingReceipt>> {
+  const read = await readJsonFile(receiptPath(commonDir, featureId, attemptId), validateReceipt, {
+    unsupported: (value) => typeof value.schemaVersion === "number" && value.schemaVersion > lifecycleSchemaVersion,
+  })
+  if (read.status === "found" && (read.value.featureId !== featureId || read.value.attemptId !== attemptId)) {
+    return { status: "corrupt", reason: "embedded identity disagrees with the record's location" }
+  }
+  return read
+}
+
+/**
+ * Writes a receipt create-only: an existing receipt file for the same
+ * attempt is never overwritten (immutability). The write lands through a
+ * rename, so a torn file can never exist at the final path.
+ */
+export async function writeReceiptIfAbsent(commonDir: string, receipt: LandingReceipt): Promise<boolean> {
+  const path = receiptPath(commonDir, receipt.featureId, receipt.attemptId)
+  try {
+    await stat(path)
+    return false
+  } catch {
+    // Absent: proceed with the create.
+  }
+  await writeJsonFile(path, receipt)
+  return true
+}
+
+/** Lists a feature's receipt IDs (read-only). */
+export async function listReceiptIds(commonDir: string, featureId: string): Promise<string[]> {
+  try {
+    const entries = await readdir(join(featureDir(commonDir, featureId), "receipts"), { withFileTypes: true })
+    return entries.filter((entry) => entry.isFile() && entry.name.endsWith(".json")).map((entry) => entry.name.replace(/\.json$/, "")).sort()
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Whether a feature has completed: a verified landing receipt exists naming
+ * the feature (task 8.2/D2). Completion releases the feature's context
+ * claim, so a new feature may reuse the branch through the explicit
+ * new-work decision.
+ */
+export async function isCompletedFeature(commonDir: string, feature: Pick<FeatureRecord, "featureId">): Promise<boolean> {
+  const receiptIds = await listReceiptIds(commonDir, feature.featureId)
+  return receiptIds.length > 0
+}

--- a/src/feature-lifecycle/refs.ts
+++ b/src/feature-lifecycle/refs.ts
@@ -1,0 +1,66 @@
+import { execFile } from "../git"
+import { createRefIfAbsent, refExists, resolveRef } from "../finalization/refs"
+
+/**
+ * Protected feature/attempt refs (design D1, task 1.4): every close attempt
+ * gets a private, create-only namespace under
+ * `refs/convoy/features/<feature-id>/<attempt-id>/` holding the prepared
+ * feature tip and the landing candidate. Identities are opaque UUIDs, so a
+ * renamed branch or a reused branch name can never collide with old
+ * evidence — unlike the legacy branch-spelled namespace.
+ *
+ * Creation is create-only (`git update-ref` with the all-zero expected old
+ * value), and a pre-existing ref whose value disagrees with the evidence
+ * being recorded is refused, never silently overwritten.
+ */
+
+const zeroSha = "0000000000000000000000000000000000000000"
+
+export function featureRefPrefix(featureId: string, attemptId: string): string {
+  return `refs/convoy/features/${featureId}/${attemptId}`
+}
+
+/** The prepared (post-archive) feature tip for one attempt. */
+export function featureTipRef(featureId: string, attemptId: string): string {
+  return `${featureRefPrefix(featureId, attemptId)}/feature-tip`
+}
+
+/** The one-parent landing candidate for one attempt. */
+export function featureCandidateRef(featureId: string, attemptId: string): string {
+  return `${featureRefPrefix(featureId, attemptId)}/candidate`
+}
+
+/**
+ * Protects `ref` at `sha` create-only. When the ref already exists the
+ * existing value is verified: a match is a no-op (idempotent replay),
+ * a mismatch throws — a pre-existing ref at a different object is evidence
+ * Convoy must not overwrite (task 1.4).
+ */
+export async function protectFeatureRef(ref: string, sha: string, cwd: string): Promise<void> {
+  if (await refExists(ref, cwd)) {
+    const existing = await resolveRef(ref, cwd)
+    if (existing === sha) return
+    throw new Error(
+      `ref ${ref} already exists at ${(existing ?? "?").slice(0, 8)} but the evidence names ${sha.slice(0, 8)} — refusing to overwrite protected evidence`,
+    )
+  }
+  await createRefIfAbsent(ref, sha, cwd)
+}
+
+/** Reads a protected ref's object, or undefined when absent/unresolvable. */
+export async function readProtectedRef(ref: string, cwd: string): Promise<string | undefined> {
+  return resolveRef(ref, cwd)
+}
+
+/** True when `landing` is reachable from `baseRef` — the receipt's reachability half. */
+export async function isLandingReachableFrom(landing: string, baseRef: string, cwd: string): Promise<boolean> {
+  const base = await execFile("git", ["rev-parse", "--verify", "--quiet", `${baseRef}^{commit}`], { cwd, allowFailure: true })
+  if (base.exitCode !== 0) return false
+  const commit = await execFile("git", ["rev-parse", "--verify", "--quiet", `${landing}^{commit}`], { cwd, allowFailure: true })
+  if (commit.exitCode !== 0) return false
+  const ancestor = await execFile("git", ["merge-base", "--is-ancestor", landing, baseRef], { cwd, allowFailure: true })
+  return ancestor.exitCode === 0
+}
+
+/** The expected-absent old value used for create-only ref writes (exported for tests). */
+export const zeroRefOldValue = zeroSha

--- a/src/feature-lifecycle/resolver.ts
+++ b/src/feature-lifecycle/resolver.ts
@@ -1,0 +1,271 @@
+import { realpath } from "node:fs/promises"
+import { isAbsolute, join, relative, resolve, sep } from "node:path"
+
+import { currentBranch, findWorktreeDirForBranch, mainWorktreeDir } from "../git"
+import { branchIdFromBranch, isOpenSpecChangeId } from "../openspec"
+import { isFound, isUuid, lifecycleCommonDir, readRepositoryRecord, type StoreRead } from "./store"
+import {
+  listFeatureRecords,
+  readFeatureRecord,
+  type FeatureRecord,
+} from "./records"
+
+/**
+ * The one shared resolver (capability `feature-lifecycle`, design D3): board,
+ * launcher, continue, publication, and close all resolve a selected feature
+ * through this module, so "which work does this action target" has exactly
+ * one answer.
+ *
+ * Resolution order (design D3):
+ *   1. explicit feature ID;
+ *   2. verified current context association (the checkout a command runs in);
+ *   3. unique association selected by explicit branch/change filters;
+ *   4. otherwise unresolved candidates.
+ *
+ * The result is tagged with evidence and blockers — never an optional branch
+ * string — and an invalid explicit selector never falls through to a
+ * heuristic (task 2.3): a mistyped ID or a contradictory selector refuses
+ * instead of silently resolving to different work.
+ */
+
+export type ResolutionStatus = "verified" | "unassociated" | "ambiguous" | "missing" | "unreadable"
+
+export type FeatureResolution =
+  | {
+      status: "verified"
+      feature: FeatureRecord
+      /** The context that verified: association revision, actual branch, checkout path. */
+      context: { branch: string; checkoutPath?: string; associationRevision: number }
+    }
+  | { status: "unassociated"; candidates: FeatureRecord[]; reason?: string }
+  | { status: "ambiguous"; candidates: FeatureRecord[]; reason: string }
+  | { status: "missing"; reason: string }
+  | { status: "unreadable"; reason: string }
+
+export type ResolveFeatureInput = {
+  /** Working directory the command runs in (for context verification). */
+  cwd: string
+  commonDir?: string
+  /** Rule 1: an explicit feature ID. Invalid IDs refuse — never a heuristic fallback. */
+  featureId?: string
+  /** Explicit branch selector; must agree with the resolved feature. */
+  branch?: string
+  /** Explicit change selector; must name one of the resolved feature's contracts. */
+  changeId?: string
+  /**
+   * The checkout's actual branch, when the caller already resolved it.
+   * Otherwise the resolver reads it from `cwd`.
+   */
+  currentBranch?: string
+}
+
+/** Fails when a store read is not `found`, producing the matching tagged result. */
+function fromStoreRead<T>(read: StoreRead<T>, reasonFor: (read: StoreRead<T>) => string): { ok: true; value: T } | { ok: false; result: FeatureResolution } {
+  switch (read.status) {
+    case "found":
+      return { ok: true, value: read.value }
+    case "missing":
+      return { ok: false, result: { status: "missing", reason: reasonFor(read) } }
+    case "corrupt":
+      return { ok: false, result: { status: "unreadable", reason: `record corrupt: ${read.reason}` } }
+    case "unsupported":
+      return { ok: false, result: { status: "unreadable", reason: `record uses an unsupported schema version (${String(read.schemaVersion)})` } }
+    case "unreadable":
+      return { ok: false, result: { status: "unreadable", reason: read.reason } }
+  }
+}
+
+/**
+ * Whether the store exists yet: an uninitialized repository resolves to
+ * `unassociated` (with no candidates), never to `missing` — work simply
+ * hasn't been adopted (design D3).
+ */
+async function storePresent(commonDir: string): Promise<boolean> {
+  const record = await readRepositoryRecord(commonDir)
+  return record.status !== "missing"
+}
+
+/**
+ * Does this feature's context match the given checkout? A verified context
+ * requires the recorded branch to be checked out at the path. Path equality
+ * is compared through realpath so /var vs /private/var aliases match.
+ */
+async function contextMatches(feature: FeatureRecord, cwd: string): Promise<boolean> {
+  if (!feature.context) return false
+  const actual = await currentBranch(cwd).catch(() => undefined)
+  if (actual !== feature.context.branch) return false
+  if (feature.context.checkoutPath) {
+    const same = await sameRealPath(feature.context.checkoutPath, cwd)
+    if (!same) return false
+  }
+  return true
+}
+
+async function sameRealPath(a: string, b: string): Promise<boolean> {
+  try {
+    return (await realpath(a)) === (await realpath(b))
+  } catch {
+    return resolve(a) === resolve(b)
+  }
+}
+
+function selectorsAgree(feature: FeatureRecord, input: ResolveFeatureInput): string | undefined {
+  if (input.branch && feature.context?.branch !== input.branch) {
+    return `feature ${feature.featureId} is associated with branch "${feature.context?.branch ?? "(none)"}", not "${input.branch}"`
+  }
+  if (input.changeId && !feature.contracts.some((contract) => contract.changeId === input.changeId)) {
+    return `change "${input.changeId}" is not one of feature ${feature.featureId}'s contracts (${feature.contracts.map((contract) => contract.changeId).join(", ") || "none"})`
+  }
+  return undefined
+}
+
+/**
+ * The resolver. Every path either verifies positively or returns a tagged
+ * refusal with evidence (task 2.3).
+ */
+export async function resolveFeature(input: ResolveFeatureInput): Promise<FeatureResolution> {
+  const commonDir = input.commonDir ?? (input.cwd ? await lifecycleCommonDir(input.cwd) : undefined)
+  if (!commonDir) return { status: "unassociated", candidates: [], reason: "not a git repository" }
+  if (!(await storePresent(commonDir))) {
+    return input.featureId
+      ? { status: "missing", reason: `no feature registry exists yet, so feature ${input.featureId} is unknown` }
+      : { status: "unassociated", candidates: [] }
+  }
+
+  // Rule 1: explicit feature ID. A mistyped/unknown ID is `missing` — it never
+  // falls through to context or branch heuristics (design D3).
+  if (input.featureId !== undefined) {
+    if (!isUuid(input.featureId)) {
+      return { status: "missing", reason: `"${input.featureId}" is not a feature id (expected an opaque UUID; run \`convoy feature show\` to list them)` }
+    }
+    const read = await readFeatureRecord(commonDir, input.featureId)
+    const loaded = fromStoreRead(read, () => `no registered feature ${input.featureId}`)
+    if (!loaded.ok) return loaded.result
+    const conflict = selectorsAgree(loaded.value, input)
+    if (conflict) return { status: "ambiguous", candidates: [loaded.value], reason: conflict }
+    return await verifyFeature(loaded.value, input)
+  }
+
+  // Rule 2: verified current context association.
+  const branch = input.branch ?? input.currentBranch ?? (await currentBranch(input.cwd).catch(() => undefined))
+  const listing = await listFeatureRecords(commonDir)
+  const unreadable = listing.filter((entry) => entry.read.status === "corrupt" || entry.read.status === "unreadable" || entry.read.status === "unsupported")
+  const features = listing.flatMap((entry) => (isFound(entry.read) ? [entry.read.value] : []))
+
+  for (const feature of features) {
+    if (await contextMatches(feature, input.cwd)) {
+      const conflict = selectorsAgree(feature, input)
+      if (conflict) return { status: "ambiguous", candidates: [feature], reason: conflict }
+      return await verifyFeature(feature, input)
+    }
+  }
+
+  // Rule 3: unique association selected by explicit filters.
+  const branchMatches = input.branch ? features.filter((feature) => feature.context?.branch === input.branch) : []
+  const changeMatches = input.changeId
+    ? features.filter((feature) => feature.contracts.some((contract) => contract.changeId === input.changeId))
+    : []
+  const filtered = input.branch || input.changeId ? (input.branch ? branchMatches : changeMatches) : []
+  if (filtered.length === 1) {
+    const feature = filtered[0]!
+    const conflict = selectorsAgree(feature, input)
+    if (conflict) return { status: "ambiguous", candidates: [feature], reason: conflict }
+    return await verifyFeature(feature, input)
+  }
+  if (filtered.length > 1) {
+    return { status: "ambiguous", candidates: filtered, reason: `${filtered.length} registered features match the selectors; name one explicitly with --feature <id>` }
+  }
+
+  // Nothing matched explicitly. Contradictory selectors are ambiguous, and
+  // unreadable records surface as unreadable rather than silently empty.
+  if (unreadable.length > 0) {
+    const reason = unreadable
+      .map((entry) => {
+        const status = entry.read.status
+        if (status === "corrupt" || status === "unreadable") return `${entry.featureId}: ${entry.read.reason}`
+        return `${entry.featureId}: unsupported schema`
+      })
+      .join("; ")
+    return { status: "unreadable", reason: `some feature records could not be read — resolve before mutating (${reason})` }
+  }
+  if (input.branch && input.changeId) {
+    return {
+      status: "unassociated",
+      candidates: features,
+      reason: `no registered feature associates branch "${input.branch}" with change "${input.changeId}"`,
+    }
+  }
+  return { status: "unassociated", candidates: features }
+}
+
+/**
+ * Positively verifies a resolved feature's current context (task 2.3): the
+ * recorded branch must still be checked out somewhere in the repository and,
+ * when a path is recorded, the path must be a registered worktree carrying
+ * that branch. A renamed/moved context stays `verified` only when Git agrees.
+ */
+async function verifyFeature(feature: FeatureRecord, input: ResolveFeatureInput): Promise<FeatureResolution> {
+  if (!feature.context) {
+    return { status: "unassociated", candidates: [feature], reason: `feature ${feature.featureId} has no implementation context` }
+  }
+  const registered = (await findWorktreeDirForBranch(feature.context.branch, input.cwd)) ?? undefined
+  if (!registered) {
+    return {
+      status: "missing",
+      reason: `branch "${feature.context.branch}" is not checked out in any worktree of this repository — rebind or recover`,
+    }
+  }
+  if (feature.context.checkoutPath && !(await sameRealPath(feature.context.checkoutPath, registered))) {
+    // Git moved the worktree; the association is stale until rebound.
+    return {
+      status: "ambiguous",
+      candidates: [feature],
+      reason: `the worktree for "${feature.context.branch}" moved from ${feature.context.checkoutPath} to ${registered} — rebind to verify`,
+    }
+  }
+  return {
+    status: "verified",
+    feature,
+    context: { branch: feature.context.branch, checkoutPath: registered, associationRevision: feature.associationRevision },
+  }
+}
+
+/**
+ * Convenience: the change IDs a resolution names, for consumers that only
+ * need the contract set (launcher pinning, close selectors).
+ */
+export function contractsOf(resolution: FeatureResolution): string[] {
+  if (resolution.status === "verified") return resolution.feature.contracts.map((contract) => contract.changeId)
+  return []
+}
+
+/**
+ * Validates a repo-relative planning path: it must stay inside the planning
+ * root (no `..` escape, no absolute path), supporting symlink escape checks
+ * by comparing real paths after resolution (design D3/D7).
+ */
+export function planningPathWithin(planningRoot: string, candidate: string): string | undefined {
+  if (candidate === "" || isAbsolute(candidate)) return undefined
+  const full = resolve(join(planningRoot, candidate))
+  const rel = relative(resolve(planningRoot), full)
+  if (rel === "" || rel.startsWith("..") || rel.includes(`..${sep}`)) return undefined
+  return rel
+}
+
+/**
+ * The main checkout of the repository hosting `cwd` — the planning root for
+ * path validation and archive-on-main operations.
+ */
+export async function planningRootFor(cwd: string): Promise<string | undefined> {
+  return mainWorktreeDir(cwd).catch(() => undefined)
+}
+
+/** Re-exported guard: a change id must pass OpenSpec's own id rules. */
+export function isValidChangeSelector(changeId: string): boolean {
+  return isOpenSpecChangeId(changeId) && !changeId.includes("/")
+}
+
+/** The slug a branch carries under the conventional `<type>/<change-id>` spelling — display only. */
+export function displaySlugFor(branch: string): string | undefined {
+  return branchIdFromBranch(branch)
+}

--- a/src/feature-lifecycle/store.ts
+++ b/src/feature-lifecycle/store.ts
@@ -1,0 +1,273 @@
+import { mkdir, open, readFile, rename, rm, stat } from "node:fs/promises"
+import { dirname, join } from "node:path"
+
+import { execFile } from "../git"
+
+/**
+ * The lifecycle store (capability `feature-lifecycle`, design D1): a
+ * versioned, repository-local record set under the canonical Git common
+ * directory, shared by every worktree of one repository.
+ *
+ * Layout:
+ *
+ *   <git-common-dir>/convoy/
+ *     repository.json                            # repository UUID + schema version
+ *     features/<feature-id>/feature.json         # current association + revision
+ *     features/<feature-id>/attempts/<attempt-id>/journal.json
+ *     features/<feature-id>/receipts/<attempt-id>.json
+ *
+ * Identities are opaque UUIDs — branch/change spellings are never encoded into
+ * filenames, so renames and reused names cannot alias records. Reads are
+ * strictly read-only: nothing in this module creates the repository UUID,
+ * locks, or any other file as a side effect of inspection (design D1: reads do
+ * not create).
+ */
+
+export const lifecycleSchemaVersion = 1
+
+/**
+ * Every read returns a typed result (task 1.1): missing, corrupt
+ * (parseable-but-invalid), unsupported (a newer schema we must not
+ * interpret), and unreadable (I/O or permission failure) are distinct —
+ * they are never collapsed into absence, because several safety decisions
+ * (fail-closed preflights, "unknown ≠ empty") depend on the difference.
+ */
+export type StoreRead<T> =
+  | { status: "found"; value: T }
+  | { status: "missing" }
+  | { status: "corrupt"; reason: string }
+  | { status: "unsupported"; schemaVersion: unknown }
+  | { status: "unreadable"; reason: string }
+
+export type StoreReadError = Extract<StoreRead<never>, { status: "corrupt" | "unsupported" | "unreadable" }>
+
+/** True when a read proves the record exists and validated; false otherwise. */
+export function isFound<T>(read: StoreRead<T>): read is { status: "found"; value: T } {
+  return read.status === "found"
+}
+
+/** The repository UUID record (D1): membership proof for everything under `convoy/`. */
+export type RepositoryRecord = {
+  schemaVersion: number
+  /** Opaque UUID for this repository's shared record set. */
+  repositoryId: string
+  createdAt: number
+}
+
+/** Whether `path` exists (file or directory). */
+export async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Parses one JSON document against a validator. `unsupported` is decided by
+ * the caller's schema gate — usually a `schemaVersion` comparison — while
+ * malformed JSON is `corrupt` and I/O failure is `unreadable`.
+ */
+export async function readJsonFile<T>(
+  path: string,
+  validate: (value: unknown) => T | undefined,
+  options: { unsupported?: (value: Record<string, unknown>) => boolean } = {},
+): Promise<StoreRead<T>> {
+  let raw: string
+  try {
+    raw = await readFile(path, "utf8")
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | undefined)?.code
+    if (code === "ENOENT") return { status: "missing" }
+    return { status: "unreadable", reason: error instanceof Error ? error.message : String(error) }
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (error) {
+    return { status: "corrupt", reason: error instanceof Error ? error.message : String(error) }
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { status: "corrupt", reason: "record is not a JSON object" }
+  }
+  if (options.unsupported?.(parsed as Record<string, unknown>)) {
+    return { status: "unsupported", schemaVersion: (parsed as Record<string, unknown>).schemaVersion }
+  }
+  const value = validate(parsed)
+  if (value === undefined) return { status: "corrupt", reason: "record failed validation" }
+  return { status: "found", value }
+}
+
+/**
+ * Writes a JSON document atomically: content lands at `<path>.<uuid>.tmp`
+ * first and is renamed into place, so a crash mid-write never exposes a torn
+ * record. The caller is responsible for conflict detection (see
+ * `withFeatureLock`) and for refusing to write when required evidence
+ * cannot be persisted (design D1: required persistence failures stop before
+ * the corresponding mutation).
+ */
+export async function writeJsonFile(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  const tmp = `${path}.${crypto.randomUUID()}.tmp`
+  try {
+    await Bun.write(tmp, JSON.stringify(value, null, 2) + "\n")
+    await rename(tmp, path)
+  } catch (error) {
+    await rm(tmp, { force: true }).catch(() => {})
+    throw error
+  }
+}
+
+/**
+ * Removes a file best-effort (force: true, errors swallowed): used only for
+ * superseded scratch state, never for receipts or journals (ordinary cleanup
+ * MUST NOT delete recovery evidence — capability feature-lifecycle).
+ */
+export async function removePath(path: string): Promise<void> {
+  await rm(path, { force: true, recursive: true }).catch(() => {})
+}
+
+/**
+ * The repository's Git common dir, or undefined outside a repository. Every
+ * worktree of one repository shares it, which is what makes the record set
+ * common (capability feature-lifecycle: worktrees sharing a Git common
+ * directory share the records).
+ */
+export async function lifecycleCommonDir(cwd: string): Promise<string | undefined> {
+  return execFile("git", ["rev-parse", "--path-format=absolute", "--git-common-dir"], { cwd, allowFailure: true }).then(
+    (result) => (result.exitCode === 0 ? result.stdout.trim() || undefined : undefined),
+    () => undefined,
+  )
+}
+
+/** `<commonDir>/convoy` — the record set root. */
+export function lifecycleRoot(commonDir: string): string {
+  return join(commonDir, "convoy")
+}
+
+function repositoryRecordPath(commonDir: string): string {
+  return join(lifecycleRoot(commonDir), "repository.json")
+}
+
+export function validateRepositoryRecord(value: unknown): RepositoryRecord | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return undefined
+  const record = value as Record<string, unknown>
+  if (typeof record.repositoryId !== "string" || !isUuid(record.repositoryId)) return undefined
+  if (typeof record.createdAt !== "number") return undefined
+  return { schemaVersion: lifecycleSchemaVersion, repositoryId: record.repositoryId, createdAt: record.createdAt }
+}
+
+/**
+ * Reads the repository record. Missing means the store has never been
+ * initialized — callers that only inspect (board, specs viewer) must treat
+ * that as "no registered features" and never create the file (design D1).
+ */
+export async function readRepositoryRecord(commonDir: string): Promise<StoreRead<RepositoryRecord>> {
+  return readJsonFile(repositoryRecordPath(commonDir), validateRepositoryRecord, {
+    unsupported: (value) => typeof value.schemaVersion === "number" && value.schemaVersion > lifecycleSchemaVersion,
+  })
+}
+
+/**
+ * Creates the repository record exactly once. An existing record of any
+ * version is returned untouched — even an unreadable one, because
+ * overwriting it would silently orphan every feature recorded under the old
+ * identity (fail closed).
+ */
+export async function ensureRepositoryRecord(commonDir: string): Promise<StoreRead<RepositoryRecord>> {
+  const existing = await readRepositoryRecord(commonDir)
+  if (existing.status !== "missing") return existing
+  const record: RepositoryRecord = {
+    schemaVersion: lifecycleSchemaVersion,
+    repositoryId: crypto.randomUUID(),
+    createdAt: Date.now(),
+  }
+  try {
+    await writeJsonFile(repositoryRecordPath(commonDir), record)
+  } catch (error) {
+    return { status: "unreadable", reason: error instanceof Error ? error.message : String(error) }
+  }
+  return { status: "found", value: record }
+}
+
+/** Opaque UUID form used for repository/feature/attempt identities. */
+export function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
+}
+
+/**
+ * True when `value` is a single, safe path segment: non-empty, not `.`/`..`,
+ * not absolute (POSIX or Windows drive), and containing no path separator.
+ * Used to validate persisted change ids and capability names on every load —
+ * a corrupt or malicious record must never escape the planning root when a
+ * read joins it onto a checkout path (design D1/D7: validate relative paths
+ * on every load).
+ */
+export function isSafePathSegment(value: string): boolean {
+  if (value === "" || value === "." || value === "..") return false
+  if (value.startsWith("/") || value.startsWith("\\")) return false
+  if (/^[A-Za-z]:/.test(value)) return false
+  return !value.includes("/") && !value.includes("\\")
+}
+
+/**
+ * True when `value` is a repo-relative path that stays within its root: not
+ * absolute (POSIX or Windows drive), and containing no `..` segment. A
+ * persisted source path must never escape when joined onto a checkout (design
+ * D7: never interpolate unchecked paths; validate relative paths on load).
+ */
+export function isSafeRelativePath(value: string): boolean {
+  if (value === "" || value.startsWith("/") || value.startsWith("\\")) return false
+  if (/^[A-Za-z]:/.test(value)) return false
+  return !value.split(/[\\/]/).some((segment) => segment === "..")
+}
+
+// ── association conflict detection ───────────────────────────────────────
+
+/**
+ * Serializes read-modify-write cycles on one feature record (capability
+ * feature-lifecycle: concurrent association edits — only one update
+ * succeeds, the other requests refreshed inspection). The lock is an
+ * exclusive-create sidecar next to the record; it is held only for the
+ * duration of the callback and always released, including on throw. A stale
+ * lock from a crashed writer is stolen after `staleMs` so recovery is always
+ * possible.
+ */
+export async function withFeatureLock<T>(
+  featureDir: string,
+  fn: () => Promise<T>,
+  options: { staleMs?: number } = {},
+): Promise<T> {
+  const lockPath = join(featureDir, ".lock")
+  await mkdir(featureDir, { recursive: true })
+  const staleMs = options.staleMs ?? 30_000
+  let handle
+  for (;;) {
+    try {
+      handle = await open(lockPath, "wx")
+      break
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException | undefined)?.code
+      if (code !== "EEXIST") throw error
+      let age = 0
+      try {
+        age = Date.now() - (await stat(lockPath)).mtimeMs
+      } catch {
+        continue
+      }
+      if (age <= staleMs) {
+        await new Promise((resolveSleep) => setTimeout(resolveSleep, 25))
+        continue
+      }
+      await rm(lockPath, { force: true }).catch(() => {})
+    }
+  }
+  try {
+    await handle!.write(`${process.pid}\n`)
+    return await fn()
+  } finally {
+    await handle!.close().catch(() => {})
+    await rm(lockPath, { force: true }).catch(() => {})
+  }
+}

--- a/src/finalization/compact.ts
+++ b/src/finalization/compact.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path"
 import { formatCommitMessage, proposeCommitMessage } from "../commit-message"
 import { currentHead, diffStat, execFile, resetSoft, resolveCommit } from "../git"
 import { convoyHome } from "../workspace"
+import type { FeaturePlanLink } from "../types"
 import { boundedCommitAsOperator } from "./executor"
 import { verifyRunInterval, type RunInterval } from "./interval"
 import { acquireMutationLease, LeaseUnavailableError, type MutationLease } from "./lease"
@@ -64,6 +65,8 @@ export type RunFinalizationInput = {
   ledger: readonly CommitLedgerEntry[]
   /** Frozen pipeline name/branch context for message composition. */
   branch?: string
+  /** The reviewed feature link, preserved in the cleanup-surviving index (task 5.1). */
+  feature?: FeaturePlanLink
   commitMessageModel?: string
   signal?: AbortSignal
   progress?: FinalizationProgress
@@ -373,6 +376,9 @@ async function updateRunIndex(
       commonDir: (await gitCommonDir(input.targetDir)) ?? "",
       worktreeDir: input.targetDir,
       ...(input.branch ? { branch: input.branch } : {}),
+      // The reviewed feature link survives workspace cleanup (task 5.1): run
+      // history joins by identity, never by reinterpreting a stored path.
+      ...(input.feature ? { feature: input.feature } : {}),
       manifestPath,
       recoveryRef,
       preCompactionHead: interval.headSha,

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -14,7 +14,7 @@ import type {
   RunControlState,
 } from "./progress"
 import type { QualityScore } from "./quality-score"
-import type { Pipeline } from "./types"
+import type { FeaturePlanLink, Pipeline } from "./types"
 import type { ModelGateway } from "./model-routing"
 import { PhaseUsage } from "./usage"
 import { aggregateAdvisorEvents, type AdvisorEvent, type AdvisorPhaseAggregate } from "./advisor-events"
@@ -91,6 +91,12 @@ export type RunMetadata = {
   goal?: GoalRunState
   /** The run boundary persisted before any run-owned mutation (schema v5; capability run-finalization). */
   boundary?: RunBoundary
+  /**
+   * The reviewed feature link (capability feature-lifecycle, task 5.1):
+   * persisted at metadata open — before any execution — so board, attach, and
+   * history join by stable identity and never reinterpret a stored path.
+   */
+  feature?: FeaturePlanLink
   /** The ordered ledger of Convoy-created commits, recorded as each commit lands (schema v5). */
   commitLedger?: CommitLedgerEntry[]
   /** The automatic compaction outcome, independent of the pipeline result (schema v5). */
@@ -142,6 +148,8 @@ export type OpenRunMetadataOptions = {
   modelOverride?: boolean
   /** Execute the reviewed resume subset without replacing the stored full pipeline. */
   useExecutionPipeline?: boolean
+  /** The reviewed feature link, persisted at open — before any execution (task 4.2/5.1). */
+  feature?: FeaturePlanLink
 }
 
 const saveDebounceMs = 2_000
@@ -155,6 +163,10 @@ export async function openRunMetadata(
   const gateway = options.gateway ?? "configured"
   const path = join(workspace.dir, "metadata.json")
   const data = (await loadMetadata(path, workspace.runID)) ?? newMetadata(workspace.runID, targetDir)
+  // The reviewed feature link persists from the first open onward, including
+  // for failed/aborted runs (capability feature-lifecycle: the link is
+  // written before execution, not only after success).
+  if (options.feature && !data.feature) data.feature = options.feature
   // Opening metadata means a new coordinator owns the run. It resumes from the
   // next pending batch; pausing/running crashes still use normal phase recovery.
   if (data.control.state !== "running") data.control = { state: "running" }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -97,6 +97,14 @@ export function createPublishSeam(input: CreatePublishSeamInput) {
       const recovery = await recoveryGate(input.runDir)
       if (!recovery.ok) return recovery
 
+      // Feature-backed publication revalidates the reviewed feature link
+      // immediately before the push (capability run-finalization, task 5.2):
+      // the run's durable feature link must still verify — the same feature,
+      // association revision, and branch. A historical run whose path was
+      // reused by another feature never publishes the replacement branch.
+      const featureGate = await featureLinkGate(input.runDir, cwd)
+      if (!featureGate.ok) return featureGate
+
       return { ok: true, plan: { branch, remote, base } }
     },
 
@@ -170,6 +178,34 @@ async function recoveryGate(runDir: string | undefined): Promise<{ ok: true } | 
     }
   }
   return { ok: true }
+}
+
+/**
+ * The feature-link gate (task 5.2): a feature-backed run's durable link is
+ * revalidated against the live repository right before publication. The
+ * resolution is lazy so no-spec runs never touch the lifecycle module.
+ */
+async function featureLinkGate(runDir: string | undefined, cwd: string): Promise<{ ok: true } | { ok: false; message: string }> {
+  if (!runDir || runDir === "/") return { ok: true }
+  let metadata: { feature?: { featureId: string; associationRevision: number; branch: string; baseRef: string; contracts: readonly string[]; repositoryId: string; worktreeDir?: string } }
+  try {
+    metadata = JSON.parse(await readFile(join(runDir, "metadata.json"), "utf8"))
+  } catch {
+    return { ok: true }
+  }
+  const link = metadata.feature
+  if (!link) return { ok: true }
+  const { revalidateFeatureLink } = await import("./feature-lifecycle/launch")
+  try {
+    await revalidateFeatureLink({ cwd, link })
+    return { ok: true }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    return {
+      ok: false,
+      message: `publication refuses: the run's reviewed feature context no longer verifies — ${detail}. Publication never pushes the branch now occupying the historical path.`,
+    }
+  }
 }
 
 /** `gh` availability and authentication, each with concrete remediation (D5). */

--- a/src/run-plan.ts
+++ b/src/run-plan.ts
@@ -2,7 +2,7 @@ import { resolveModel, type ModelGateway, type ModelRoutingOverrides } from "./m
 import type { OpenSpecBundle } from "./openspec"
 import type { PrdHistoryPreview } from "./prd-history"
 import { stepRunnerFor } from "./step-runners"
-import type { AgentStep, Pipeline, ResolvedGoalPlan, RunOptions, RunPlan, Step } from "./types"
+import type { AgentStep, FeaturePlanLink, Pipeline, ResolvedGoalPlan, RunOptions, RunPlan, Step } from "./types"
 
 export type BuildRunPlanInput = RunOptions & {
   promptSource?: RunPlan["prompt"]["source"]
@@ -17,6 +17,8 @@ export type BuildRunPlanInput = RunOptions & {
   prdHistoryPreview?: PrdHistoryPreview
   /** Precomputed OpenSpec contract; `buildRunPlan` does not touch the filesystem. */
   openspec?: OpenSpecBundle
+  /** Precomputed feature link (verified by the caller); frozen into the plan for execution-time revalidation. */
+  feature?: FeaturePlanLink
 }
 
 /** Purely resolves the complete execution shape; it performs no filesystem or process effects. */
@@ -51,6 +53,7 @@ export function buildRunPlan(input: BuildRunPlanInput): RunPlan {
     hooks,
     attachments: [...input.files],
     ...(input.openspec ? { openspec: input.openspec } : {}),
+    ...(input.feature ? { feature: input.feature } : {}),
     ...(input.prdHistoryPreview ? { prdHistory: input.prdHistoryPreview } : {}),
     permissions: input.yolo ? "yolo" : input.smart ? "smart" : "interactive",
     ...(pipeline.goalPlan ? { goal: pipeline.goalPlan } : {}),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -524,6 +524,8 @@ export async function run(options: RunOptions, deps: RunDeps = defaultRunDeps) {
       // The plan has already applied --only/--skip. Never re-expand a reviewed
       // resume back to the entire persisted pipeline.
       useExecutionPipeline: Boolean(options.resumeRunID && options.plan),
+      // The reviewed feature link persists before any execution (task 4.2).
+      ...(options.plan?.feature ? { feature: options.plan.feature } : {}),
     })
     const pipeline = metadata.pipeline
     pipelineNameForHooks = pipeline.name
@@ -900,6 +902,8 @@ export async function run(options: RunOptions, deps: RunDeps = defaultRunDeps) {
           boundary: metadata.boundary(),
           ledger: metadata.ledger(),
           ...(identity.branch ? { branch: identity.branch } : {}),
+          // The reviewed feature link survives workspace cleanup (task 5.1).
+          ...(options.plan?.feature ? { feature: options.plan.feature } : {}),
           signal: shutdown.signal,
           progress: {
             activity: (detail, kind) => progress.phaseActivity(compactRunRowName, detail, kind),

--- a/src/runs.ts
+++ b/src/runs.ts
@@ -48,6 +48,23 @@ export type RunEntry = {
    * Git inspection commands.
    */
   finalization?: RunEntryFinalization
+  /**
+   * The durable feature link (capability feature-lifecycle, task 5.1/SC-6):
+   * the run's stable feature identity, surfaced from the cleanup-surviving
+   * run-record index so board, attach, and history join by identity rather
+   * than reinterpreting the stored worktree path as today's branch. Absent
+   * for legacy or no-spec runs.
+   */
+  feature?: RunEntryFeatureLink
+}
+
+/** The feature identity a run is linked to, as preserved in run history. */
+export type RunEntryFeatureLink = {
+  featureId: string
+  associationRevision: number
+  branch: string
+  baseRef: string
+  contracts: readonly string[]
 }
 
 /** The finalization facts run history presents, from durable records only. */
@@ -87,6 +104,12 @@ export type RunIndexRecord = {
   reason?: string
   /** The protected ref holding the pre-compaction tip. */
   recoveryRef?: string
+  /**
+   * The reviewed feature link, preserved through workspace cleanup (task
+   * 5.1): history joins by stable identity, never by reinterpreting the
+   * stored worktree path as today's branch.
+   */
+  feature?: { featureId: string; associationRevision: number; branch: string; baseRef: string; contracts: readonly string[] }
 }
 
 /** Reads one run-record index entry; undefined when absent or malformed. */
@@ -140,6 +163,18 @@ function parseRunIndexRecord(raw: string, runID: string): RunIndexRecord | undef
     } else if (typeof value.state === "string") {
       record.state = value.state
     }
+    // The feature link survives cleanup as a plain object; a malformed one is
+    // dropped rather than interpreted (readers never invent identity).
+    if (typeof value.feature === "object" && value.feature !== null && typeof (value.feature as Record<string, unknown>).featureId === "string") {
+      const raw = value.feature as Record<string, unknown>
+      record.feature = {
+        featureId: raw.featureId as string,
+        ...(typeof raw.associationRevision === "number" ? { associationRevision: raw.associationRevision } : { associationRevision: 0 }),
+        ...(typeof raw.branch === "string" ? { branch: raw.branch } : { branch: "" }),
+        ...(typeof raw.baseRef === "string" ? { baseRef: raw.baseRef } : { baseRef: "" }),
+        contracts: Array.isArray(raw.contracts) ? raw.contracts.filter((entry): entry is string => typeof entry === "string") : [],
+      }
+    }
     return record
   } catch {
     return undefined
@@ -148,6 +183,19 @@ function parseRunIndexRecord(raw: string, runID: string): RunIndexRecord | undef
 
 function isRecordOf(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Merges the run's durable feature link from the cleanup-surviving index record. */
+function featureLinkOf(index: RunIndexRecord | undefined): RunEntryFeatureLink | undefined {
+  const feature = index?.feature
+  if (!feature) return undefined
+  return {
+    featureId: feature.featureId,
+    associationRevision: feature.associationRevision,
+    branch: feature.branch,
+    baseRef: feature.baseRef,
+    contracts: feature.contracts,
+  }
 }
 
 /** Merges the run's durable finalization outcome into the entry's presentation shape. */
@@ -239,6 +287,7 @@ function runEntryFromIndexRecord(record: RunIndexRecord, root: string): RunEntry
     live: false,
     phases: [],
     finalization: finalizationInfo(undefined, record),
+    ...(featureLinkOf(record) ? { feature: featureLinkOf(record) } : {}),
   }
 }
 
@@ -368,6 +417,7 @@ async function loadRunEntry(root: string, runID: string): Promise<RunEntry> {
     phases: phaseInfos(metadata),
     ...(goal ? { goal: goalInfo(goal) } : {}),
     ...(finalization ? { finalization } : {}),
+    ...(featureLinkOf(indexRecord) ? { feature: featureLinkOf(indexRecord) } : {}),
   }
 }
 

--- a/src/specs-browser.ts
+++ b/src/specs-browser.ts
@@ -6,7 +6,7 @@ import { copyReportToClipboard, writeClipboardOSC52, type ClipboardResult } from
 import type { FeatureRow, WorktreeWithoutSpec } from "./control-board"
 import { parseMarkdown, renderMarkdownDoc, type MarkdownDoc } from "./markdown-render"
 import { stripYamlFrontmatter } from "./openspec"
-import { groupChangeArtifacts, specGroupSource, type SpecGroup, type SpecsChangeEntry, type SpecsResolution, type SpecsView } from "./specs"
+import { groupChangeArtifacts, loadSpecsView, specGroupSource, type LifecycleFeatureRow, type SpecGroup, type SpecsChangeEntry, type SpecsResolution, type SpecsView } from "./specs"
 import {
   hintsRow,
   joinLines,
@@ -35,9 +35,22 @@ const compactSpecsMaxWidth = 84
  */
 type ListRow =
   | { kind: "header"; label: string }
+  | { kind: "feature"; feature: LifecycleFeatureRow }
   | { kind: "change"; change: SpecsChangeEntry }
   | { kind: "worktree"; worktree: WorktreeWithoutSpec }
   | { kind: "spec"; path: string }
+
+/**
+ * One dispatchable or inspectable Actions-menu entry, built from the shared
+ * assessment's actions (`LifecycleFeatureRow.actions`) — the same eligibility
+ * rules the CLI, headless listing, and board rows consume, so no duplicated
+ * branch/path gate lives in the renderer.
+ */
+type MenuItem = {
+  action: { id: string; label: string; enabled: boolean; blockers: readonly string[]; remediation?: readonly string[] }
+  /** Present only when the browser can run the action itself. */
+  dispatch?: "close" | "continue" | "history" | "refresh" | "archive-main"
+}
 
 export class SpecsBrowser {
   readonly result: Promise<SpecsResolution>
@@ -55,11 +68,20 @@ export class SpecsBrowser {
   private scroll = 0
   /** Set while a change/spec was entered: the detail level's subject. */
   private subject?: { kind: "change"; change: SpecsChangeEntry } | { kind: "spec"; path: string }
+  /**
+   * The feature whose read-only History view is the current subject. History
+   * is inspection, not an active change: its subject id is a feature id, so
+   * apply/iterate stay hidden and inert while this is set.
+   */
+  private historyFeature?: LifecycleFeatureRow
   private groups: SpecGroup[] = []
   private selectedGroup = 0
   private detailScroll = 0
   /** Outcome of the last copy attempt, reported in the reader's title bar. */
   private copyStatus?: ClipboardResult
+  /** Set while the lifecycle Actions menu overlays the current level (task 6.4). */
+  private menuOpen = false
+  private menuIndex = 0
   /** Scroll position for the fullscreen reader's title bar (`top` / `end` / `%` / `all`). */
   private readerPosition = ""
   /** Artifact markdown read lazily, keyed by repo-relative file; failures become placeholders. */
@@ -100,7 +122,7 @@ export class SpecsBrowser {
 
   constructor(
     private readonly renderer: CliRenderer,
-    private readonly view: SpecsView,
+    private view: SpecsView,
     // Clipboard deps are constructor-injected exactly like the dashboard's
     // copyReport, so tests swap the transport instead of shelling out.
     private readonly copyReport: typeof copyReportToClipboard = copyReportToClipboard,
@@ -218,6 +240,8 @@ export class SpecsBrowser {
   // ── keys ────────────────────────────────────────────────────────────────
 
   private handleRootKey(key: KeyEvent) {
+    // The Actions menu owns the keyboard while open (task 6.4).
+    if (this.menuOpen && this.handleMenuKey(key)) return
     switch (key.name) {
       case "up":
       case "k":
@@ -263,6 +287,12 @@ export class SpecsBrowser {
         break
       }
       case "c": {
+        const lifecycle = this.selectedLifecycleFeature()
+        if (lifecycle?.checkoutPath && lifecycle.branch) {
+          const changeId = lifecycle.contracts.find((contract) => contract.state === "active")?.changeId
+          if (changeId) this.finish({ type: "continue-change", changeID: changeId, worktreeDir: lifecycle.checkoutPath, branch: lifecycle.branch })
+          break
+        }
         const feature = this.selectedFeature()
         if (feature?.worktreeDir && feature.branch) {
           this.finish({ type: "continue-change", changeID: feature.id, worktreeDir: feature.worktreeDir, branch: feature.branch })
@@ -270,6 +300,21 @@ export class SpecsBrowser {
         break
       }
       case "x": {
+        const lifecycle = this.selectedLifecycleFeature()
+        if (lifecycle?.checkoutPath && lifecycle.branch) {
+          const changeId = lifecycle.contracts.find((contract) => contract.state === "active")?.changeId
+          if (changeId) this.finish({ type: "close-change", changeID: changeId, worktreeDir: lifecycle.checkoutPath, branch: lifecycle.branch })
+          break
+        }
+        // A registered feature whose worktree is gone still reaches the close
+        // review — through its stable identity, never a silent no-op (task
+        // 6.4; the review reports the recorded landing or the concrete
+        // missing-context blocker with remediation).
+        const lifecycleOnly = this.selectedLifecycleFeature()
+        if (lifecycleOnly) {
+          this.finish({ type: "close-feature", featureId: lifecycleOnly.featureId })
+          break
+        }
         const feature = this.selectedFeature()
         if (feature?.worktreeDir && feature.branch) {
           this.finish({ type: "close-change", changeID: feature.id, worktreeDir: feature.worktreeDir, branch: feature.branch })
@@ -281,6 +326,17 @@ export class SpecsBrowser {
         if (feature?.probablyMerged) this.finish({ type: "archive-change-main", changeID: feature.id })
         break
       }
+      case "r": {
+        // Explicit refresh (task 6.5): reload the whole view, invalidate the
+        // artifact/document caches together, and keep the selection attached
+        // to identity rather than list position.
+        void this.refresh()
+        break
+      }
+      case "!":
+      case "exclamation":
+        this.openActionsMenu()
+        break
       case "q":
       case "escape":
         this.finish({ type: "exit" })
@@ -289,6 +345,9 @@ export class SpecsBrowser {
   }
 
   private handleDetailKey(key: KeyEvent) {
+    // The Actions menu owns the keyboard while open (task 6.4); the fullscreen
+    // reader keeps its copy/close/tab keys and never opens the menu.
+    if (this.menuOpen && !this.fullscreen && this.handleMenuKey(key)) return
     // Digits 1–9 jump straight to a tab (the strip labels the numbers).
     if (this.digitTab(key)) {
       this.render()
@@ -343,12 +402,12 @@ export class SpecsBrowser {
         break
       case "a": {
         const subject = this.subject
-        if (subject?.kind === "change") this.finish({ type: "apply-change", changeID: subject.change.id })
+        if (subject?.kind === "change" && !this.historyFeature) this.finish({ type: "apply-change", changeID: subject.change.id })
         return
       }
       case "i": {
         const subject = this.subject
-        if (subject?.kind === "change") this.finish({ type: "iterate-change", changeID: subject.change.id })
+        if (subject?.kind === "change" && !this.historyFeature) this.finish({ type: "iterate-change", changeID: subject.change.id })
         return
       }
       case "escape":
@@ -362,8 +421,135 @@ export class SpecsBrowser {
       case "b":
         if (!this.fullscreen) this.leaveSubject()
         break
+      case "!":
+      case "exclamation":
+        // The Actions menu exists at the ordinary detail level too (task 6.4);
+        // the fullscreen reader keeps its copy/close/tab keys untouched.
+        if (!this.fullscreen) this.openActionsMenu()
+        break
     }
     this.render()
+  }
+
+  // ── the lifecycle Actions menu (task 6.4) ────────────────────────────────
+
+  /** The lifecycle feature the menu acts on, at the current level. */
+  private menuTarget(): LifecycleFeatureRow | undefined {
+    if (this.level === "root") return this.selectedLifecycleFeature()
+    if (this.historyFeature) return this.historyFeature
+    const subject = this.subject
+    if (subject?.kind === "change") {
+      return (this.view.features ?? []).find((feature) => feature.contracts.some((contract) => contract.changeId === subject.change.id))
+    }
+    return undefined
+  }
+
+  /** The menu entries: the shared assessment's applicable actions plus the browser's own refresh. */
+  private menuItems(): MenuItem[] {
+    const feature = this.menuTarget()
+    if (!feature) return []
+    const items: MenuItem[] = (feature.actions ?? [])
+      .filter((action) => action.id !== "spin" && action.id !== "adopt")
+      .map((action) => {
+        switch (action.id) {
+          case "close":
+            // Identity-keyed close review: dispatchable even when the
+            // worktree is gone — the review reports the verified landing or
+            // the concrete missing-context blocker.
+            return { action, dispatch: "close" as const }
+          case "continue":
+            return feature.checkoutPath && feature.branch && feature.contracts.some((contract) => contract.state === "active")
+              ? { action, dispatch: "continue" as const }
+              : { action }
+          case "history":
+            return { action, dispatch: "history" as const }
+          case "archive-on-main": {
+            const changeId = feature.contracts.find((contract) => contract.state === "active")?.changeId
+            return changeId ? { action, dispatch: "archive-main" as const } : { action }
+          }
+          default:
+            // push/bind and any other shared action without an in-browser
+            // executor stay inspectable with their blockers and the exact
+            // remediation command, never silently absent.
+            return { action }
+        }
+      })
+    items.push({ action: { id: "refresh", label: "Refresh", enabled: true, blockers: [] }, dispatch: "refresh" })
+    return items
+  }
+
+  private openActionsMenu() {
+    if (this.menuItems().length === 0) return
+    this.menuOpen = true
+    this.menuIndex = Math.max(0, this.menuItems().findIndex((item) => item.dispatch && item.action.enabled))
+    this.render()
+  }
+
+  private closeActionsMenu() {
+    this.menuOpen = false
+    this.render()
+  }
+
+  /** Menu keys; returns false when the key wasn't a menu key (root falls through). */
+  private handleMenuKey(key: KeyEvent): boolean {
+    const items = this.menuItems()
+    switch (key.name) {
+      case "up":
+      case "k":
+        this.menuIndex = (this.menuIndex - 1 + items.length) % Math.max(1, items.length)
+        break
+      case "down":
+      case "j":
+        this.menuIndex = (this.menuIndex + 1) % Math.max(1, items.length)
+        break
+      case "return":
+      case "linefeed": {
+        const item = items[this.menuIndex]
+        if (item?.dispatch && item.action.enabled) {
+          this.menuOpen = false
+          this.dispatchMenuItem(item, this.menuTarget())
+          return true
+        }
+        break
+      }
+      case "escape":
+        this.closeActionsMenu()
+        return true
+      case "q":
+        // q keeps its global meaning (quit/back) instead of closing the menu.
+        return false
+      default:
+        return true
+    }
+    this.render()
+    return true
+  }
+
+  private dispatchMenuItem(item: MenuItem, feature: LifecycleFeatureRow | undefined) {
+    if (!feature) return
+    switch (item.dispatch) {
+      case "close":
+        this.finish({ type: "close-feature", featureId: feature.featureId })
+        return
+      case "continue": {
+        const changeId = feature.contracts.find((contract) => contract.state === "active")?.changeId
+        if (changeId && feature.checkoutPath && feature.branch) {
+          this.finish({ type: "continue-change", changeID: changeId, worktreeDir: feature.checkoutPath, branch: feature.branch })
+        }
+        return
+      }
+      case "history":
+        this.enterFeatureHistory(feature)
+        return
+      case "refresh":
+        void this.refresh()
+        return
+      case "archive-main": {
+        const changeId = feature.contracts.find((contract) => contract.state === "active")?.changeId
+        if (changeId) this.finish({ type: "archive-change-main", changeID: changeId })
+        return
+      }
+    }
   }
 
   /** Digits 1–9 jump straight to a tab; the strip labels the numbers. */
@@ -436,6 +622,50 @@ export class SpecsBrowser {
     return change ? this.featureFor(change) : undefined
   }
 
+  /** The selected registered lifecycle row, when the cursor sits on one. */
+  private selectedLifecycleFeature(): LifecycleFeatureRow | undefined {
+    const row = this.rows[this.selectedRow]
+    return row?.kind === "feature" ? row.feature : undefined
+  }
+
+  /**
+   * Explicit refresh (task 6.5): reloads the view, invalidates cached
+   * artifact/assessment data together, and re-anchors the selection to the
+   * same identity (feature id, change id, worktree dir, or spec path). A
+   * failed refresh keeps the current view — stale evidence stays visible as
+   * such instead of readiness being presented as current.
+   */
+  private async refresh() {
+    const previous = this.rows[this.selectedRow]
+    const identity = previous?.kind === "feature" ? previous.feature.featureId : previous?.kind === "change" ? previous.change.id : previous?.kind === "worktree" ? previous.worktree.dir : previous?.kind === "spec" ? previous.path : undefined
+    try {
+      const next = await loadSpecsView(this.view.targetDir)
+      this.view = next
+    } catch {
+      // Keep the previous view: a failed refresh must not silently empty the
+      // board or present stale readiness as current. The next refresh retries.
+      this.render()
+      return
+    }
+    this.bodies.clear()
+    this.docs.clear()
+    const rows = this.rows
+    const matchIndex = rows.findIndex((row) => {
+      if (row.kind === "header" || previous === undefined || previous.kind === "header") return false
+      if (row.kind === "feature" && previous.kind === "feature") return row.feature.featureId === previous.feature.featureId
+      if (row.kind === "change" && previous.kind === "change") return row.change.id === previous.change.id
+      if (row.kind === "worktree" && previous.kind === "worktree") return row.worktree.dir === previous.worktree.dir
+      if (row.kind === "spec" && previous.kind === "spec") return row.path === previous.path
+      return false
+    })
+    if (matchIndex >= 0) this.selectedRow = matchIndex
+    else {
+      const firstSelectable = rows.findIndex((row) => row.kind !== "header")
+      if (firstSelectable >= 0) this.selectedRow = Math.min(firstSelectable, this.selectedRow)
+    }
+    this.render()
+  }
+
   private featureFor(change: SpecsChangeEntry): FeatureRow | undefined {
     return this.view.rows?.find((row) => row.id === change.id)
   }
@@ -445,11 +675,16 @@ export class SpecsBrowser {
     const row = this.rows[this.selectedRow]
     if (!row || row.kind === "header") return
     if (row.kind === "change") {
+      this.historyFeature = undefined
       this.subject = { kind: "change", change: row.change }
       this.groups = groupChangeArtifacts(row.change)
     } else if (row.kind === "worktree") {
       return
+    } else if (row.kind === "feature") {
+      this.enterFeatureHistory(row.feature)
+      return
     } else {
+      this.historyFeature = undefined
       this.subject = { kind: "spec", path: row.path }
       this.groups = [{ label: "Spec", delta: false, entries: [{ file: row.path }] }]
     }
@@ -463,8 +698,61 @@ export class SpecsBrowser {
   private leaveSubject() {
     if (!this.subject) return
     this.subject = undefined
+    this.historyFeature = undefined
     this.level = "root"
     this.fullscreen = false
+    this.menuOpen = false
+    this.render()
+  }
+
+  /**
+   * The discoverable History view (task 6.3): Enter on a feature row opens a
+   * single-group reading pane rendering the feature's durable history —
+   * landing receipts with their current reachability, linked runs, and the
+   * association events. Rendered from the row's own evidence; completed
+   * features stay inspectable without their worktrees.
+   */
+  private enterFeatureHistory(feature: LifecycleFeatureRow) {
+    const lines: string[] = [`# ${feature.displayName}`, "", `feature ${feature.featureId}`, `status: ${feature.summary}`, ""]
+    if (feature.branch) lines.push(`branch: ${feature.branch}`)
+    if (feature.receipts && feature.receipts.length > 0) {
+      lines.push("", "## Landing receipts", "")
+      for (const receipt of feature.receipts) {
+        lines.push(
+          `- attempt \`${receipt.attemptId.slice(0, 8)}\` — landing \`${receipt.landingSha.slice(0, 8)}\` — ${receipt.landingReachable ? "reachable from the base (verified)" : "**unreachable** (stale evidence)"}`,
+        )
+      }
+    }
+    if (feature.runIds && feature.runIds.length > 0) {
+      lines.push("", "## Runs", "")
+      for (const runId of feature.runIds) lines.push(`- \`${runId}\``)
+    }
+    if (feature.history && feature.history.length > 0) {
+      lines.push("", "## Association history", "")
+      for (const event of feature.history) {
+        const at = new Date(event.at).toISOString().slice(0, 16).replace("T", " ")
+        lines.push(`- ${at} · ${event.kind} — ${event.summary}`)
+      }
+    }
+    if (feature.blockers.length > 0) {
+      lines.push("", "## Blockers", "")
+      for (const blocker of feature.blockers) lines.push(`- ${blocker}`)
+    }
+    const historyKey = `history:${feature.featureId}`
+    this.bodies.set(historyKey, lines.join("\n"))
+    // The subject keeps the stable feature id as its identity; the display
+    // name only shapes the title (rendered history-aware below). The marker
+    // keeps apply/iterate — change-level actions — off this read-only view.
+    this.historyFeature = feature
+    this.subject = {
+      kind: "change",
+      change: { kind: "change", id: feature.featureId, title: `${feature.displayName} — history`, artifacts: [{ section: "other", file: historyKey }] },
+    }
+    this.groups = [{ label: "History", delta: false, entries: [{ file: historyKey }] }]
+    this.level = "detail"
+    this.selectedGroup = 0
+    this.detailScroll = 0
+    void this.loadSelectedGroup().then(() => this.render())
     this.render()
   }
 
@@ -496,6 +784,14 @@ export class SpecsBrowser {
 
   private get rows(): ListRow[] {
     const rows: ListRow[] = []
+    // Registered lifecycle features lead the board (capability specs-viewer:
+    // Features precedes Worktrees without spec, which precedes Canonical
+    // Specs); rows are keyed by stable feature identity.
+    const features = this.view.features ?? []
+    if (features.length > 0) {
+      rows.push({ kind: "header", label: "Features" })
+      for (const feature of features) rows.push({ kind: "feature", feature })
+    }
     if (this.view.changes.length > 0) {
       rows.push({ kind: "header", label: "Active Changes" })
       for (const change of this.view.changes) rows.push({ kind: "change", change })
@@ -623,7 +919,9 @@ export class SpecsBrowser {
     const group = this.groups[this.selectedGroup]
     if (this.fullscreen) {
       const subject = this.subject
-      const name = subject?.kind === "change" ? subject.change.id : subject ? specDisplayPath(subject.path) : ""
+      // The history view leads with its display name; the group label carries
+      // the "history" word, so the id (a feature uuid) never headlines it.
+      const name = subject?.kind === "change" ? (this.historyFeature ? this.historyFeature.displayName : subject.change.id) : subject ? specDisplayPath(subject.path) : ""
       const status = this.copyStatus ? ` · ${copyStatusLabel(this.copyStatus)}` : ""
       const position = this.readerPosition ? ` · ${this.readerPosition}` : ""
       return ` ${name} · ${group?.label.toLowerCase() ?? "read"}${status} · c copy · v/esc close${position} `
@@ -650,6 +948,20 @@ export class SpecsBrowser {
   private rowLine(row: ListRow, selected: boolean, width: number): StyledText {
     if (row.kind === "header") {
       return new StyledText([bold(fg(theme.accent)(` ${truncate(row.label.toUpperCase(), width)}`))])
+    }
+    if (row.kind === "feature") {
+      const feature = row.feature
+      const left: TextChunk[] = [selected ? fg(theme.accent)("▸ ") : raw("  "), fg(lifecycleColor(feature))("●"), raw(" ")]
+      const heading = feature.displayName === feature.featureId ? feature.featureId.slice(0, 8) : `${feature.displayName}`
+      const title = truncate(heading, Math.max(12, width - 18))
+      left.push(selected ? bold(fg(theme.text)(title)) : fg(theme.text)(title))
+      const state: TextChunk[] = [fg(lifecycleColor(feature))(feature.summary)]
+      const rest: string[] = []
+      if (feature.branch) rest.push(feature.branch)
+      if (feature.tasks && feature.tasks !== "unknown" && feature.tasks.total > 0) rest.push(`${feature.tasks.done}/${feature.tasks.total}`)
+      if (feature.liveRuns > 0) rest.push(`${feature.liveRuns} live`)
+      if (rest.length > 0) state.push(fg(theme.dim)(` · ${rest.join(" · ")}`))
+      return padBetween(left, state, width)
     }
     if (row.kind === "change") {
       const change = row.change
@@ -684,11 +996,46 @@ export class SpecsBrowser {
    * tab's markdown scrolls. Single-group subjects render no strip at all.
    */
   private detailsContent(width: number): StyledText {
+    // The Actions menu overlays either level (task 6.4); the fullscreen reader
+    // never shows it (its copy/close/tab keys are unchanged).
+    if (this.menuOpen && !(this.level === "detail" && this.fullscreen)) return this.menuContent(width)
     if (this.level !== "detail") {
       this.readerPosition = ""
       const row = this.rows[this.selectedRow]
       if (!row || row.kind === "header") return plain("")
       const lines: StyledText[] = []
+      if (row.kind === "feature") {
+        const feature = row.feature
+        // The same faint `label: ` anatomy the change rows' lifecycle block
+        // uses, so both root panels read as one surface.
+        const add = (label: string, value: string, color = theme.text) => {
+          lines.push(new StyledText([fg(theme.faint)(`${label}: `), fg(color)(truncate(value, Math.max(8, width - label.length - 2)))]))
+        }
+        lines.push(t`${bold(fg(theme.text)(truncate(feature.displayName, width)))}`)
+        lines.push(t`${fg(theme.dim)(`feature ${feature.featureId}`)}`)
+        lines.push(plain(""))
+        add("status", feature.summary, lifecycleColor(feature))
+        if (feature.branch) add("branch", feature.branch)
+        if (feature.checkoutPath) add("worktree", shortPath(feature.checkoutPath, Math.max(12, width - 10)))
+        if (feature.tasks && feature.tasks !== "unknown" && feature.tasks.total > 0) add("tasks", `${feature.tasks.done}/${feature.tasks.total} complete`)
+        if (feature.runIds?.length) add("runs", `${feature.runIds.length}${feature.liveRuns > 0 ? ` (${feature.liveRuns} live)` : ""}`)
+        else if (feature.liveRuns > 0) add("runs", `${feature.liveRuns} live`)
+        for (const contract of feature.contracts) add("contract", `${contract.changeId} (${contract.state})`)
+        if (feature.actions && feature.actions.length > 0) {
+          lines.push(plain(""))
+          lines.push(new StyledText([bold(fg(theme.accent)("actions"))]))
+          for (const action of feature.actions.filter((candidate) => candidate.enabled)) {
+            lines.push(new StyledText([raw("  "), fg(theme.green)("·"), fg(theme.text)(` ${truncate(action.label, Math.max(8, width - 4))}`)]))
+          }
+          for (const action of feature.actions.filter((candidate) => !candidate.enabled && candidate.blockers.length > 0)) {
+            lines.push(new StyledText([raw("  "), fg(theme.yellow)("·"), fg(theme.dim)(` ${truncate(action.label, Math.max(8, width - 4))} — blocked`)]))
+            for (const blocker of action.blockers) {
+              lines.push(new StyledText([raw("    "), fg(theme.yellow)(truncate(blocker, Math.max(8, width - 6)))]))
+            }
+          }
+        }
+        return joinLines(lines)
+      }
       if (row.kind === "change") {
         const change = row.change
         const feature = this.featureFor(change)
@@ -735,8 +1082,9 @@ export class SpecsBrowser {
     const subject = this.subject
     const lines: StyledText[] = []
 
-    // Title row identifying the subject.
-    const name = subject?.kind === "change" ? (subject.change.title === subject.change.id ? subject.change.id : `${subject.change.id} — ${subject.change.title}`) : subject ? specDisplayPath(subject.path) : ""
+    // Title row identifying the subject. A feature's history view titles by
+    // display name — its subject id is an opaque feature uuid, not a slug.
+    const name = subject?.kind === "change" ? (this.historyFeature ? `${this.historyFeature.displayName} — history` : subject.change.title === subject.change.id ? subject.change.id : `${subject.change.id} — ${subject.change.title}`) : subject ? specDisplayPath(subject.path) : ""
     lines.push(new StyledText([bold(fg(theme.accent)(` ${truncate(name, width)}`))]))
 
     // The tab strip: content rows, never a new box; hidden for single groups
@@ -773,12 +1121,56 @@ export class SpecsBrowser {
     return joinLines(lines.slice(0, this.detailsHeight()))
   }
 
+  /** The Actions menu overlay: dispatchable entries plus blocked reasons/remediation. */
+  private menuContent(width: number): StyledText {
+    const feature = this.menuTarget()
+    const items = this.menuItems()
+    if (this.menuIndex >= items.length) this.menuIndex = Math.max(0, items.length - 1)
+    const lines: StyledText[] = []
+    const title = feature ? `Actions — ${feature.displayName}` : "Actions"
+    lines.push(new StyledText([bold(fg(theme.accent)(` ${truncate(title, width)}`))]))
+    lines.push(plain(""))
+    items.forEach((item, index) => {
+      const selected = index === this.menuIndex
+      const marker = selected ? fg(theme.accent)("▸ ") : raw("  ")
+      const label = truncate(item.action.label, Math.max(8, width - 4))
+      if (item.dispatch && item.action.enabled) {
+        lines.push(new StyledText([marker, selected ? bold(fg(theme.text)(label)) : fg(theme.text)(label)]))
+      } else {
+        lines.push(new StyledText([marker, fg(theme.dim)(`${label} — blocked`)]))
+      }
+      for (const blocker of item.action.blockers) {
+        lines.push(new StyledText([raw("    "), fg(theme.yellow)(truncate(blocker, Math.max(8, width - 6)))]))
+      }
+      for (const remediation of item.action.remediation ?? []) {
+        lines.push(new StyledText([raw("    "), fg(theme.dim)(truncate(remediation, Math.max(8, width - 6)))]))
+      }
+    })
+    return joinLines(lines)
+  }
+
   /** Only actions that are not universal navigation conventions get hints. */
   private footerContent(width: number) {
+    // The open menu owns the footer: it names what answers what.
+    if (this.menuOpen) {
+      const hints: Hint[] = [
+        { keys: "↑↓", label: "move", priority: 1, style: "spaced" },
+        { keys: "enter", label: "run", priority: 2, style: "spaced" },
+        { keys: "esc", label: "back", priority: 3, style: "spaced" },
+      ]
+      return hintsRow(hints, [], width, { style: "spaced", overflow: moreHintsMarker })
+    }
+    // The discoverable action-menu entry is pinned (priority 0): footer
+    // truncation may drop every other hint, but access to the menu — and
+    // through it close review and its blockers — survives (task 6.4).
+    const actionsHint: Hint = { keys: "!", label: "actions", priority: 0, style: "spaced" }
     if (this.level === "detail") {
       const subject = this.subject
       const hints: Hint[] = [
-        ...(subject?.kind === "change"
+        actionsHint,
+        // Apply/iterate are change-level actions: the feature history view is
+        // read-only, so they stay off it entirely.
+        ...(subject?.kind === "change" && !this.historyFeature
           ? ([
               { keys: "a", label: "pply", priority: 2, style: "glued" },
               { keys: "i", label: "terate", priority: 5, style: "glued" },
@@ -793,9 +1185,11 @@ export class SpecsBrowser {
     }
 
     const feature = this.selectedFeature()
+    const lifecycle = this.selectedLifecycleFeature()
     const selected = this.rows[this.selectedRow]
     const canRead = selected?.kind === "change" || selected?.kind === "spec"
     const hints: Hint[] = [
+      actionsHint,
       ...(canRead ? ([{ keys: "enter", label: "read", priority: 2 }] as Hint[]) : []),
       ...(this.selectedChange()
         ? ([
@@ -806,6 +1200,15 @@ export class SpecsBrowser {
             ...(feature?.probablyMerged ? ([{ keys: "m", label: "archive", priority: 7 }] as Hint[]) : []),
           ] as Hint[])
         : []),
+      // Registered feature rows: the same continue/close/archive shortcuts,
+      // dispatched through the feature's verified identity (task 6.4).
+      ...(lifecycle?.checkoutPath && lifecycle.branch
+        ? ([
+            { keys: "c", label: "ontinue", priority: 6, style: "glued" },
+            { keys: "x", label: "close", priority: 7 },
+          ] as Hint[])
+        : []),
+      { keys: "r", label: "efresh", priority: 5, style: "glued" },
       { keys: "q", label: this.scene ? "back" : "uit", priority: 1, style: this.scene ? undefined : "glued" },
     ]
     const selectable = this.rows.filter((row) => row.kind !== "header").length
@@ -881,6 +1284,30 @@ function stageColor(stage: FeatureRow["stage"], live: boolean): string {
     case "probably-merged":
       return theme.orange
   }
+}
+
+/**
+ * A lifecycle row's dot and summary color, speaking the board's stage
+ * vocabulary: verified/ready in green, probable/stale in orange, repair in
+ * yellow (same attention color as a stranded row), live work in green, and
+ * everything else informational cyan. The summary strings come from the
+ * shared assessment (feature-lifecycle/assessment.ts), so the two move
+ * together.
+ */
+function lifecycleColor(feature: LifecycleFeatureRow): string {
+  if (feature.integration === "verified") return theme.green
+  if (feature.integration === "probable" || feature.integration === "stale") return theme.orange
+  if (feature.summary === "Ready to close" || feature.summary === "Implementation complete · archive verified") return theme.green
+  if (
+    feature.summary === "Association needed" ||
+    feature.summary === "Context missing" ||
+    feature.summary === "Context needs review" ||
+    feature.summary === "Contract sources need review" ||
+    feature.summary === "Implementation complete · blocked"
+  ) {
+    return theme.yellow
+  }
+  return feature.liveRuns > 0 ? theme.green : theme.cyan
 }
 
 /** The right-column state summary of a feature row: colored stage first, then dim signals. */

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import { stdin, stdout } from "node:process"
 
@@ -57,8 +57,49 @@ export type SpecsView = {
   rows?: FeatureRow[]
   /** Worktrees carrying runs but no OpenSpec change — a peer board section. */
   worktreesWithoutSpec?: WorktreeWithoutSpec[]
+  /**
+   * Registered lifecycle features with their shared assessment (capability
+   * feature-lifecycle, task 6.1/6.3): the pending-work surface beyond active
+   * directories. Undefined when discovery never ran.
+   */
+  features?: LifecycleFeatureRow[]
   /** The repo's detected base branch, for the sync/merged markers. */
   baseBranch?: string
+}
+
+/** One registered feature's derived lifecycle row for the specs viewer. */
+export type LifecycleFeatureRow = {
+  featureId: string
+  displayName: string
+  branch?: string
+  /** The verified checkout path, when the context verified (task 6.2). */
+  checkoutPath?: string
+  /** The derived summary (design D5's precedence), never a persisted status. */
+  summary: string
+  blockers: string[]
+  tasks?: { done: number; total: number } | "unknown"
+  liveRuns: number
+  integration: "pending" | "probable" | "verified" | "stale" | "unknown"
+  contracts: Array<{ changeId: string; state: string }>
+  /**
+   * The verified associated source for each readable contract (task 6.2):
+   * absolute artifact roots that take precedence over same-id copies in the
+   * launch checkout. Absent for missing/ambiguous/unreadable sources — the
+   * row's blockers disclose the condition instead of a silent fallback.
+   */
+  artifactSources?: Array<{ changeId: string; root: string }>
+  /**
+   * The shared assessment's applicable actions with availability, blocker
+   * reasons, and remediation (tasks 2.5/6.4): the same eligibility the CLI
+   * and headless listing render, never a duplicated rule.
+   */
+  actions?: Array<{ id: string; label: string; enabled: boolean; blockers: readonly string[]; remediation?: readonly string[] }>
+  /** The verified landing receipts (task 6.3): completed work's durable evidence. */
+  receipts?: Array<{ attemptId: string; landingSha: string; landingReachable: boolean }>
+  /** The association history events, oldest first (task 6.3). */
+  history?: Array<{ at: number; kind: string; summary: string }>
+  /** Durable run ids linked to the feature (task 6.3). */
+  runIds?: string[]
 }
 
 /**
@@ -75,6 +116,8 @@ export type SpecsResolution =
   | { type: "continue-change"; changeID: string; worktreeDir: string; branch: string }
   /** Run the full closing sequence (sync → archive → squash → merge) for a feature. */
   | { type: "close-change"; changeID: string; worktreeDir: string; branch: string }
+  /** Run the close review by stable feature identity — dispatched even when the worktree is gone (task 6.4). */
+  | { type: "close-feature"; featureId: string }
   /** Archive a probably-merged-but-unarchived change in the main checkout. */
   | { type: "archive-change-main"; changeID: string }
 
@@ -155,6 +198,25 @@ export async function loadSpecsView(targetDir: string): Promise<SpecsView> {
     // the launch checkout's `openspec/changes/` holds for the id — a stale
     // husk on the base checkout must not shadow the real files.
     const merged = await mergeWorktreeChanges(changes, board.rows)
+    // Registered lifecycle features join the view through the shared
+    // assessment (task 6.1): read-only discovery, no registry writes.
+    const features = await loadLifecycleFeatureRows(targetDir)
+    // The verified associated source outranks the heuristic merge (task 6.2):
+    // for every registered feature contract whose source is readable, its own
+    // tree — absolute paths — supplies the artifact inventory and title, and
+    // an inherited or husk copy in the launch checkout never claims the id.
+    if (features) {
+      for (const feature of features) {
+        for (const source of feature.artifactSources ?? []) {
+          const entry = await loadSpecsChangeAt(source.root, source.changeId, { absolute: true })
+          if (entry.artifacts.length === 0) continue
+          const index = merged.findIndex((change) => change.id === source.changeId)
+          if (index >= 0) merged[index] = entry
+          else merged.push(entry)
+        }
+      }
+      merged.sort((a, b) => a.id.localeCompare(b.id))
+    }
     return {
       targetDir,
       present,
@@ -162,10 +224,84 @@ export async function loadSpecsView(targetDir: string): Promise<SpecsView> {
       specs,
       rows: board.rows,
       worktreesWithoutSpec: board.worktreesWithoutSpec,
+      ...(features ? { features } : {}),
       ...(board.baseBranch ? { baseBranch: board.baseBranch } : {}),
     }
   } catch {
     return { targetDir, present, changes, specs }
+  }
+}
+
+/**
+ * Builds the registered-feature rows for the specs viewer via read-only
+ * discovery and the shared lifecycle assessment (tasks 2.5/6.1). Every fact
+ * is derived at load time; discovery never writes the registry. A discovery
+ * failure degrades to no rows rather than failing the browser.
+ */
+export async function loadLifecycleFeatureRows(targetDir: string): Promise<LifecycleFeatureRow[] | undefined> {
+  try {
+    const { discoverLifecycle } = await import("./feature-lifecycle/discovery")
+    const { buildObservationsForFeature } = await import("./feature-lifecycle/observe")
+    const { assessLifecycle } = await import("./feature-lifecycle/assessment")
+    const discovery = await discoverLifecycle({ cwd: targetDir })
+    const rows: LifecycleFeatureRow[] = []
+    for (const discovered of discovery.features) {
+      const { lifecycleCommonDir } = await import("./feature-lifecycle/store")
+      const commonDir = (await lifecycleCommonDir(targetDir)) ?? ""
+      const observations = await buildObservationsForFeature({ cwd: targetDir, commonDir, feature: discovered.record })
+      const assessment = assessLifecycle(observations)
+      // Verified associated sources (task 6.2): each readable contract's
+      // own tree, addressed absolutely, in feature-then-contract order.
+      const artifactSources: Array<{ changeId: string; root: string }> = []
+      const checkout = observations.context.verification === "verified" ? observations.context.checkoutPath : undefined
+      if (checkout) {
+        for (const contract of discovered.record.contracts) {
+          const root = join(checkout, contract.sourcePath)
+          const present = await stat(root).then(
+            () => true,
+            () => false,
+          )
+          if (!present) continue
+          const files = await collectDirRelativeMarkdown(root, ".")
+          if (files.length === 0) continue
+          if (!artifactSources.some((source) => source.changeId === contract.changeId)) {
+            artifactSources.push({ changeId: contract.changeId, root })
+          }
+        }
+      }
+      rows.push({
+        featureId: discovered.record.featureId,
+        displayName: discovered.record.displayName,
+        ...(observations.context.branch ? { branch: observations.context.branch } : {}),
+        ...(observations.context.checkoutPath ? { checkoutPath: observations.context.checkoutPath } : {}),
+        summary: assessment.summary,
+        blockers: [...assessment.blockers],
+        ...(assessment.tasks === "unknown" ? { tasks: "unknown" as const } : assessment.tasks ? { tasks: assessment.tasks } : {}),
+        liveRuns: assessment.liveRuns,
+        integration: assessment.integration,
+        contracts: assessment.contracts.map((contract) => ({ changeId: contract.changeId, state: contract.state })),
+        ...(artifactSources.length > 0 ? { artifactSources } : {}),
+        ...(assessment.actions ? { actions: assessment.actions.map((action) => ({ id: action.id, label: action.label, enabled: action.enabled, blockers: action.blockers, ...(action.remediation.length > 0 ? { remediation: action.remediation } : {}) })) } : {}),
+        ...(discovered.receipts.length > 0
+          ? {
+              receipts: await Promise.all(
+                discovered.receipts.flatMap(async ({ receipt }) => {
+                  if (!receipt) return []
+                  const { isLandingReachableFrom } = await import("./feature-lifecycle/refs")
+                  return [{ attemptId: receipt.attemptId, landingSha: receipt.landingSha, landingReachable: await isLandingReachableFrom(receipt.landingSha, receipt.baseRef, targetDir) }]
+                }),
+              ).then((nested) => nested.flat()),
+            }
+          : {}),
+        ...(discovered.record.history.length > 0
+          ? { history: discovered.record.history.map((event) => ({ at: event.at, kind: event.kind, summary: event.summary })) }
+          : {}),
+        ...(discovered.record.runIds.length > 0 ? { runIds: [...discovered.record.runIds] } : {}),
+      })
+    }
+    return rows
+  } catch {
+    return undefined
   }
 }
 
@@ -211,7 +347,19 @@ async function loadSpecsChange(
   id: string,
   options: { absolute?: boolean } = {},
 ): Promise<SpecsChangeEntry> {
-  const changeRoot = join(changesDir, id)
+  return loadSpecsChangeAt(join(changesDir, id), id, options)
+}
+
+/**
+ * Loads one change's entry from an explicit change root — shared by the
+ * launch-checkout loader and the association-driven source precedence
+ * (task 6.2), so both produce identical entries.
+ */
+export async function loadSpecsChangeAt(
+  changeRoot: string,
+  id: string,
+  options: { absolute?: boolean } = {},
+): Promise<SpecsChangeEntry> {
   let title = id
   try {
     const body = await readFile(join(changeRoot, "proposal.md"), "utf8")
@@ -233,10 +381,24 @@ async function loadSpecsChange(
 }
 
 /**
- * Plain-text listing for pipes and CI: active changes with their artifact
- * inventory first, canonical specs below. No colors, no control sequences.
+ * Plain-text listing for pipes and CI: registered lifecycle features with
+ * their summaries and blockers, active changes with their artifact inventory,
+ * run-bearing unassociated worktrees, then canonical specs. No colors, no
+ * control sequences.
  */
-export function printSpecsList(view: Pick<SpecsView, "present" | "changes" | "specs">): void {
+export function printSpecsList(view: Pick<SpecsView, "present" | "changes" | "specs"> & Partial<Pick<SpecsView, "features" | "worktreesWithoutSpec">>): void {
+  if (view.features && view.features.length > 0) {
+    stdout.write("\nfeatures:\n")
+    for (const feature of view.features) {
+      const heading = feature.displayName === feature.featureId ? feature.featureId : `${feature.displayName} (${feature.featureId})`
+      const branch = feature.branch ? ` on ${feature.branch}` : ""
+      stdout.write(`    ${heading}${branch} — ${feature.summary}\n`)
+      if (feature.tasks && feature.tasks !== "unknown") stdout.write(`      tasks ${feature.tasks.done}/${feature.tasks.total}\n`)
+      if (feature.liveRuns > 0) stdout.write(`      ${feature.liveRuns} live run${feature.liveRuns === 1 ? "" : "s"}\n`)
+      for (const contract of feature.contracts) stdout.write(`      contract ${contract.changeId}: ${contract.state}\n`)
+      for (const blocker of feature.blockers) stdout.write(`      blocker: ${blocker}\n`)
+    }
+  }
   stdout.write("\nspecs:\n")
   stdout.write("  active changes:\n")
   if (view.changes.length === 0) {
@@ -252,6 +414,12 @@ export function printSpecsList(view: Pick<SpecsView, "present" | "changes" | "sp
       for (const artifact of inventory(change)) {
         stdout.write(`      ${artifact}\n`)
       }
+    }
+  }
+  if (view.worktreesWithoutSpec && view.worktreesWithoutSpec.length > 0) {
+    stdout.write("  worktrees without spec:\n")
+    for (const worktree of view.worktreesWithoutSpec) {
+      stdout.write(`    ${worktree.dir}${worktree.branch ? ` (${worktree.branch})` : ""} — ${worktree.runCount} run${worktree.runCount === 1 ? "" : "s"}\n`)
     }
   }
   stdout.write("  canonical specs:\n")
@@ -280,7 +448,12 @@ function inventory(change: SpecsChangeEntry): string[] {
  */
 export async function browseSpecs(targetDir: string, route?: TuiRoute): Promise<SpecsResolution> {
   const view = await loadSpecsView(targetDir)
-  if (view.changes.length === 0 && view.specs.length === 0 && (view.worktreesWithoutSpec?.length ?? 0) === 0) {
+  if (
+    view.changes.length === 0 &&
+    view.specs.length === 0 &&
+    (view.worktreesWithoutSpec?.length ?? 0) === 0 &&
+    (view.features?.length ?? 0) === 0
+  ) {
     if (route) {
       const { showNoticeTui } = await import("./notice-tui")
       await showNoticeTui(route, { title: "specs", message: `No specs found under ${join(view.targetDir, openspecDirName)}` })

--- a/src/spin.ts
+++ b/src/spin.ts
@@ -39,6 +39,8 @@ export type SpinResult = {
   committedOnBase: boolean
   /** The inferred or overridden conventional prefix the branch got. */
   prefix: string
+  /** The stable feature identity spin registered for this work (capability feature-lifecycle). */
+  featureId: string
 }
 
 /**
@@ -85,7 +87,26 @@ export async function runSpin(options: SpinOptions): Promise<SpinResult> {
   // 4. Create the worktree on the base ref a launcher-isolated run would use.
   const worktree = await createIsolatedWorktree({ targetDir, branch, baseRef })
 
-  // 5. Carry the uncommitted files over. Committed files stay exactly where
+  // 5. Persist the spin intent (capability feature-lifecycle, design D4):
+  //    the association's intent record is durable before the proposal
+  //    transfer, so a crash mid-transfer leaves recoverable evidence instead
+  //    of an ownerless worktree.
+  const { registerSpinFeature } = await import("./feature-lifecycle/commands")
+  let registration: Awaited<ReturnType<typeof registerSpinFeature>>
+  try {
+    registration = await registerSpinFeature({ cwd: targetDir, changeId: changeID, branch: worktree.branch, worktreeDir: worktree.dir, baseRef, phase: "intent" })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `the worktree was created but persisting the spin intent failed — spin cannot proceed without durable registration evidence\n` +
+        `  created worktree (not yet transferred into): ${worktree.dir}\n` +
+        `  branch: ${worktree.branch}\n` +
+        `  recovery: remove it with \`git worktree remove ${worktree.dir}\`, or adopt it with \`convoy feature adopt --branch ${worktree.branch} --change ${changeID} --base ${baseRef}\`\n` +
+        `  (${detail})`,
+    )
+  }
+
+  // 6. Carry the uncommitted files over. Committed files stay exactly where
   //    they are — the worktree's base ref carries them, and overlap resolves
   //    at merge time.
   const untracked = await listUntrackedFilesUnder(targetDir, join(openspecDirName, "changes", changeID))
@@ -99,13 +120,34 @@ export async function runSpin(options: SpinOptions): Promise<SpinResult> {
       : []
   const committedOnBase = seenOnBase && movedFiles.length === 0
   if (!seenOnBase && untracked.length === 0) {
+    // The intent record stays: the operator can adopt or clean up explicitly.
     throw new Error(
       `the change ${changeID} is not uncommitted here and not on the base ref (${baseRef}) — it is committed on another branch, ` +
-        "so its files would not arrive in this worktree; check out the branch that carries it or spin a change that exists here",
+        `so its files would not arrive in this worktree; check out the branch that carries it or spin a change that exists here. ` +
+        `A spin intent for feature ${registration.feature.featureId} was already recorded with the created worktree at ${worktree.dir}.`,
     )
   }
 
-  return { changeID, branch: worktree.branch, worktreeDir: worktree.dir, movedFiles, committedOnBase, prefix }
+  // 7. Commit the association before success output (design D4): a
+  //    persistence failure here prevents the success handoff and exposes the
+  //    created context and transferred files with recovery guidance.
+  let committed: Awaited<ReturnType<typeof registerSpinFeature>>
+  try {
+    committed = await registerSpinFeature({ cwd: targetDir, changeId: changeID, branch: worktree.branch, worktreeDir: worktree.dir, baseRef, phase: "committed" })
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `the worktree and file transfer succeeded but persisting the feature association failed — spin cannot claim successful registration\n` +
+        `  feature intent: ${registration.feature.featureId}\n` +
+        `  worktree: ${worktree.dir}\n` +
+        `  branch: ${worktree.branch}\n` +
+        `  transferred files: ${movedFiles.length === 0 ? "none" : movedFiles.join(", ")}\n` +
+        `  recovery: resolve the storage error, then run \`convoy feature show\` (or adopt explicitly). Nothing was committed and no transferred file was deleted.\n` +
+        `  (${detail})`,
+    )
+  }
+
+  return { changeID, branch: worktree.branch, worktreeDir: worktree.dir, movedFiles, committedOnBase, prefix, featureId: committed.feature.featureId }
 }
 
 /**
@@ -119,6 +161,7 @@ export function printSpinHandoff(result: SpinResult): void {
   const lines: string[] = []
   lines.push(`spun out ${result.changeID} → ${result.worktreeDir}`)
   lines.push(`branch: ${result.branch}`)
+  lines.push(`feature: ${result.featureId} (registered; \`convoy feature show\` inspects it)`)
   if (result.committedOnBase) {
     lines.push("nothing was moved: the change is already committed on the base branch, and the worktree's base ref carries it")
   } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,25 @@ import type { LoopGuardSettings } from "./loop-guard"
 import type { NotificationSettings } from "./notifications"
 import type { OpenSpecBundle } from "./openspec"
 import type { PrdHistoryPreview } from "./prd-history"
+
+/**
+ * The reviewed feature/contract/context association a feature-backed run
+ * freezes into its plan (capability feature-lifecycle, design D4). Pure
+ * data — defined here so plans and metadata stay dependency-light.
+ */
+export type FeaturePlanLink = {
+  featureId: string
+  repositoryId: string
+  /** The association revision the review validated; execution refuses a stale one. */
+  associationRevision: number
+  contracts: readonly string[]
+  /** The intended local base ref the feature recorded. */
+  baseRef: string
+  /** The verified implementation branch. */
+  branch: string
+  /** The verified checkout path, when resolved. */
+  worktreeDir?: string
+}
 import type { AutoAccept, ProgressUI } from "./progress"
 import type { StepRunnerId } from "./step-runners"
 import type { ModelGateway, ModelRoutingOverrides, ResolvedModel } from "./model-routing"
@@ -13,6 +32,8 @@ export type RunOptions = {
   prdHistory: boolean
   /** Explicit OpenSpec change id (`--change <id>`); resolves the spec bundle contract. */
   change?: string
+  /** Explicit feature id (`--feature <id>`); resolves the feature/contract/context link. */
+  featureId?: string
   files: string[]
   onlySteps: string[]
   skipSteps: string[]
@@ -296,6 +317,13 @@ export type RunPlan = {
     /** Worktree runs only: where that branch will be checked out. */
     worktreeDir?: string
   }
+  /**
+   * The frozen feature link (capability feature-lifecycle): the stable
+   * identity, association revision, contract set, and verified context this
+   * run was reviewed against. Execution revalidates it before starting, and
+   * durable run metadata preserves it after cleanup (task 4.2/5.1).
+   */
+  feature?: FeaturePlanLink
   pipeline: Pipeline
   modelRouting: { gateway: ModelGateway }
   smartJudge?: { model: ResolvedModel }

--- a/test/cross-flow.test.ts
+++ b/test/cross-flow.test.ts
@@ -145,6 +145,11 @@ async function makeRepo(): Promise<Repo> {
   await git(worktreeDir, operatorEnv, "add", "-A")
   await git(worktreeDir, operatorEnv, "commit", "-qm", "feat(openspec): propose add-widget")
 
+  // Register the feature as spin would have: close's adoption gate (task 7.1)
+  // refuses unassociated work, so the cross-flow fixtures start associated.
+  const { registerSpinFeature } = await import("../src/feature-lifecycle/commands")
+  await registerSpinFeature({ cwd: mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir, baseRef: "main", phase: "intent" })
+
   return { root, remote, mainDir, worktreeDir }
 }
 
@@ -372,7 +377,7 @@ describe("cross-flow: hermetic lifecycle and crash-resume (8.3)", () => {
 async function writeOpenspecDouble(binDir: string): Promise<void> {
   const script = [
     "#!/usr/bin/env bun",
-    "import { readdirSync, readFileSync, mkdirSync, renameSync, statSync } from 'node:fs'",
+    "import { readdirSync, readFileSync, mkdirSync, renameSync, statSync, writeFileSync } from 'node:fs'",
     "import { join } from 'node:path'",
     "const [cmd, ...rest] = process.argv.slice(2)",
     "const root = process.cwd()",
@@ -398,6 +403,11 @@ async function writeOpenspecDouble(binDir: string): Promise<void> {
     "  statSync(from)",
     "  mkdirSync(join(root, 'openspec', 'changes', 'archive'), { recursive: true })",
     "  renameSync(from, to)",
+    "  // A real archive merges the deltas into the canonical specs; the double",
+    "  // writes the fixture's expected canonical requirement so close's",
+    "  // positive archive verification (task 7.2) sees a provable result.",
+    "  mkdirSync(join(root, 'openspec', 'specs', 'cli'), { recursive: true })",
+    "  writeFileSync(join(root, 'openspec', 'specs', 'cli', 'spec.md'), '## Requirements\\n\\n### Requirement: Widget\\n')",
     "  process.exit(0)",
     "}",
     "console.error('unexpected openspec invocation: ' + cmd)",

--- a/test/feature-close-command.test.ts
+++ b/test/feature-close-command.test.ts
@@ -161,6 +161,22 @@ describe("parseCloseArgs", () => {
     expect(() => parseCloseArgs(["--branch"])).toThrow(/requires a value/)
     expect(() => parseCloseArgs(["--message"])).toThrow(/requires a value/)
   })
+
+  test("--feature and --cleanup parse; a bad cleanup value refuses (SC-2)", () => {
+    expect(parseCloseArgs(["--feature", "abc-uuid"])).toMatchObject({ featureId: "abc-uuid" })
+    expect(parseCloseArgs(["--feature=abc-uuid"])).toMatchObject({ featureId: "abc-uuid" })
+    expect(parseCloseArgs(["--cleanup", "worktree"])).toMatchObject({ cleanup: "worktree" })
+    expect(parseCloseArgs(["--cleanup=branch"])).toMatchObject({ cleanup: "branch" })
+    expect(() => parseCloseArgs(["--cleanup", "everything"])).toThrow(/expects "worktree" or "branch"/)
+    expect(() => parseCloseArgs(["--cleanup"])).toThrow(/requires a value/)
+  })
+
+  test("the help documents --feature and --cleanup (the remediation never names a flag the parser rejects)", () => {
+    const help = closeHelp()
+    expect(help).toContain("--feature <id>")
+    expect(help).toContain("--cleanup")
+    expect(help).toContain("worktree|branch")
+  })
 })
 
 // -- task 3.2: the checklist frames ----------------------------------------------
@@ -342,8 +358,31 @@ describe("resolveCloseFollowUps", () => {
     const unevidenced = await resolveCloseFollowUps({ targetDir: fixture.mainDir, baseRef: "main", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir })
     expect(unevidenced.branchDelete).toBeUndefined()
     expect(unevidenced.branchDeleteRemediation).toContain("receipt")
-    // With the receipt the deletion is offered as a guarded command that
-    // re-checks the exact tip and landing reachability right before `branch -D`.
+    // With the receipt and the resolved feature, cleanup prints the
+    // feature-keyed guarded commands (design D9): they execute the same
+    // identity-aware checks as the TUI actions — fresh association,
+    // unresolved-attempt, live-run, worktree-inventory, and mutation-lease
+    // checks on top of the landing evidence — never a display-only git
+    // recipe.
+    const tip = await git(fixture.mainDir, "rev-parse", "feat/add-widget")
+    const followUps = await resolveCloseFollowUps({
+      targetDir: fixture.mainDir,
+      baseRef: "main",
+      branch: "feat/add-widget",
+      worktreeDir: fixture.worktreeDir,
+      featureId: "11111111-2222-3333-4444-555555555555",
+      evidence: { landingSha: tip, featureTip: tip },
+    })
+    // Push still names its explicit remote and refspec (publication is not cleanup).
+    const main = await realPath(fixture.mainDir)
+    expect(followUps.push).toEqual({ remote: "origin", refspec: "main:main", command: `git -C ${main} push origin main:main` })
+    expect(followUps.pushRemediation).toBeUndefined()
+    expect(followUps.worktreeRemoval).toBe("convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup worktree")
+    expect(followUps.branchDelete).toBe("convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup branch")
+  })
+
+  test("without a resolved feature the guarded git display remains (synthetic callers only; close itself always resolves one)", async () => {
+    const fixture = await makeFixture()
     const tip = await git(fixture.mainDir, "rev-parse", "feat/add-widget")
     const followUps = await resolveCloseFollowUps({
       targetDir: fixture.mainDir,
@@ -352,20 +391,19 @@ describe("resolveCloseFollowUps", () => {
       worktreeDir: fixture.worktreeDir,
       evidence: { landingSha: tip, featureTip: tip },
     })
-    // The printed commands carry git -C <main-repo> and only quote unsafe paths,
-    // so they stay executable from inside the feature worktree (SC-2).
     const main = await realPath(fixture.mainDir)
-    expect(followUps.push).toEqual({ remote: "origin", refspec: "main:main", command: `git -C ${main} push origin main:main` })
-    expect(followUps.pushRemediation).toBeUndefined()
     expect(followUps.worktreeRemoval).toBe(`git -C ${main} worktree remove ${fixture.worktreeDir}`)
+    // The legacy display keeps the full guarded chain: tip check, reachability,
+    // worktree inventory, then the atomic expected-tip ref deletion.
     expect(followUps.branchDelete).toBe(
       `git -C ${main} rev-parse --verify refs/heads/feat/add-widget | grep -qx ${tip} && ` +
       `git -C ${main} merge-base --is-ancestor ${tip} main && ` +
-      `git -C ${main} branch -D feat/add-widget`,
+      `! git -C ${main} worktree list --porcelain | grep -qx 'branch refs/heads/feat/add-widget' && ` +
+      `git -C ${main} update-ref -d refs/heads/feat/add-widget ${tip}`,
     )
   })
 
-  test("a feature tip that moved past the landing withdraws the deletion command", async () => {
+  test("a moved tip cannot withdraw the feature-keyed command: it is the guarded op and refuses at action time", async () => {
     const fixture = await makeFixture()
     const tip = await git(fixture.mainDir, "rev-parse", "feat/add-widget")
     await git(fixture.worktreeDir, "commit", "--allow-empty", "-m", "feat: new work after the landing")
@@ -374,10 +412,12 @@ describe("resolveCloseFollowUps", () => {
       baseRef: "main",
       branch: "feat/add-widget",
       worktreeDir: fixture.worktreeDir,
+      featureId: "11111111-2222-3333-4444-555555555555",
       evidence: { landingSha: tip, featureTip: tip },
     })
-    expect(followUps.branchDelete).toBeUndefined()
-    expect(followUps.branchDeleteRemediation).toContain("moved past the landed state")
+    // The command is printed, but executing it refuses with the moved-tip
+    // diagnostic — the guard lives in the operation, not in the printout.
+    expect(followUps.branchDelete).toBe("convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup branch")
   })
 
   test("a missing upstream yields the remediation and no push", async () => {
@@ -397,13 +437,13 @@ describe("resolveCloseFollowUps", () => {
   test("formatCloseFollowUps keeps push, worktree removal, then branch deletion in order", () => {
     const lines = formatCloseFollowUps({
       push: { remote: "origin", refspec: "main:main", command: "git push origin main:main" },
-      worktreeRemoval: "git worktree remove /wt",
-      branchDelete: "git branch -d feat/x",
+      worktreeRemoval: "convoy close --feature f-1 --cleanup worktree",
+      branchDelete: "convoy close --feature f-1 --cleanup branch",
     })
     const at = (needle: string) => lines.findIndex((line) => line.includes(needle))
     expect(at("git push origin main:main")).toBeGreaterThan(-1)
-    expect(at("git worktree remove /wt")).toBeGreaterThan(at("git push origin main:main"))
-    expect(at("git branch -d feat/x")).toBeGreaterThan(at("git worktree remove /wt"))
+    expect(at("convoy close --feature f-1 --cleanup worktree")).toBeGreaterThan(at("git push origin main:main"))
+    expect(at("convoy close --feature f-1 --cleanup branch")).toBeGreaterThan(at("convoy close --feature f-1 --cleanup worktree"))
   })
 })
 
@@ -452,12 +492,13 @@ describe("confirmCloseMessage", () => {
 describe("buildCloseFollowUpsView", () => {
   const offersFor = (fixture: { mainDir: string; worktreeDir: string }): FollowUpOffers => ({
     push: { remote: "origin", refspec: "main:main", command: `git -C ${fixture.mainDir} push origin main:main` },
-    worktreeRemoval: `git -C ${fixture.mainDir} worktree remove '${fixture.worktreeDir}'`,
-    branchDelete: `git -C ${fixture.mainDir} branch -d feat/add-widget`,
+    worktreeRemoval: "convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup worktree",
+    branchDelete: "convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup branch",
     baseRef: "main",
     branch: "feat/add-widget",
     worktreeDir: fixture.worktreeDir,
     targetDir: fixture.mainDir,
+    featureId: "11111111-2222-3333-4444-555555555555",
   })
 
   test("launched outside the worktree: push and removal are actions, branch deletion is blocked (same-session dependency)", async () => {
@@ -469,8 +510,8 @@ describe("buildCloseFollowUpsView", () => {
       "worktree:available",
       "branch:blocked",
     ])
-    // The blocked row keeps its explicit command for later use.
-    expect(view.actions[2]!.command).toContain("branch -d feat/add-widget")
+    // The blocked row keeps its explicit feature-keyed command for later use.
+    expect(view.actions[2]!.command).toContain("convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup branch")
   })
 
   test("launched inside the worktree: only push is an action; cleanup is ordered deferred guidance naming the shell location", async () => {
@@ -479,9 +520,11 @@ describe("buildCloseFollowUpsView", () => {
     expect(view.actions.map((action) => action.id)).toEqual(["push"])
     expect(view.deferred).toBeDefined()
     expect(view.deferred!.reason).toContain("launched from inside")
+    // The deferred steps are the feature-keyed guarded commands, worktree
+    // removal before branch deletion (design D9) — not raw git recipes.
     expect(view.deferred!.steps.map((step) => step.command)).toEqual([
-      `git -C ${fixture.mainDir} worktree remove '${fixture.worktreeDir}'`,
-      `git -C ${fixture.mainDir} branch -d feat/add-widget`,
+      "convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup worktree",
+      "convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup branch",
     ])
   })
 
@@ -522,19 +565,20 @@ describe("offerCloseFollowUps", () => {
     const io = createIO(["n"])
     await offerCloseFollowUps(
       {
-        branchDelete: "git branch -D feat/add-widget",
+        branchDelete: "convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup branch",
         ...(await evidenceFor(fixture.mainDir)),
-        worktreeRemoval: `git worktree remove ${fixture.worktreeDir}`,
+        worktreeRemoval: "convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup worktree",
         baseRef: "main",
         branch: "feat/add-widget",
         worktreeDir: fixture.worktreeDir,
         targetDir: fixture.mainDir,
+        featureId: "11111111-2222-3333-4444-555555555555",
       },
       io,
     )
     const text = cleaned(io.chunks)
-    expect(text).toContain(`next: git worktree remove ${fixture.worktreeDir}`)
-    expect(text).toContain("next (after the worktree is removed): git branch -D feat/add-widget")
+    expect(text).toContain("next: convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup worktree")
+    expect(text).toContain("next (after the worktree is removed): convoy close --feature 11111111-2222-3333-4444-555555555555 --cleanup branch")
     // The branch still exists and still has its worktree.
     expect((await stat(fixture.worktreeDir)).isDirectory()).toBe(true)
     expect(await git(fixture.mainDir, "rev-parse", "--verify", "feat/add-widget")).toBeTruthy()

--- a/test/feature-close-identity.test.ts
+++ b/test/feature-close-identity.test.ts
@@ -1,0 +1,585 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { chmod, mkdir, mkdtemp, realpath as realPath, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { runClose, verifiedCloseReceipt, readCloseJournal, type CloseInput } from "../src/feature-close"
+import { templateCommitMessage, type CommitMessageProposal } from "../src/commit-message"
+import { writeCloseJournal } from "../src/close-journal"
+import { listFeatureIds } from "../src/feature-lifecycle/records"
+import { lifecycleCommonDir } from "../src/feature-lifecycle/store"
+import { listAttemptIds, listReceiptIds, readAttemptJournal, readReceipt, readFeatureRecord } from "../src/feature-lifecycle/records"
+import { registerSpinFeature } from "../src/feature-lifecycle/commands"
+import { isFound } from "../src/feature-lifecycle/store"
+import { resolveCommit, execFile } from "../src/git"
+
+/**
+ * Tasks 7.1/7.3/7.4: close resolves through stable feature identity, persists
+ * the attempt before the first mutation, writes an immutable identity-keyed
+ * receipt at landing, and a repeated close (with or without --resume) performs
+ * no second landing.
+ */
+
+const dirs: string[] = []
+const originalPath = process.env.PATH
+const originalConvoyHome = process.env.CONVOY_HOME
+
+async function git(dir: string, env: Record<string, string>, ...args: string[]): Promise<void> {
+  const result = await execFile("git", args, { cwd: dir, env: { ...process.env, ...env } as Record<string, string>, allowFailure: true })
+  if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${result.stderr || result.stdout}`)
+}
+
+const user = { GIT_AUTHOR_NAME: "Operator", GIT_AUTHOR_EMAIL: "operator@example.com", GIT_COMMITTER_NAME: "Operator", GIT_COMMITTER_EMAIL: "operator@example.com" }
+const convoy = { GIT_AUTHOR_NAME: "convoy", GIT_AUTHOR_EMAIL: "convoy@local", GIT_COMMITTER_NAME: "convoy", GIT_COMMITTER_EMAIL: "convoy@local" }
+
+/** The injected OpenSpec double (same shape feature-close.test.ts uses). */
+async function writeOpenspecDouble(binDir: string): Promise<void> {
+  const script = `#!/bin/sh
+cmd="$1"; shift
+root="$(pwd)"
+if [ "$cmd" = "list" ] && [ "$1" = "--json" ]; then
+  # Count checkboxes the way the real CLI would, for every active change.
+  changes=""
+  for d in "$root"/openspec/changes/*/; do
+    id="$(basename "$d")"
+    [ "$id" = "archive" ] && continue
+    [ -f "$d/tasks.md" ] || continue
+    total="$(grep -cE '^\\s*[-*+]\\s+\\[[xX ]\\]' "$d/tasks.md" || true)"
+    done_n="$(grep -cE '^\\s*[-*+]\\s+\\[[xX]\\]' "$d/tasks.md" || true)"
+    entry="{\\"name\\":\\"$id\\",\\"completedTasks\\":$done_n,\\"totalTasks\\":$total}"
+    if [ -z "$changes" ]; then changes="$entry"; else changes="$changes,$entry"; fi
+  done
+  echo "{\\"changes\\":[$changes]}"
+  exit 0
+fi
+if [ "$cmd" = "archive" ]; then
+  id="$1"
+  dir="$root/openspec/changes"
+  if [ ! -d "$dir/$id" ]; then
+    echo "no such change: $id" >&2
+    exit 1
+  fi
+  mkdir -p "$root/openspec/changes/archive"
+  mv "$dir/$id" "$root/openspec/changes/archive/$id"
+  if [ -z "$CONVOY_OPENSPEC_NO_CANONICAL" ]; then
+    mkdir -p "$root/openspec/specs/cli"
+    printf '# cli\\n\\n## Requirements\\n\\n### Requirement: Widget\\n' > "$root/openspec/specs/cli/spec.md"
+  fi
+  exit 0
+fi
+echo "unexpected openspec invocation: $cmd" >&2
+exit 1
+`
+  const path = join(binDir, "openspec")
+  await writeFile(path, script)
+  await chmod(path, 0o755)
+}
+
+async function makeFixture(): Promise<{ root: string; mainDir: string; worktreeDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), "convoy-close-identity-"))
+  dirs.push(root)
+  const mainDir = join(root, "main")
+  const worktreeDir = join(root, "wt")
+  await mkdir(mainDir, { recursive: true })
+  await git(mainDir, {}, "init", "-b", "main")
+  await git(mainDir, user, "config", "user.email", "operator@example.com")
+  await git(mainDir, user, "config", "user.name", "Operator")
+  await writeFile(join(mainDir, "README.md"), "# repo\n")
+  await git(mainDir, user, "add", ".")
+  await git(mainDir, user, "commit", "-m", "chore: init")
+  await git(mainDir, {}, "worktree", "add", "-b", "feat/add-widget", worktreeDir, "main")
+
+  const changeDir = join(worktreeDir, "openspec", "changes", "add-widget")
+  await mkdir(join(changeDir, "specs", "cli"), { recursive: true })
+  await writeFile(join(changeDir, "proposal.md"), "# Add widget\n")
+  await writeFile(join(changeDir, "tasks.md"), "- [x] one\n- [x] two\n")
+  await writeFile(join(changeDir, "specs", "cli", "spec.md"), "## ADDED Requirements\n### Requirement: Widget\n")
+  await git(worktreeDir, user, "add", ".")
+  await git(worktreeDir, user, "commit", "-m", "feat(openspec): propose add-widget")
+  await writeFile(join(worktreeDir, "src.ts"), "export const widget = 1\n")
+  await git(worktreeDir, convoy, "add", ".")
+  await git(worktreeDir, convoy, "commit", "-m", "convoy(implement): implement add-widget")
+
+  return { root, mainDir: await realPath(mainDir), worktreeDir: await realPath(worktreeDir) }
+}
+
+const closeInput = (fixture: { mainDir: string; worktreeDir: string }, extra: Partial<CloseInput> = {}): CloseInput => ({
+  targetDir: fixture.mainDir,
+  worktreeDir: fixture.worktreeDir,
+  branch: "feat/add-widget",
+  changeID: "add-widget",
+  ...extra,
+})
+
+const writerFails: CloseInput["writer"] = async () =>
+  ({ message: templateCommitMessage({ targetDir: "", branch: "", commits: [] }), source: "template", error: "writer unavailable (test double)" }) satisfies CommitMessageProposal
+
+beforeAll(async () => {
+  const binDir = join(tmpdir(), `convoy-close-identity-bin-${Math.random().toString(36).slice(2)}`)
+  dirs.push(binDir)
+  await mkdir(binDir, { recursive: true })
+  await writeOpenspecDouble(binDir)
+  process.env.PATH = `${binDir}:${process.env.PATH}`
+  const home = await mkdtemp(join(tmpdir(), "convoy-close-identity-home-"))
+  dirs.push(home)
+  process.env.CONVOY_HOME = home
+})
+
+afterAll(async () => {
+  if (originalConvoyHome === undefined) delete process.env.CONVOY_HOME
+  else process.env.CONVOY_HOME = originalConvoyHome
+  if (originalPath !== undefined) process.env.PATH = originalPath
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("identity-keyed close (tasks 7.1/7.3/7.4)", () => {
+  test("close on a registered feature writes the attempt and an immutable receipt; repeated close performs nothing", async () => {
+    const fixture = await makeFixture()
+
+    // Register the feature first (as spin would have).
+    const registration = await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const featureId = registration.feature.featureId
+
+    const result = await runClose({ ...closeInput(fixture), writer: writerFails })
+    expect(result.disposition).toBe("landed")
+    expect(result.landing).toBeDefined()
+
+    const commonDir = (await lifecycleCommonDir(fixture.mainDir))!
+    // The attempt journal persisted under the stable identity.
+    const attemptIds = await listAttemptIds(commonDir, featureId)
+    expect(attemptIds).toHaveLength(1)
+    const journal = await readAttemptJournal(commonDir, featureId, attemptIds[0]!)
+    expect(journal.status).toBe("found")
+    if (isFound(journal)) {
+      expect(journal.value.phase).toBe("landed")
+      expect(journal.value.landingSha).toBe(result.landing!.sha)
+    }
+    // The immutable receipt exists and names the exact tip and landing.
+    const receiptIds = await listReceiptIds(commonDir, featureId)
+    expect(receiptIds).toHaveLength(1)
+    const receipt = await readReceipt(commonDir, featureId, receiptIds[0]!)
+    expect(receipt.status).toBe("found")
+    if (isFound(receipt)) {
+      expect(receipt.value.landingSha).toBe(result.landing!.sha)
+      expect(receipt.value.branch).toBe("feat/add-widget")
+      expect(receipt.value.featureTip).toBeTruthy()
+    }
+    // The feature record carries the attempt pointer.
+    const feature = await readFeatureRecord(commonDir, featureId)
+    expect(isFound(feature) && feature.value.closeAttemptIds).toEqual([attemptIds[0]])
+
+    // A repeated close (no --resume) reports the existing landing: no sync,
+    // no archive, no second commit.
+    const baseBefore = await resolveCommit("main", fixture.mainDir)
+    const again = await runClose({ ...closeInput(fixture), writer: writerFails })
+    expect(again.disposition).toBe("already-landed")
+    expect(again.landing!.sha).toBe(result.landing!.sha)
+    expect(await resolveCommit("main", fixture.mainDir)).toBe(baseBefore)
+    // The receipt count is still exactly one.
+    expect(await listReceiptIds(commonDir, featureId).then((ids) => ids.length)).toBe(1)
+  })
+
+  test("verifiedCloseReceipt resolves the identity-keyed receipt for the board", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const result = await runClose({ ...closeInput(fixture), writer: writerFails })
+    const receipt = await verifiedCloseReceipt(fixture.mainDir, "feat/add-widget", "add-widget")
+    expect(receipt).toBeDefined()
+    expect(receipt!.landingSha).toBe(result.landing!.sha)
+  })
+
+  test("the checklist's preflight names the verified feature (task 7.8)", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const events: Array<{ type: string; summary?: string }> = []
+    await runClose({ ...closeInput(fixture), writer: writerFails, onEvent: (event) => events.push(event) })
+    const preflight = events.find((event) => event.type === "preflight")
+    expect(preflight?.summary).toContain("feature add-widget")
+    // The result names the landing (integration) — never a merge shape.
+    const result = events.find((event) => event.type === "result")
+    expect(result).toBeTruthy()
+  })
+
+  test("archive-on-main verifies the base copy and records the archive source (task 7.9)", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+
+    // The probably-merged scenario: the same change also sits on the base
+    // checkout (committed, so the checkout is clean). Archive-on-main
+    // verifies that base copy (markdown present, effects provable) and
+    // records the archive source on the feature's contract.
+    const baseChange = join(fixture.mainDir, "openspec", "changes", "add-widget")
+    await mkdir(baseChange, { recursive: true })
+    await writeFile(join(baseChange, "proposal.md"), "# Add widget\n")
+    await writeFile(join(baseChange, "tasks.md"), "- [x] one\n- [x] two\n")
+    await git(fixture.mainDir, user, "add", ".")
+    await git(fixture.mainDir, user, "commit", "-m", "feat(openspec): copy of add-widget proposal on main")
+
+    const { archiveChangeOnMain } = await import("../src/feature-close")
+    const result = await archiveChangeOnMain({ targetDir: fixture.mainDir, changeID: "add-widget" })
+    expect(result.committed).toBe(true)
+    expect(result.archiveSource).toBe(join("openspec", "changes", "archive", "add-widget"))
+
+    const commonDir = (await lifecycleCommonDir(fixture.mainDir))!
+    const { listFeatureIds } = await import("../src/feature-lifecycle/records")
+    const featureIds = await listFeatureIds(commonDir)
+    const feature = await readFeatureRecord(commonDir, featureIds[0]!)
+    if (!isFound(feature)) throw new Error("feature record missing")
+    const contract = feature.value.contracts.find((entry) => entry.changeId === "add-widget")
+    expect(contract?.kind).toBe("archive")
+    expect(contract?.sourcePath).toBe(join("openspec", "changes", "archive", "add-widget"))
+
+    // A husk copy on the base checkout is refused, never archived as work.
+    const husk = join(fixture.mainDir, "openspec", "changes", "husk-change")
+    await mkdir(husk, { recursive: true })
+    await expect(archiveChangeOnMain({ targetDir: fixture.mainDir, changeID: "husk-change" })).rejects.toThrow(/husk/)
+  })
+
+  test("a selector that contradicts the registered association refuses before mutation", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const baseBefore = await resolveCommit("main", fixture.mainDir)
+    const branchBefore = await resolveCommit("feat/add-widget", fixture.worktreeDir)
+    await expect(
+      runClose({ ...closeInput(fixture), changeID: "not-a-contract", writer: writerFails }),
+    ).rejects.toThrow(/disagree with the registered association/)
+    // Nothing changed on any branch.
+    expect(await resolveCommit("main", fixture.mainDir)).toBe(baseBefore)
+    expect(await resolveCommit("feat/add-widget", fixture.worktreeDir)).toBe(branchBefore)
+    // The worktree's change directory is untouched (no archive ran).
+    await expect(stat(join(fixture.worktreeDir, "openspec", "changes", "add-widget"))).resolves.toBeTruthy()
+  })
+
+  test("unverifiable archive output stops before committing or landing (task 7.2)", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const baseBefore = await resolveCommit("main", fixture.mainDir)
+    // The double archives the change but writes no canonical spec — the
+    // ADDED delta effect cannot be proven, so close must refuse.
+    process.env.CONVOY_OPENSPEC_NO_CANONICAL = "1"
+    let message: string | undefined
+    try {
+      await runClose({ ...closeInput(fixture), writer: writerFails })
+      expect.unreachable("close must refuse an unprovable archive result")
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    } finally {
+      delete process.env.CONVOY_OPENSPEC_NO_CANONICAL
+    }
+    expect(message).toMatch(/does not prove every delta effect/)
+    expect(message).toMatch(/canonical specs/)
+    // The base is unadvanced and no archive commit landed on the feature branch.
+    expect(await resolveCommit("main", fixture.mainDir)).toBe(baseBefore)
+    const log = await execFile("git", ["log", "--format=%s", "main..feat/add-widget"], { cwd: fixture.worktreeDir, allowFailure: true })
+    expect(log.stdout).not.toMatch(/chore\(openspec\): archive/)
+    // Resume guidance names the remediation.
+    expect(message).toMatch(/convoy close --resume/)
+  })
+
+  test("resume after the operator commits an incomplete archive still refuses (task 7.2)", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const baseBefore = await resolveCommit("main", fixture.mainDir)
+
+    // First attempt: the archive runs but its canonical effect is unprovable;
+    // the operator then commits that incomplete archive state themselves.
+    process.env.CONVOY_OPENSPEC_NO_CANONICAL = "1"
+    try {
+      await runClose({ ...closeInput(fixture), writer: writerFails })
+      expect.unreachable("close must refuse an unprovable archive result")
+    } catch {
+      // Expected stop.
+    } finally {
+      delete process.env.CONVOY_OPENSPEC_NO_CANONICAL
+    }
+    await git(fixture.worktreeDir, user, "add", ".")
+    await git(fixture.worktreeDir, user, "commit", "-m", "chore(openspec): archive add-widget (operator, incomplete)")
+    // The change is now absent from openspec/changes/ and present in the
+    // archive layout, with its incomplete state committed.
+    await expect(stat(join(fixture.worktreeDir, "openspec", "changes", "add-widget"))).rejects.toThrow()
+
+    // A resumed close revalidates the original contract's delta effects
+    // against the canonical specs and refuses — the base stays unadvanced.
+    const branchBefore = await resolveCommit("feat/add-widget", fixture.worktreeDir)
+    await expect(runClose({ ...closeInput(fixture), resume: true, writer: writerFails })).rejects.toThrow(/does not prove every delta effect/)
+    expect(await resolveCommit("main", fixture.mainDir)).toBe(baseBefore)
+    expect(await resolveCommit("feat/add-widget", fixture.worktreeDir)).toBe(branchBefore)
+  })
+
+  test("an unassociated close refuses before any mutation and names the explicit adoption command (task 7.1)", async () => {
+    const fixture = await makeFixture()
+    // No registration: the close must not act on a branch-name guess.
+    const baseBefore = await resolveCommit("main", fixture.mainDir)
+    const branchBefore = await resolveCommit("feat/add-widget", fixture.worktreeDir)
+
+    let message: string | undefined
+    try {
+      await runClose({ ...closeInput(fixture), writer: writerFails })
+      expect.unreachable("close must refuse an unassociated context")
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error)
+    }
+    // The refusal names the exact explicit adoption command (design D3).
+    expect(message).toMatch(/no verified feature association/)
+    expect(message).toContain("convoy feature adopt --branch feat/add-widget --change add-widget --base main")
+    // Nothing was archived, committed, or landed: no mutation happened.
+    expect(await resolveCommit("main", fixture.mainDir)).toBe(baseBefore)
+    expect(await resolveCommit("feat/add-widget", fixture.worktreeDir)).toBe(branchBefore)
+    await expect(stat(join(fixture.worktreeDir, "openspec", "changes", "add-widget"))).resolves.toBeTruthy()
+    // No journal or registry files were created by the refused close.
+    const commonDir = (await lifecycleCommonDir(fixture.mainDir))!
+    await expect(stat(join(commonDir, "convoy", "close"))).rejects.toThrow()
+    await expect(stat(join(commonDir, "convoy", "features"))).rejects.toThrow()
+
+    // After explicit adoption the same close proceeds: identity, not branch
+    // spelling, authorized the mutation.
+    const { featureAdopt } = await import("../src/feature-lifecycle/commands")
+    const { feature } = await featureAdopt({ cwd: fixture.mainDir, branch: "feat/add-widget", changeIds: ["add-widget"], base: "main" })
+    expect(feature.featureId).toBeTruthy()
+    const result = await runClose({ ...closeInput(fixture), writer: writerFails })
+    expect(result.disposition).toBe("landed")
+  })
+
+  test("legacy effect snapshots are still written for adopted features (task 7.2)", async () => {
+    const fixture = await makeFixture()
+    const registration = await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const featureIdsOf = (commonDir: string) => registration.feature.featureId
+    const baseBefore = await resolveCommit("main", fixture.mainDir)
+
+    process.env.CONVOY_OPENSPEC_NO_CANONICAL = "1"
+    try {
+      await runClose({ ...closeInput(fixture), writer: writerFails })
+      expect.unreachable("close must refuse an unprovable archive result")
+    } catch {
+      // Expected stop.
+    } finally {
+      delete process.env.CONVOY_OPENSPEC_NO_CANONICAL
+    }
+    // The identity attempt journal carries the effect snapshot from before
+    // the archive — the durable intent resume validates against.
+    const commonDir = (await lifecycleCommonDir(fixture.mainDir))!
+    const attemptIds = await listAttemptIds(commonDir, featureIdsOf(commonDir))
+    const attempt = await readAttemptJournal(commonDir, featureIdsOf(commonDir), attemptIds[0]!)
+    expect(isFound(attempt)).toBe(true)
+    if (isFound(attempt)) {
+      expect(attempt.value.contracts[0]?.requiredEffects).toHaveLength(1)
+    }
+
+    // The operator deletes the archived delta and commits the residue; the
+    // resumed close must still refuse from the snapshot.
+    await rm(join(fixture.worktreeDir, "openspec", "changes", "archive", "add-widget", "specs", "cli", "spec.md"), { force: true })
+    await git(fixture.worktreeDir, user, "add", ".")
+    await git(fixture.worktreeDir, user, "commit", "-m", "chore(openspec): archive add-widget (operator, delta removed)")
+
+    const branchBefore = await resolveCommit("feat/add-widget", fixture.worktreeDir)
+    await expect(runClose({ ...closeInput(fixture), resume: true, writer: writerFails })).rejects.toThrow(/does not prove every delta effect/)
+    expect(await resolveCommit("main", fixture.mainDir)).toBe(baseBefore)
+    expect(await resolveCommit("feat/add-widget", fixture.worktreeDir)).toBe(branchBefore)
+  })
+
+  test("an interrupted landing after ref success is reconciled without a second commit (task 7.5)", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const first = await runClose({ ...closeInput(fixture), writer: writerFails })
+    expect(first.disposition).toBe("landed")
+    const commitCount = await execFile("git", ["rev-list", "--count", "main"], { cwd: fixture.mainDir, allowFailure: true })
+
+    // Simulate the crash window: the ref landed and the journal recorded the
+    // landing, but materialization was never acknowledged and the receipt
+    // was never written.
+    const commonDir = (await lifecycleCommonDir(fixture.mainDir))!
+    const journal = await readCloseJournal(commonDir, "feat/add-widget", "add-widget")
+    expect(journal?.checkoutMaterialized).toBe(true)
+    await writeCloseJournal(commonDir, { ...journal!, checkoutMaterialized: false })
+    // Remove every identity receipt under the registered feature.
+    const { listReceiptIds } = await import("../src/feature-lifecycle/records")
+    for (const featureId of await listFeatureIds(commonDir)) {
+      for (const receiptId of await listReceiptIds(commonDir, featureId)) {
+        await rm(join(commonDir, "convoy", "features", featureId, "receipts", `${receiptId}.json`), { force: true })
+      }
+    }
+
+    // Resume: close reconciles the checkout and rewrites the receipt without
+    // creating another commit.
+    const resumed = await runClose({ ...closeInput(fixture), resume: true, writer: writerFails })
+    expect(resumed.disposition).toBe("landed")
+    expect(resumed.landing!.sha).toBe(first.landing!.sha)
+    expect(await execFile("git", ["rev-list", "--count", "main"], { cwd: fixture.mainDir, allowFailure: true }).then((r) => r.stdout.trim())).toBe(commitCount.stdout.trim())
+    // The receipt was rewritten (recovery evidence is durable again).
+    const rewritten = await verifiedCloseReceipt(fixture.mainDir, "feat/add-widget", "add-widget")
+    expect(rewritten?.landingSha).toBe(first.landing!.sha)
+  })
+
+  test("a moved base refuses the stale attempt instead of landing across it (task 7.5)", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const baseBefore = await resolveCommit("main", fixture.mainDir)
+    // First attempt: declined message stops the sequence at the squash gate.
+    await expect(runClose({ ...closeInput(fixture), resolveMessage: async () => undefined, writer: writerFails })).rejects.toThrow(/wasn't confirmed/)
+    // The base advances independently.
+    await writeFile(join(fixture.mainDir, "parallel.txt"), "parallel work\n")
+    await git(fixture.mainDir, user, "add", ".")
+    await git(fixture.mainDir, user, "commit", "-m", "chore: parallel advance")
+    // The resume refuses the stale attempt; the base is unchanged.
+    await expect(runClose({ ...closeInput(fixture), resume: true, writer: writerFails })).rejects.toThrow(/the base moved since this attempt was recorded/)
+    expect(await resolveCommit("main", fixture.mainDir)).not.toBe(baseBefore)
+  })
+
+  test("resume verifies against the persisted effect snapshot, not the archived copy (task 7.2)", async () => {
+    const fixture = await makeFixture()
+    await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const baseBefore = await resolveCommit("main", fixture.mainDir)
+
+    // First attempt: the archive runs unprovably; the operator then deletes
+    // the unsatisfied delta from the archived copy and commits the residue.
+    process.env.CONVOY_OPENSPEC_NO_CANONICAL = "1"
+    try {
+      await runClose({ ...closeInput(fixture), writer: writerFails })
+      expect.unreachable("close must refuse an unprovable archive result")
+    } catch {
+      // Expected stop.
+    } finally {
+      delete process.env.CONVOY_OPENSPEC_NO_CANONICAL
+    }
+    // Deleting the delta from the archived copy must not make resume's
+    // verification vacuous: the snapshot persisted before the archive still
+    // demands the ADDED effect.
+    await rm(join(fixture.worktreeDir, "openspec", "changes", "archive", "add-widget", "specs", "cli", "spec.md"), { force: true })
+    await git(fixture.worktreeDir, user, "add", ".")
+    await git(fixture.worktreeDir, user, "commit", "-m", "chore(openspec): archive add-widget (operator, delta removed)")
+
+    const branchBefore = await resolveCommit("feat/add-widget", fixture.worktreeDir)
+    await expect(runClose({ ...closeInput(fixture), resume: true, writer: writerFails })).rejects.toThrow(/does not prove every delta effect/)
+    expect(await resolveCommit("main", fixture.mainDir)).toBe(baseBefore)
+    expect(await resolveCommit("feat/add-widget", fixture.worktreeDir)).toBe(branchBefore)
+  })
+})
+
+describe("feature-keyed cleanup and worktree-less resume (tasks 7.5/7.7, SC-2)", () => {
+  test("--feature --resume resolves the recorded landing after the worktree was removed, with no branch spelling", async () => {
+    const fixture = await makeFixture()
+    const registration = await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const featureId = registration.feature.featureId
+    const result = await runClose({ ...closeInput(fixture), writer: writerFails })
+    expect(result.disposition).toBe("landed")
+
+    // The worktree is removed outside any close flow.
+    await git(fixture.mainDir, {}, "worktree", "remove", fixture.worktreeDir)
+
+    // Identity-keyed resume: no --branch, no --change, no worktree — the
+    // feature's receipt supplies the branch, landing, and base. The old
+    // branch-keyed surface would have refused here.
+    const resumed = await runClose({ targetDir: fixture.mainDir, featureId, resume: true, writer: writerFails })
+    expect(resumed.disposition).toBe("already-landed")
+    expect(resumed.landing!.sha).toBe(result.landing!.sha)
+    expect(resumed.branch).toBe("feat/add-widget")
+  })
+
+  test("--cleanup worktree removes the verified worktree; --cleanup branch then deletes the branch at its landed tip", async () => {
+    const fixture = await makeFixture()
+    const registration = await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const featureId = registration.feature.featureId
+    await runClose({ ...closeInput(fixture), writer: writerFails })
+
+    const { runCloseCleanup } = await import("../src/feature-close")
+    const removed = await runCloseCleanup({ targetDir: fixture.mainDir, featureId, cleanup: "worktree" })
+    expect(removed).toMatch(/removed the feature worktree/)
+    await expect(stat(fixture.worktreeDir)).rejects.toThrow()
+
+    const deleted = await runCloseCleanup({ targetDir: fixture.mainDir, featureId, cleanup: "branch" })
+    expect(deleted).toMatch(/deleted the local feat\/add-widget branch/)
+    expect((await execFile("git", ["rev-parse", "--verify", "refs/heads/feat/add-widget"], { cwd: fixture.mainDir, allowFailure: true })).exitCode).not.toBe(0)
+    // The landing evidence survives cleanup.
+    const commonDir = (await lifecycleCommonDir(fixture.mainDir))!
+    expect(await listReceiptIds(commonDir, featureId).then((ids) => ids.length)).toBe(1)
+  })
+
+  test("--cleanup branch refuses when the tip moved past the landed state", async () => {
+    const fixture = await makeFixture()
+    const registration = await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const featureId = registration.feature.featureId
+    await runClose({ ...closeInput(fixture), writer: writerFails })
+
+    // New work lands on the branch after the receipt — the old receipt must
+    // never delete it.
+    await git(fixture.worktreeDir, user, "commit", "--allow-empty", "-m", "feat: new work after the landing")
+
+    const { runCloseCleanup } = await import("../src/feature-close")
+    await expect(runCloseCleanup({ targetDir: fixture.mainDir, featureId, cleanup: "branch" })).rejects.toThrow(/tip moved past the landed state/)
+    // The branch still exists — nothing was deleted.
+    expect((await execFile("git", ["rev-parse", "--verify", "refs/heads/feat/add-widget"], { cwd: fixture.mainDir, allowFailure: true })).exitCode).toBe(0)
+  })
+
+  test("--cleanup refuses without a verified landing receipt and without a feature id", async () => {
+    const fixture = await makeFixture()
+    const registration = await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const featureId = registration.feature.featureId
+
+    const { runCloseCleanup } = await import("../src/feature-close")
+    // No close ran: no receipt exists, so cleanup is unauthorized.
+    await expect(runCloseCleanup({ targetDir: fixture.mainDir, featureId, cleanup: "branch" })).rejects.toThrow(/no verified landing receipt/)
+    // Cleanup without identity is refused outright (feature-keyed, never branch-keyed).
+    await expect(runCloseCleanup({ targetDir: fixture.mainDir, cleanup: "worktree" })).rejects.toThrow(/requires --feature/)
+  })
+
+  test("a landed close's result feeds the feature-keyed follow-up surface (design D9)", async () => {
+    const fixture = await makeFixture()
+    const registration = await registerSpinFeature({ cwd: fixture.mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: fixture.worktreeDir, baseRef: "main", phase: "intent" })
+    const featureId = registration.feature.featureId
+    const result = await runClose({ ...closeInput(fixture), writer: writerFails })
+    expect(result.disposition).toBe("landed")
+    // The result carries the resolved feature so every follow-up surface can
+    // print the feature-keyed guarded commands.
+    expect(result.featureId).toBe(featureId)
+
+    const { resolveCloseFollowUps } = await import("../src/feature-close-command")
+    const receipt = await verifiedCloseReceipt(fixture.mainDir, result.branch, result.changeID)
+    const followUps = await resolveCloseFollowUps({
+      targetDir: fixture.mainDir,
+      baseRef: result.baseRef,
+      branch: result.branch,
+      worktreeDir: result.worktreeDir,
+      featureId: result.featureId,
+      ...(receipt ? { evidence: { landingSha: receipt.landingSha, featureTip: receipt.postArchiveTip } } : {}),
+    })
+    expect(followUps.worktreeRemoval).toBe(`convoy close --feature ${featureId} --cleanup worktree`)
+    expect(followUps.branchDelete).toBe(`convoy close --feature ${featureId} --cleanup branch`)
+
+    // The deferred (launched-inside) guidance carries the same commands.
+    const { buildCloseFollowUpsView } = await import("../src/feature-close-command")
+    const view = await buildCloseFollowUpsView({
+      followUps: { ...followUps, baseRef: result.baseRef, branch: result.branch, worktreeDir: result.worktreeDir, targetDir: fixture.mainDir, featureId },
+      cwdInside: true,
+    })
+    expect(view.deferred!.steps.map((step) => step.command)).toEqual([
+      `convoy close --feature ${featureId} --cleanup worktree`,
+      `convoy close --feature ${featureId} --cleanup branch`,
+    ])
+
+    // And an accepted deferred-style action executes the same guarded
+    // operation: the worktree removal routes through runCloseCleanup.
+    const { offerCloseFollowUps } = await import("../src/feature-close-command")
+    const { PassThrough } = await import("node:stream")
+    const input = new PassThrough()
+    const chunks: string[] = []
+    let answered = false
+    const output = {
+      write: (text: string) => {
+        chunks.push(text)
+        if (!answered && text.includes("[y")) {
+          answered = true
+          input.write("y\n")
+          // Only one acceptance is buffered; EOF afterwards declines the
+          // branch-deletion prompt the same way a closed terminal would.
+          setImmediate(() => input.end())
+        }
+        return true
+      },
+    }
+    await offerCloseFollowUps(
+      { ...followUps, baseRef: result.baseRef, branch: result.branch, worktreeDir: result.worktreeDir, targetDir: fixture.mainDir, featureId },
+      { output, input } as never,
+    )
+    await expect(stat(fixture.worktreeDir)).rejects.toThrow()
+  })
+})

--- a/test/feature-close.test.ts
+++ b/test/feature-close.test.ts
@@ -52,7 +52,7 @@ async function git(cwd: string, env: Record<string, string> | undefined, ...args
 async function writeOpenspecDouble(binDir: string): Promise<void> {
   const script = [
     "#!/usr/bin/env bun",
-    "import { readdirSync, readFileSync, mkdirSync, renameSync, statSync } from 'node:fs'",
+    "import { readdirSync, readFileSync, mkdirSync, renameSync, statSync, writeFileSync } from 'node:fs'",
     "import { join } from 'node:path'",
     "const [cmd, ...rest] = process.argv.slice(2)",
     "const root = process.cwd()",
@@ -76,13 +76,18 @@ async function writeOpenspecDouble(binDir: string): Promise<void> {
     "    console.error('openspec archive failed (injected)')",
     "    process.exit(4)",
     "  }",
-    "  const id = rest.find((a) => !a.startsWith('-'))",
-    "  const from = join(root, 'openspec', 'changes', id)",
-    "  const to = join(root, 'openspec', 'changes', 'archive', id)",
-    "  statSync(from)",
-    "  mkdirSync(join(root, 'openspec', 'changes', 'archive'), { recursive: true })",
-    "  renameSync(from, to)",
-    "  process.exit(0)",
+  "  const id = rest.find((a) => !a.startsWith('-'))",
+  "  const from = join(root, 'openspec', 'changes', id)",
+  "  const to = join(root, 'openspec', 'changes', 'archive', id)",
+  "  statSync(from)",
+  "  mkdirSync(join(root, 'openspec', 'changes', 'archive'), { recursive: true })",
+  "  renameSync(from, to)",
+  "  // A real archive merges the deltas into the canonical specs; the double",
+  "  // writes the fixture's expected canonical requirement so close's",
+  "  // positive archive verification (task 7.2) sees a provable result.",
+  "  mkdirSync(join(root, 'openspec', 'specs', 'cli'), { recursive: true })",
+  "  writeFileSync(join(root, 'openspec', 'specs', 'cli', 'spec.md'), '## Requirements\\n\\n### Requirement: Widget\\n')",
+  "  process.exit(0)",
     "}",
     "console.error('unexpected openspec invocation: ' + cmd)",
     "process.exit(3)",
@@ -137,6 +142,12 @@ async function makeFixture(input: { tasksDone: boolean } = { tasksDone: true }):
   await writeFile(join(worktreeDir, "src.ts"), "export const widget = 1\n")
   await git(worktreeDir, convoy, "add", ".")
   await git(worktreeDir, convoy, "commit", "-m", "convoy(implement): implement add-widget")
+
+  // Register the feature as spin would have: the adoption gate (task 7.1)
+  // refuses closes on unassociated work, so every close fixture starts from
+  // an explicitly associated context.
+  const { registerSpinFeature } = await import("../src/feature-lifecycle/commands")
+  await registerSpinFeature({ cwd: mainDir, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: await realPath(worktreeDir), baseRef: "main", phase: "intent" })
 
   return { root, mainDir: await realPath(mainDir), worktreeDir: await realPath(worktreeDir) }
 }
@@ -392,7 +403,8 @@ describe("runClose", () => {
     const fixture = await makeFixture()
     const events = await collectEvents(fixture)
 
-    expect(events[0]).toEqual({ type: "preflight", summary: "clean tree · 2/2 tasks · no live runs" })
+    // The checklist's preflight line names the registered feature it acts on (task 7.8).
+    expect(events[0]).toEqual({ type: "preflight", summary: "feature add-widget · clean tree · 2/2 tasks · no live runs" })
     // The base hasn't moved, so the sync is a detected skip, not a merge.
     expect(events[1]).toMatchObject({ type: "step-skipped", step: "sync" })
     const steps = events.map((event) =>

--- a/test/feature-lifecycle-archive-verify.test.ts
+++ b/test/feature-lifecycle-archive-verify.test.ts
@@ -1,0 +1,221 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  capabilityFromDeltaPath,
+  composeContractEffects,
+  effectsForDeltas,
+  parseCanonicalRequirements,
+  parseDeltaSpec,
+  verifyEffects,
+} from "../src/feature-lifecycle/archive-verify"
+
+/**
+ * Task 2.4: deterministic archive-effect verification — ADDED/MODIFIED/
+ * REMOVED/RENAMED parsing over full capability paths, canonical presence/
+ * absence proof by structural Markdown comparison, and overlapping-contract
+ * composed-effect ordering with retained per-contract evidence.
+ */
+
+const addedDelta = `## ADDED Requirements
+
+### Requirement: Worktree location resolution order
+
+Convoy SHALL resolve the directory.
+
+#### Scenario: Repo convention wins over config
+
+- **WHEN** documentation declares a convention
+- **THEN** Convoy uses it
+`
+
+const modifiedDelta = `## MODIFIED Requirements
+
+### Requirement: Built-in default location
+
+Updated prose.
+
+#### Scenario: No convention or config
+
+- **WHEN** nothing configured
+- **THEN** default used
+`
+
+const removedDelta = `## REMOVED Requirements
+
+### Requirement: Legacy finish lookup
+`
+
+const renamedDelta = `## RENAMED Requirements
+
+- FROM: \`### Requirement: Old name\`
+- TO: \`### Requirement: New name\`
+
+### Requirement: New name
+
+#### Scenario: Renamed scenario
+
+- **WHEN** renamed
+- **THEN** both sides verified
+`
+
+const canonicalBody = `# spec
+
+## Requirements
+
+### Requirement: Worktree location resolution order
+
+Convoy SHALL resolve the directory.
+
+#### Scenario: Repo convention wins over config
+
+- **WHEN** documentation declares a convention
+- **THEN** Convoy uses it
+
+### Requirement: Built-in default location
+
+Updated prose.
+
+#### Scenario: No convention or config
+
+- **WHEN** nothing configured
+- **THEN** default used
+
+### Requirement: Old name
+
+Legacy prose.
+`
+
+const renamedCanonicalBody = `# spec
+
+## Requirements
+
+### Requirement: New name
+
+#### Scenario: Renamed scenario
+
+- **WHEN** renamed
+- **THEN** both sides verified
+`
+
+const dirs: string[] = []
+
+/** Builds a real <dir>/openspec/specs/<capability>/spec.md tree for verification. */
+async function specTree(files: Record<string, string>): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "convoy-archive-verify-"))
+  dirs.push(dir)
+  for (const [relative, content] of Object.entries(files)) {
+    const path = join(dir, "openspec", "specs", relative)
+    await mkdir(path.replace(/\/spec\.md$/, ""), { recursive: true })
+    await writeFile(path, content)
+  }
+  return dir
+}
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("delta parsing (task 2.4)", () => {
+  test("parses operations with names and scenarios per section", () => {
+    const deltas = parseDeltaSpec(`${addedDelta}\n${removedDelta}`)
+    expect(deltas.map((delta) => delta.operation)).toEqual(["ADDED", "REMOVED"])
+    expect(deltas[0]!.name).toBe("Worktree location resolution order")
+    expect(deltas[0]!.scenarios).toEqual(["Repo convention wins over config"])
+    expect(deltas[1]!.name).toBe("Legacy finish lookup")
+  })
+
+  test("RENAMED entries carry their FROM source", () => {
+    const deltas = parseDeltaSpec(renamedDelta)
+    expect(deltas).toHaveLength(1)
+    expect(deltas[0]!.operation).toBe("RENAMED")
+    expect(deltas[0]!.renamedFrom).toBe("Old name")
+  })
+
+  test("multiple requirement blocks per section are all captured", () => {
+    const body = `## ADDED Requirements\n\n### Requirement: One\n\n#### Scenario: A\n\n### Requirement: Two\n\n#### Scenario: B\n`
+    const deltas = parseDeltaSpec(body)
+    expect(deltas.map((delta) => delta.name)).toEqual(["One", "Two"])
+  })
+
+  test("capability path extraction", () => {
+    expect(capabilityFromDeltaPath("control-board/spec.md")).toBe("control-board")
+    expect(capabilityFromDeltaPath("specs/cli/spec.md")).toBe("specs/cli")
+    expect(capabilityFromDeltaPath("proposal.md")).toBeUndefined()
+  })
+})
+
+describe("canonical effect verification (task 2.4)", () => {
+  test("ADDED/MODIFIED presence is proven when canonical carries name + scenarios", async () => {
+    const target = await specTree({ "control-board/spec.md": canonicalBody })
+    const effects = effectsForDeltas([
+      { capability: "control-board", operations: parseDeltaSpec(addedDelta) },
+      { capability: "control-board", operations: parseDeltaSpec(modifiedDelta) },
+    ])
+    const verification = await verifyEffects(target, effects)
+    expect(verification.unproven.map((entry) => entry.reason)).toEqual([])
+    expect(verification.proven).toHaveLength(2)
+  })
+
+  test("missing scenario names are unproven, not assumed", async () => {
+    const target = await specTree({ "control-board/spec.md": canonicalBody })
+    const effects = effectsForDeltas([
+      { capability: "control-board", operations: [{ operation: "ADDED", name: "Worktree location resolution order", scenarios: ["Repo convention wins over config", "New scenario"], body: "" }] },
+    ])
+    const verification = await verifyEffects(target, effects)
+    expect(verification.proven).toEqual([])
+    expect(verification.unproven[0]!.reason).toMatch(/missing scenario/)
+  })
+
+  test("REMOVED absence is proven when the requirement is gone or the file is missing", async () => {
+    const target = await specTree({ "control-board/spec.md": "# spec\n\n## Requirements\n\n### Requirement: Something else\n" })
+    const verification = await verifyEffects(target, effectsForDeltas([
+      { capability: "control-board", operations: parseDeltaSpec(removedDelta) },
+    ]))
+    expect(verification.unproven).toEqual([])
+
+    const absentFile = await verifyEffects(target, effectsForDeltas([
+      { capability: "never-written", operations: parseDeltaSpec(removedDelta) },
+    ]))
+    expect(absentFile.unproven).toEqual([])
+  })
+
+  test("REMOVED with the requirement still present is unproven", async () => {
+    const target = await specTree({ "control-board/spec.md": canonicalBody })
+    const verification = await verifyEffects(target, effectsForDeltas([
+      { capability: "control-board", operations: parseDeltaSpec(removedDelta.replace("Legacy finish lookup", "Worktree location resolution order")) },
+    ]))
+    expect(verification.unproven[0]!.reason).toMatch(/still contains/)
+  })
+
+  test("RENAMED proves source absence plus destination presence", async () => {
+    const target = await specTree({ "control-board/spec.md": renamedCanonicalBody })
+    const verification = await verifyEffects(target, effectsForDeltas([{ capability: "control-board", operations: parseDeltaSpec(renamedDelta) }]))
+    expect(verification.unproven).toEqual([])
+  })
+})
+
+describe("overlapping-contract composition (task 2.4/D7)", () => {
+  test("later contracts dominate per requirement key, with per-contract evidence retained", () => {
+    const first = new Map([["cap", { capability: "cap", operations: [{ operation: "MODIFIED" as const, name: "Shared requirement", scenarios: ["S1"], body: "" }] }]])
+    const second = new Map([["cap", { capability: "cap", operations: [{ operation: "REMOVED" as const, name: "Shared requirement", scenarios: [], body: "" }] }]])
+    const { composed, perContract } = composeContractEffects([
+      { changeId: "first", deltas: first },
+      { changeId: "second", deltas: second },
+    ])
+    expect(composed.some((effect) => effect.kind === "requirement-absent" && effect.name === "Shared requirement")).toBe(true)
+    expect(composed.some((effect) => effect.kind === "requirement-present" && effect.name === "Shared requirement")).toBe(false)
+    expect(perContract).toHaveLength(2)
+    expect(perContract[0]!.effects[0]!.kind).toBe("requirement-present")
+    expect(perContract[1]!.effects[0]!.kind).toBe("requirement-absent")
+  })
+
+  test("canonical requirement block parsing keeps names unique", () => {
+    const body = `### Requirement: A\n\nbody a\n\n### Requirement: B\n\nbody b\n`
+    const parsed = parseCanonicalRequirements(body)
+    expect([...parsed.keys()]).toEqual(["A", "B"])
+    expect(parsed.get("A")).toMatch(/body a/)
+  })
+})

--- a/test/feature-lifecycle-assessment.test.ts
+++ b/test/feature-lifecycle-assessment.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test"
+
+import { assessLifecycle, closeStartPrerequisites, type LifecycleObservations } from "../src/feature-lifecycle/assessment"
+import type { FeatureRecord } from "../src/feature-lifecycle/records"
+
+/**
+ * Task 2.1: the pure assessment — orthogonal facts, unknown/unreadable
+ * evidence modeled explicitly, summary precedence (recovery/unknown favored
+ * over claimed readiness), and "ready to close" derived from prerequisites,
+ * never from task counts alone.
+ */
+
+const feature: FeatureRecord = {
+  schemaVersion: 1,
+  featureId: "aaaaaaaa-0000-4000-8000-000000000001",
+  repositoryId: "bbbbbbbb-0000-4000-8000-000000000001",
+  displayName: "add-widget",
+  associationRevision: 1,
+  contracts: [{ changeId: "add-widget", kind: "active", sourcePath: "openspec/changes/add-widget", provenance: "adopt", selectedAtRevision: 1 }],
+  intendedBaseRef: "main",
+  context: { branch: "feat/add-widget", checkoutPath: "/wt" },
+  runIds: [],
+  closeAttemptIds: [],
+  history: [],
+  createdAt: 1,
+  updatedAt: 1,
+}
+
+function baseObservations(overrides: Partial<LifecycleObservations> = {}): LifecycleObservations {
+  return {
+    feature,
+    context: { verification: "verified", branch: "feat/add-widget", checkoutPath: "/wt" },
+    contracts: [{ changeId: "add-widget", state: "active", tasks: { done: 3, total: 11 } }],
+    execution: { kind: "known", liveRunIds: [], totalRuns: 0 },
+    integration: "pending",
+    publication: { kind: "known", published: false },
+    cleanup: { kind: "known", worktreePresent: false, branchPresent: false },
+    ...overrides,
+  }
+}
+
+describe("pure lifecycle assessment (task 2.1)", () => {
+  test("no feature → association needed with adopt/spin offered", () => {
+    const assessment = assessLifecycle(baseObservations({ feature: undefined }))
+    expect(assessment.summary).toBe("Association needed")
+    expect(assessment.closeStartPrerequisitesPass).toBe(false)
+    expect(assessment.actions.map((action) => action.id)).toContain("adopt")
+    const adopt = assessment.actions.find((action) => action.id === "adopt")!
+    expect(adopt.enabled).toBe(true)
+  })
+
+  test("complete tasks with a live run are 'In implementation', never ready to close", () => {
+    const assessment = assessLifecycle(
+      baseObservations({
+        contracts: [{ changeId: "add-widget", state: "active", tasks: { done: 11, total: 11 } }],
+        execution: { kind: "known", liveRunIds: ["run-1"], totalRuns: 2 },
+      }),
+    )
+    expect(assessment.summary).toBe("In implementation")
+    expect(assessment.closeStartPrerequisitesPass).toBe(false)
+    expect(assessment.liveRuns).toBe(1)
+    const close = assessment.actions.find((action) => action.id === "close")!
+    expect(close.enabled).toBe(false)
+    expect(close.blockers.join(" ")).toMatch(/live run/)
+  })
+
+  test("ready to close requires verified context, complete tasks, readable contracts, no live runs", () => {
+    const assessment = assessLifecycle(
+      baseObservations({ contracts: [{ changeId: "add-widget", state: "active", tasks: { done: 11, total: 11 } }] }),
+    )
+    expect(assessment.summary).toBe("Ready to close")
+    expect(assessment.closeStartPrerequisitesPass).toBe(true)
+    expect(assessment.actions.find((action) => action.id === "close")!.enabled).toBe(true)
+  })
+
+  test("unknown task evidence blocks readiness instead of counting as zero (D5)", () => {
+    const assessment = assessLifecycle(
+      baseObservations({ contracts: [{ changeId: "add-widget", state: "active", tasks: "unknown" }] }),
+    )
+    expect(assessment.summary).toBe("In implementation")
+    expect(assessment.closeStartPrerequisitesPass).toBe(false)
+    expect(assessment.blockers.join(" ")).toMatch(/task completion unknown/)
+  })
+
+  test("unreadable run state is unknown, never an empty live-run set (task 2.2)", () => {
+    const assessment = assessLifecycle(
+      baseObservations({
+        contracts: [{ changeId: "add-widget", state: "active", tasks: { done: 11, total: 11 } }],
+        execution: { kind: "unknown", reason: "run history unreadable" },
+      }),
+    )
+    expect(assessment.closeStartPrerequisitesPass).toBe(false)
+    expect(assessment.blockers.join(" ")).toMatch(/live-run state unknown/)
+  })
+
+  test("verified-archived contracts without integration read 'archive verified', with review still discoverable", () => {
+    const assessment = assessLifecycle(
+      baseObservations({
+        contracts: [{ changeId: "add-widget", state: "verified-archived", tasks: { done: 11, total: 11 } }],
+      }),
+    )
+    expect(assessment.summary).toBe("Implementation complete · archive verified")
+    expect(assessment.closeStartPrerequisitesPass).toBe(false)
+    expect(assessment.actions.find((action) => action.id === "close")!.applicable).toBe(true)
+  })
+
+  test("verified integration reports cleanup pending or completed, with push gated on upstream", () => {
+    const pending = assessLifecycle(
+      baseObservations({
+        integration: "verified",
+        contracts: [{ changeId: "add-widget", state: "verified-archived" }],
+        cleanup: { kind: "known", worktreePresent: true, branchPresent: true },
+        publication: { kind: "known", upstream: "origin/main", published: true },
+      }),
+    )
+    expect(pending.summary).toBe("Integrated locally · cleanup pending")
+    expect(pending.actions.find((action) => action.id === "push")!.enabled).toBe(true)
+
+    const noUpstream = assessLifecycle(
+      baseObservations({
+        integration: "verified",
+        contracts: [{ changeId: "add-widget", state: "verified-archived" }],
+        cleanup: { kind: "known", worktreePresent: true, branchPresent: true },
+        publication: { kind: "known", published: false },
+      }),
+    )
+    const push = noUpstream.actions.find((action) => action.id === "push")!
+    expect(push.enabled).toBe(false)
+    expect(push.blockers.join(" ")).toMatch(/upstream/)
+  })
+
+  test("probable integration stays probabilistic and offers archive-on-main (D5/D8)", () => {
+    const assessment = assessLifecycle(
+      baseObservations({ integration: "probable" }),
+    )
+    expect(assessment.summary).toBe("Probably merged")
+    expect(assessment.actions.find((action) => action.id === "archive-on-main")!.applicable).toBe(true)
+  })
+
+  test("missing contract sources are surfaced with their reasons", () => {
+    const assessment = assessLifecycle(
+      baseObservations({
+        contracts: [{ changeId: "add-widget", state: "missing", reason: "directory absent" }],
+      }),
+    )
+    expect(assessment.summary).toBe("Contract sources need review")
+    expect(assessment.blockers.join(" ")).toMatch(/directory absent/)
+  })
+
+  test("closeStartPrerequisites separates per-contract task deficits", () => {
+    const prerequisites = closeStartPrerequisites(
+      baseObservations({
+        contracts: [
+          { changeId: "one", state: "active", tasks: { done: 8, total: 11 } },
+          { changeId: "two", state: "active", tasks: { done: 2, total: 2 } },
+        ],
+      }),
+    )
+    expect(prerequisites.pass).toBe(false)
+    expect(prerequisites.blockers.join(" ")).toMatch(/contract one: 3 of 11 tasks incomplete/)
+    expect(prerequisites.blockers.join(" ")).not.toMatch(/contract two/)
+  })
+
+  test("stale integration evidence wins precedence over readiness (D8)", () => {
+    const assessment = assessLifecycle(baseObservations({ integration: "stale" }))
+    expect(assessment.summary).toBe("Integration evidence stale")
+    expect(assessment.closeStartPrerequisitesPass).toBe(false)
+  })
+
+  test("blocked close actions remain applicable/inspectable with remediation (D6)", () => {
+    const assessment = assessLifecycle(baseObservations({ contracts: [{ changeId: "add-widget", state: "active", tasks: { done: 3, total: 11 } }] }))
+    const close = assessment.actions.find((action) => action.id === "close")!
+    expect(close.applicable).toBe(true)
+    expect(close.enabled).toBe(false)
+    expect(close.remediation.length).toBeGreaterThan(0)
+  })
+})

--- a/test/feature-lifecycle-commands.test.ts
+++ b/test/feature-lifecycle-commands.test.ts
@@ -1,0 +1,295 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { execFile } from "../src/git"
+import { lifecycleCommonDir, readRepositoryRecord } from "../src/feature-lifecycle/store"
+import { listFeatureIds } from "../src/feature-lifecycle/records"
+import { featureAdopt, featureBind, featureNewWork, featureRevise, featureShow } from "../src/feature-lifecycle/commands"
+
+/**
+ * Tasks 3.1–3.6: the explicit identity operations. Adoption accepts an
+ * arbitrary Git-valid branch name and never renames it; bind validates the
+ * registered worktree and claims nothing twice; revise refuses while a run is
+ * live; new-work creates a fresh identity on a retained context.
+ */
+
+const dirs: string[] = []
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const result = await execFile("git", args, { cwd, allowFailure: true })
+  if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${result.stderr || result.stdout}`)
+}
+
+async function makeRepoWithWorktree(branch: string): Promise<{ main: string; wt: string }> {
+  const root = await mkdtemp(join(tmpdir(), "convoy-feature-cmd-"))
+  dirs.push(root)
+  const main = join(root, "main")
+  const wt = join(root, "wt")
+  await mkdir(main, { recursive: true })
+  await git(["init", "-q", "-b", "main"], main)
+  await writeFile(join(main, "README.md"), "# repo\n")
+  await git(["add", "."], main)
+  await git(["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init"], main)
+  await git(["worktree", "add", "-b", branch, wt], main)
+  return { main, wt }
+}
+
+async function proposeChange(checkout: string, id: string): Promise<void> {
+  const dir = join(checkout, "openspec", "changes", id)
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, "proposal.md"), `# ${id}\n`)
+  await writeFile(join(dir, "tasks.md"), "- [ ] one\n")
+}
+
+beforeAll(async () => {
+  const home = await mkdtemp(join(tmpdir(), "convoy-feature-cmd-home-"))
+  dirs.push(home)
+  process.env.CONVOY_HOME = home
+})
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("convoy feature operations (tasks 3.1–3.6)", () => {
+  test("adopt associates an arbitrary branch name without renaming it", async () => {
+    const { main, wt } = await makeRepoWithWorktree("team/alice/release-42")
+    await proposeChange(wt, "add-widget")
+    const { feature } = await featureAdopt({ cwd: main, branch: "team/alice/release-42", changeIds: ["add-widget"], base: "main" })
+    expect(feature.context?.branch).toBe("team/alice/release-42")
+    // The branch still exists under its own name.
+    expect(await execFile("git", ["rev-parse", "--verify", "team/alice/release-42"], { cwd: main, allowFailure: true }).then((r) => r.exitCode)).toBe(0)
+    // show is read-only and renders the feature.
+    const shown = await featureShow({ cwd: main, featureId: feature.featureId })
+    expect(shown.output.featureId).toBe(feature.featureId)
+    expect(shown.output.assessment?.summary).toBeTruthy()
+    // Store exists exactly once.
+    const commonDir = (await lifecycleCommonDir(main))!
+    expect((await readRepositoryRecord(commonDir)).status).toBe("found")
+  })
+
+  test("adopt validates the actual checked-out branch, worktree registration, and source", async () => {
+    const { main, wt } = await makeRepoWithWorktree("feature/one")
+    await proposeChange(wt, "add-widget")
+    // A branch nobody checked out is refused.
+    await expect(featureAdopt({ cwd: main, branch: "nowhere/checked-out", changeIds: ["add-widget"], base: "main" })).rejects.toThrow(/not checked out in any worktree/)
+    // A change that doesn't exist is refused.
+    await expect(featureAdopt({ cwd: main, branch: "feature/one", changeIds: ["missing-change"], base: "main" })).rejects.toThrow(/is not an active change/)
+    // A bogus base ref is refused.
+    await expect(featureAdopt({ cwd: main, branch: "feature/one", changeIds: ["add-widget"], base: "no/such/ref" })).rejects.toThrow(/does not resolve/)
+  })
+
+  test("bind rebinds a verified context and refuses a claimed one", async () => {
+    const { main, wt } = await makeRepoWithWorktree("feature/move-me")
+    await proposeChange(wt, "add-widget")
+    const { feature } = await featureAdopt({ cwd: main, branch: "feature/move-me", changeIds: ["add-widget"], base: "main" })
+
+    // A second worktree on a free branch is a valid rebind target.
+    const wt2 = join(wt, "..", "wt2")
+    await git(["worktree", "add", "-b", "feature/moved-here", wt2], main)
+    const rebound = await featureBind({ cwd: main, featureId: feature.featureId, branch: "feature/moved-here", worktree: wt2 })
+    expect(rebound.context?.branch).toBe("feature/moved-here")
+    expect(rebound.associationRevision).toBe(2)
+
+    // A third feature on a free branch; adopting it onto the change proposed
+    // in ITS worktree, then binding it onto the first feature's claimed
+    // branch is refused.
+    const wt3 = join(wt, "..", "wt3")
+    await git(["worktree", "add", "-b", "feature/other", wt3], main)
+    await proposeChange(wt3, "other-change")
+    const { feature: other } = await featureAdopt({ cwd: main, branch: "feature/other", changeIds: ["other-change"], base: "main" })
+    await expect(featureBind({ cwd: main, featureId: other.featureId, branch: "feature/moved-here", worktree: wt2 })).rejects.toThrow(/already claimed by feature/)
+  })
+
+  test("bind refuses when the branch is not checked out at the named worktree", async () => {
+    const { main, wt } = await makeRepoWithWorktree("feature/bind-check")
+    await proposeChange(wt, "add-widget")
+    const { feature } = await featureAdopt({ cwd: main, branch: "feature/bind-check", changeIds: ["add-widget"], base: "main" })
+    const wt2 = join(wt, "..", "wt2")
+    await git(["worktree", "add", "-b", "feature/elsewhere", wt2], main)
+    // The worktree named is not where the branch is checked out.
+    await expect(featureBind({ cwd: main, featureId: feature.featureId, branch: "feature/bind-check", worktree: wt2 })).rejects.toThrow(/checked out at/)
+  })
+
+  test("adopt refuses double-claiming a context (context uniqueness)", async () => {
+    const { main, wt } = await makeRepoWithWorktree("feature/claim")
+    await proposeChange(wt, "add-widget")
+    await featureAdopt({ cwd: main, branch: "feature/claim", changeIds: ["add-widget"], base: "main" })
+    // A second feature on the same branch is refused.
+    await expect(featureAdopt({ cwd: main, branch: "feature/claim", changeIds: ["add-widget"], base: "main" })).rejects.toThrow(/already claimed|refuses/)
+  })
+
+  test("revise records the complete reviewed set and refuses while a run is live", async () => {
+    const { main, wt } = await makeRepoWithWorktree("feature/revise")
+    await proposeChange(wt, "one")
+    await proposeChange(wt, "two")
+    const { feature } = await featureAdopt({ cwd: main, branch: "feature/revise", changeIds: ["one"], base: "main" })
+    const revised = await featureRevise({ cwd: main, featureId: feature.featureId, changeIds: ["one", "two"], base: "main" })
+    expect(revised.associationRevision).toBe(2)
+    expect(revised.contracts.map((contract) => contract.changeId)).toEqual(["one", "two"])
+
+    // A live run on the context refuses the revision: a fake run whose
+    // metadata names a reachable server and this worktree as its target.
+    const runHome = process.env.CONVOY_HOME!
+    const runsDir = join(runHome, ".convoy", "runs", "20260101-000000-live")
+    const server = Bun.serve({ port: 0, fetch: () => new Response("ok") })
+    const port = server.port
+    try {
+      await mkdir(join(runsDir), { recursive: true })
+      await writeFile(
+        join(runsDir, "metadata.json"),
+        JSON.stringify({
+          schemaVersion: 5,
+          runID: "20260101-000000-live",
+          targetDir: await realpath(wt),
+          createdAt: 1,
+          updatedAt: 1,
+          control: { state: "running" },
+          server: { url: `http://127.0.0.1:${port}`, pid: process.pid, startedAt: 1 },
+          phases: {},
+        }),
+      )
+      await expect(featureRevise({ cwd: main, featureId: revised.featureId, changeIds: ["one"], base: "main" })).rejects.toThrow(/run is live/)
+    } finally {
+      server.stop(true)
+    }
+  })
+
+  test("new-work creates a fresh identity on a retained completed context", async () => {
+    const { main, wt } = await makeRepoWithWorktree("feature/new-work")
+    await proposeChange(wt, "next-thing")
+    // No prior feature claims the branch: new-work creates one directly.
+    const created = await featureNewWork({ cwd: main, branch: "feature/new-work", worktree: wt, changeIds: ["next-thing"], base: "main" })
+    const commonDir = (await lifecycleCommonDir(main))!
+    const ids = await listFeatureIds(commonDir)
+    expect(ids).toContain(created.featureId)
+    expect(created.history.at(-1)?.kind).toBe("new-work")
+    // It does not inherit another feature's runs or receipt (fresh record).
+    expect(created.runIds).toEqual([])
+    expect(created.closeAttemptIds).toEqual([])
+  })
+
+  test("featureShow mutates nothing on an unassociated context (no store created)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "convoy-feature-cmd-show-"))
+    dirs.push(root)
+    await git(["init", "-q", "-b", "main"], root)
+    await writeFile(join(root, "README.md"), "x\n")
+    await git(["add", "."], root)
+    await git(["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init"], root)
+    const { output } = await featureShow({ cwd: root })
+    expect(output.resolution?.status).toBe("unassociated")
+    const commonDir = (await lifecycleCommonDir(root))!
+    expect((await readRepositoryRecord(commonDir)).status).toBe("missing")
+  })
+
+  test("legacy adoption imports a landed legacy journal once and refuses reassignment (task 8.2)", async () => {
+    const { main } = await makeRepoWithWorktree("feature/legacy")
+    const { ensureRepositoryRecord } = await import("../src/feature-lifecycle/store")
+    const { writeCloseJournal } = await import("../src/close-journal")
+    const commonDir = (await lifecycleCommonDir(main))!
+    const repoRecord = await ensureRepositoryRecord(commonDir)
+    if (repoRecord.status !== "found") throw new Error("no repo record")
+
+    // A landed legacy close journal with a landing reachable from main.
+    await writeFile(join(main, "landed.txt"), "content\n")
+    await git(["add", "."], main)
+    await git(["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "feat: land legacy"], main)
+    const landing = (await execFile("git", ["rev-parse", "HEAD"], { cwd: main, allowFailure: true })).stdout.trim()
+    const base = (await execFile("git", ["rev-parse", "main"], { cwd: main, allowFailure: true })).stdout.trim()
+    await writeCloseJournal(commonDir, {
+      schemaVersion: 1,
+      attemptID: "legacy-attempt-1",
+      branch: "feature/legacy",
+      changeID: "old-change",
+      baseRef: "main",
+      baseSha: base,
+      postArchiveTip: landing,
+      preparedTree: "e".repeat(40),
+      candidateSha: landing,
+      landingSha: landing,
+      phase: "landed",
+      recordedAt: 1,
+      updatedAt: 1,
+    })
+    const journalPath = join(commonDir, "convoy", "close", "feature_legacy__old-change.json")
+    const originalBytes = await readFile(journalPath, "utf8")
+
+    const { featureRecover } = await import("../src/feature-lifecycle/commands")
+    const { listReceiptIds, readReceipt } = await import("../src/feature-lifecycle/records")
+    const recovered = await featureRecover({ cwd: main, legacy: true, changeId: "old-change" })
+    expect(recovered.displayName).toBe("old-change")
+    expect(recovered.closeAttemptIds).toHaveLength(1)
+    const receipts = await listReceiptIds(commonDir, recovered.featureId)
+    expect(receipts).toHaveLength(1)
+    const receipt = await readReceipt(commonDir, recovered.featureId, receipts[0]!)
+    expect(receipt.status === "found" && receipt.value.landingSha).toBe(landing)
+    // The original legacy journal bytes are preserved untouched.
+    expect(await readFile(journalPath, "utf8")).toBe(originalBytes)
+
+    // A second adoption of the same evidence refuses (already claimed).
+    const { featureRecover: recoverAgain } = await import("../src/feature-lifecycle/commands")
+    await expect(recoverAgain({ cwd: main, legacy: true, changeId: "old-change" })).rejects.toThrow(/collides with registered feature/)
+  })
+
+  test("recover grants receipt-verified follow-ups for a completed feature without a worktree (task 3.5)", async () => {
+    const { main } = await makeRepoWithWorktree("feature/done")
+    const { ensureRepositoryRecord } = await import("../src/feature-lifecycle/store")
+    const { writeFeatureRecord, writeReceiptIfAbsent } = await import("../src/feature-lifecycle/records")
+    const commonDir = (await lifecycleCommonDir(main))!
+    const repoRecord = await ensureRepositoryRecord(commonDir)
+    if (repoRecord.status !== "found") throw new Error("no repo record")
+
+    // A completed feature: worktree gone, branch gone, receipt on disk with a
+    // landing that is reachable from main (an ordinary commit).
+    await writeFile(join(main, "landed.txt"), "content\n")
+    await git(["add", "."], main)
+    await git(["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "feat: land widget"], main)
+    const landing = (await execFile("git", ["rev-parse", "HEAD"], { cwd: main, allowFailure: true })).stdout.trim()
+    const base = (await execFile("git", ["rev-parse", "main"], { cwd: main, allowFailure: true })).stdout.trim()
+    const featureId = "cccccccc-0000-4000-8000-00000000abc2"
+    await writeFeatureRecord(commonDir, {
+      schemaVersion: 1,
+      featureId,
+      repositoryId: repoRecord.value.repositoryId,
+      displayName: "feature/done",
+      associationRevision: 3,
+      contracts: [{ changeId: "add-widget", kind: "archive", sourcePath: "openspec/archive/add-widget", provenance: "close", selectedAtRevision: 3 }],
+      intendedBaseRef: "main",
+      runIds: [],
+      closeAttemptIds: ["dddddddd-0000-4000-8000-00000000abc3"],
+      history: [],
+      createdAt: 1,
+      updatedAt: 1,
+    }, 0)
+    await writeReceiptIfAbsent(commonDir, {
+      schemaVersion: 1,
+      attemptId: "dddddddd-0000-4000-8000-00000000abc3",
+      featureId,
+      repositoryId: repoRecord.value.repositoryId,
+      associationRevision: 3,
+      branch: "feature/removed-branch",
+      baseRef: "main",
+      baseSha: base,
+      featureTip: "e".repeat(40),
+      preparedTree: "f".repeat(40),
+      candidateSha: landing,
+      landingSha: landing,
+      landingAt: 1,
+    })
+    const { featureRecover } = await import("../src/feature-lifecycle/commands")
+    const recovered = await featureRecover({ cwd: main, featureId })
+    expect(recovered.featureId).toBe(featureId)
+    expect(recovered.closeAttemptIds.length).toBe(1)
+    // show reports the verified receipt with reachability.
+    const { output } = await featureShow({ cwd: main, featureId })
+    expect(output.receipts?.[0]?.landingReachable).toBe(true)
+    // New execution authority is not granted: the record has no live context.
+    expect(recovered.context).toBeUndefined()
+    // With exactly one receipt-bearing feature, recover without --feature
+    // resolves it; ambiguity across several would refuse instead of guessing.
+    const unique = await featureRecover({ cwd: main })
+    expect(unique.featureId).toBe(featureId)
+  })
+})

--- a/test/feature-lifecycle-e2e.test.ts
+++ b/test/feature-lifecycle-e2e.test.ts
@@ -1,0 +1,136 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { execFile as nodeExecFile } from "node:child_process"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+import { resolveFeature } from "../src/feature-lifecycle/resolver"
+import { featureAdopt, featureBind, featureNewWork } from "../src/feature-lifecycle/commands"
+import { loadLifecycleFeatureRows } from "../src/specs"
+import { runClose } from "../src/feature-close"
+import { execFile } from "../src/git"
+import { templateCommitMessage, type CommitMessageProposal } from "../src/commit-message"
+
+/**
+ * Task 9.3: end-to-end ownership regression — a completed feature stays
+ * discoverable after cleanup, and a renamed/unassociated feature is never
+ * silently closed or claimed by the work that reused its name.
+ */
+
+const exec = promisify(nodeExecFile)
+const dirs: string[] = []
+const originalConvoyHome = process.env.CONVOY_HOME
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  const { stdout } = await exec("git", args, { cwd })
+  void stdout
+}
+
+async function makeRepo(): Promise<{ main: string; wt: string }> {
+  const root = await mkdtemp(join(tmpdir(), "convoy-e2e-own-"))
+  dirs.push(root)
+  const main = join(root, "main")
+  const wt = join(root, "wt")
+  await mkdir(main, { recursive: true })
+  await git(main, "init", "-b", "main")
+  await writeFile(join(main, "README.md"), "# repo\n")
+  await git(main, "add", ".")
+  await git(main, "-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init")
+  await git(main, "worktree", "add", "-b", "feat/one", wt)
+  const changeDir = join(wt, "openspec", "changes", "one")
+  await mkdir(changeDir, { recursive: true })
+  await writeFile(join(changeDir, "proposal.md"), "# One\n")
+  await writeFile(join(changeDir, "tasks.md"), "- [x] a\n- [x] b\n")
+  await writeFile(join(wt, "src.ts"), "export const one = 1\n")
+  await git(wt, "add", ".")
+  await git(wt, "-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "feat(openspec): propose one")
+  return { main, wt }
+}
+
+const closeInput = (fixture: { mainDir: string; worktreeDir: string }) => ({
+  targetDir: fixture.mainDir,
+  worktreeDir: fixture.worktreeDir,
+  branch: "feat/one",
+  changeID: "one",
+})
+
+const writerFails: Parameters<typeof runClose>[0]["writer"] = async () =>
+  ({ message: templateCommitMessage({ targetDir: "", branch: "", commits: [] }), source: "template", error: "test double" }) satisfies CommitMessageProposal
+
+beforeAll(async () => {
+  const home = await mkdtemp(join(tmpdir(), "convoy-e2e-own-home-"))
+  dirs.push(home)
+  process.env.CONVOY_HOME = home
+})
+
+afterAll(async () => {
+  if (originalConvoyHome === undefined) delete process.env.CONVOY_HOME
+  else process.env.CONVOY_HOME = originalConvoyHome
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("ownership end-to-end (task 9.3)", () => {
+  test("a completed feature stays discoverable after cleanup; new work on the reused name is a different identity", async () => {
+    const { main, wt } = await makeRepo()
+    // Adopt, close, and clean up.
+    const { feature } = await featureAdopt({ cwd: main, branch: "feat/one", changeIds: ["one"], base: "main" })
+    const result = await runClose({ ...closeInput({ mainDir: main, worktreeDir: wt }), writer: writerFails })
+    expect(result.disposition).toBe("landed")
+    // Cleanup: worktree removal, then the guarded branch deletion.
+    await git(main, "worktree", "remove", wt)
+    const tip = (await execFile("git", ["rev-parse", "refs/heads/feat/one"], { cwd: main, allowFailure: true })).stdout.trim()
+    await git(main, "update-ref", "-d", "refs/heads/feat/one", tip)
+    // The feature record stays discoverable with its evidence.
+    const { isFound, lifecycleCommonDir } = await import("../src/feature-lifecycle/store")
+    const { readFeatureRecord, listReceiptIds, readReceipt } = await import("../src/feature-lifecycle/records")
+    const commonDir = (await lifecycleCommonDir(main))!
+    const record = await readFeatureRecord(commonDir, feature.featureId)
+    expect(isFound(record)).toBe(true)
+    const receiptIds = await listReceiptIds(commonDir, feature.featureId)
+    expect(receiptIds.length).toBe(1)
+    const receipt = await readReceipt(commonDir, feature.featureId, receiptIds[0]!)
+    expect(isFound(receipt) && receipt.value.landingSha).toBe(result.landing!.sha)
+    // The branch is gone (guard executed with the exact tip).
+    expect((await execFile("git", ["rev-parse", "--verify", "refs/heads/feat/one"], { cwd: main, allowFailure: true })).exitCode).not.toBe(0)
+
+    // New work reusing the branch name is a NEW identity through the explicit
+    // new-work decision: never the old feature's record, runs, or receipts.
+    const wt2 = join(root2(wt), "wt2")
+    await git(main, "worktree", "add", "-b", "feat/one", wt2)
+    const newChange = join(wt2, "openspec", "changes", "one")
+    await mkdir(newChange, { recursive: true })
+    await writeFile(join(newChange, "proposal.md"), "# One (again)\n")
+    await writeFile(join(newChange, "tasks.md"), "- [ ] a\n")
+    const second = await featureNewWork({ cwd: main, branch: "feat/one", worktree: wt2, changeIds: ["one"], base: "main" })
+    expect(second.featureId).not.toBe(feature.featureId)
+    expect(second.runIds).toEqual([])
+    expect(second.closeAttemptIds).toEqual([])
+    // Plain adoption of the reused name is still refused (new-work is the
+    // decision; the live new feature holds the claim).
+    await expect(featureAdopt({ cwd: main, branch: "feat/one", changeIds: ["one"], base: "main" })).rejects.toThrow(/already claimed/)
+  })
+
+  test("a renamed/unassociated context is not silently closed or claimed", async () => {
+    const { main, wt } = await makeRepo()
+    const { feature } = await featureAdopt({ cwd: main, branch: "feat/one", changeIds: ["one"], base: "main" })
+    // External rename.
+    await git(wt, "branch", "-m", "feat/one", "feat/renamed")
+    // The old spelling no longer resolves; the close through the old branch
+    // name must refuse rather than guess, and the feature stays visible.
+    await expect(runClose({ targetDir: main, branch: "feat/one", changeID: "one", writer: writerFails })).rejects.toThrow()
+    const rows = await loadLifecycleFeatureRows(main)
+    expect(rows!.some((row) => row.featureId === feature.featureId)).toBe(true)
+    // Explicit rebinding of the verified renamed context resolves everything.
+    const bound = await featureBind({ cwd: main, featureId: feature.featureId, branch: "feat/renamed", worktree: wt })
+    expect(bound.context?.branch).toBe("feat/renamed")
+    const resolution = await resolveFeature({ cwd: main, featureId: feature.featureId })
+    expect(resolution.status).toBe("verified")
+    // Another feature cannot silently claim the renamed branch.
+    await expect(featureAdopt({ cwd: main, branch: "feat/renamed", changeIds: ["one"], base: "main" })).rejects.toThrow(/already claimed/)
+  })
+})
+
+function root2(path: string): string {
+  return join(path, "..")
+}

--- a/test/feature-lifecycle-e2e.test.ts
+++ b/test/feature-lifecycle-e2e.test.ts
@@ -34,6 +34,12 @@ async function makeRepo(): Promise<{ main: string; wt: string }> {
   const wt = join(root, "wt")
   await mkdir(main, { recursive: true })
   await git(main, "init", "-b", "main")
+  // The close pipeline commits the archive result with the operator's ambient
+  // git identity (`commitAsUser` runs plain `git commit`). A runner image has
+  // no identity at all — configure one locally so the fixture does not depend
+  // on the machine's global git config.
+  await git(main, "config", "user.email", "t@x")
+  await git(main, "config", "user.name", "T")
   await writeFile(join(main, "README.md"), "# repo\n")
   await git(main, "add", ".")
   await git(main, "-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init")

--- a/test/feature-lifecycle-launch.test.ts
+++ b/test/feature-lifecycle-launch.test.ts
@@ -1,0 +1,185 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { execFile, currentBranch, findWorktreeDirForBranch } from "../src/git"
+import { ensureRepositoryRecord, isFound, lifecycleCommonDir } from "../src/feature-lifecycle/store"
+import { writeFeatureRecord, type FeatureRecord } from "../src/feature-lifecycle/records"
+import { revalidateFeatureLink, resolveFeatureForLaunch } from "../src/feature-lifecycle/launch"
+import type { FeaturePlanLink } from "../src/types"
+
+/**
+ * Tasks 4.3/4.4: feature-aware launches resolve the reviewed link through the
+ * shared resolver (from any checkout), and execution revalidates it — a
+ * branch switch or association change after review refuses and attaches
+ * nothing to the replacement context.
+ */
+
+const dirs: string[] = []
+let repoDir: string
+let worktreeDir: string
+let commonDir: string
+let featureId: string
+let repositoryId: string
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const result = await execFile("git", args, { cwd, allowFailure: true })
+  if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`)
+}
+
+function record(overrides: Partial<FeatureRecord> = {}): FeatureRecord {
+  return {
+    schemaVersion: 1,
+    featureId,
+    repositoryId,
+    displayName: "add-widget",
+    associationRevision: 1,
+    contracts: [{ changeId: "add-widget", kind: "active", sourcePath: "openspec/changes/add-widget", provenance: "adopt", selectedAtRevision: 1 }],
+    intendedBaseRef: "main",
+    runIds: [],
+    closeAttemptIds: [],
+    history: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+beforeAll(async () => {
+  repoDir = await mkdtemp(join(tmpdir(), "convoy-lifecycle-launch-"))
+  dirs.push(repoDir)
+  await Bun.write(join(repoDir, "README.md"), "# repo\n")
+  await git(["init", "-q", "-b", "main"], repoDir)
+  await git(["add", "."], repoDir)
+  await git(["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init"], repoDir)
+  worktreeDir = join(await mkdtemp(join(tmpdir(), "convoy-lifecycle-launch-wt-")), "wt")
+  dirs.push(worktreeDir)
+  const added = await execFile("git", ["worktree", "add", "-b", "feat/add-widget", worktreeDir], { cwd: repoDir, allowFailure: true })
+  if (added.exitCode !== 0) throw new Error(`worktree add failed: ${added.stderr}`)
+  commonDir = (await lifecycleCommonDir(repoDir))!
+  const repoRecord = await ensureRepositoryRecord(commonDir)
+  if (!isFound(repoRecord)) throw new Error("no repository record")
+  repositoryId = repoRecord.value.repositoryId
+  featureId = "aaaaaaaa-0000-4000-8000-00000000abc1"
+  await writeFeatureRecord(commonDir, record({ context: { branch: "feat/add-widget" } }), 0)
+})
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("resolveFeatureForLaunch (task 4.3)", () => {
+  test("a verified association resolves from any checkout of the repository", async () => {
+    // From the main checkout…
+    const fromMain = await resolveFeatureForLaunch({ cwd: repoDir, featureId })
+    expect(fromMain).toBeDefined()
+    expect(fromMain!.branch).toBe("feat/add-widget")
+    expect(fromMain!.baseRef).toBe("main")
+    // …and from the worktree itself (cross-checkout Apply/Continue).
+    const fromWorktree = await resolveFeatureForLaunch({ cwd: worktreeDir, featureId })
+    expect(fromWorktree).toBeDefined()
+    expect(fromWorktree!.featureId).toBe(fromMain!.featureId)
+    expect(fromWorktree!.worktreeDir).toBeTruthy()
+  })
+
+  test("a run without --feature and an unassociated context resolves no link (no-spec flow intact)", async () => {
+    const resolved = await resolveFeatureForLaunch({ cwd: repoDir })
+    expect(resolved).toBeUndefined()
+  })
+
+  test("an explicit --feature that is not verified refuses with remediation guidance", async () => {
+    await expect(resolveFeatureForLaunch({ cwd: repoDir, featureId: "99999999-9999-4999-8999-999999999999" })).rejects.toThrow(/convoy feature (adopt|show)/)
+    await expect(resolveFeatureForLaunch({ cwd: repoDir, featureId: "garbage" })).rejects.toThrow(/not a feature id/)
+  })
+
+  test("a mistyped change selector refuses instead of resolving to other work", async () => {
+    await expect(resolveFeatureForLaunch({ cwd: repoDir, featureId, changeId: "other-change" })).rejects.toThrow(/not one of feature/)
+  })
+})
+
+describe("revalidateFeatureLink (task 4.4)", () => {
+  test("an unchanged verified target revalidates", async () => {
+    const link = await resolveFeatureForLaunch({ cwd: repoDir, featureId })
+    expect(link).toBeDefined()
+    await revalidateFeatureLink({ cwd: repoDir, link: link! })
+  })
+
+  test("the reviewed feature link persists in run metadata before execution (task 4.2)", async () => {
+    const link = await resolveFeatureForLaunch({ cwd: repoDir, featureId })
+    expect(link).toBeDefined()
+    const { mkdtempSync } = await import("node:fs")
+    const workspaceDir = mkdtempSync(join(tmpdir(), "convoy-lifecycle-meta-"))
+    dirs.push(workspaceDir)
+    const { openRunMetadata } = await import("../src/metadata")
+    const store = await openRunMetadata(
+      { dir: workspaceDir, runID: "20260101-000000-feat" } as never,
+      repoDir,
+      { name: "full-cycle", steps: [] } as never,
+      { feature: link },
+    )
+    await store.flush()
+    const persisted = JSON.parse(await import("node:fs/promises").then((fs) => fs.readFile(join(workspaceDir, "metadata.json"), "utf8")))
+    expect(persisted.feature.featureId).toBe(link!.featureId)
+    expect(persisted.feature.associationRevision).toBe(link!.associationRevision)
+    expect(persisted.feature.branch).toBe("feat/add-widget")
+    // A resume never replaces the recorded link.
+    const store2 = await openRunMetadata(
+      { dir: workspaceDir, runID: "20260101-000000-feat" } as never,
+      repoDir,
+      { name: "full-cycle", steps: [] } as never,
+      { feature: { ...link!, associationRevision: link!.associationRevision + 5 } },
+    )
+    void store2
+    await store2.flush()
+    expect(JSON.parse(await import("node:fs/promises").then((fs) => fs.readFile(join(workspaceDir, "metadata.json"), "utf8"))).feature.associationRevision).toBe(link!.associationRevision)
+    void store
+  })
+
+  test("a branch switch after review refuses and attaches nothing to the new branch", async () => {
+    const link = await resolveFeatureForLaunch({ cwd: repoDir, featureId })
+    expect(link).toBeDefined()
+    // Switch the worktree's branch out from under the association.
+    await git(["checkout", "-q", "-b", "other-branch"], worktreeDir)
+    try {
+      await expect(revalidateFeatureLink({ cwd: repoDir, link: link! })).rejects.toThrow(/refuses to start/)
+    } finally {
+      await git(["checkout", "-q", "feat/add-widget"], worktreeDir)
+    }
+  })
+
+  test("a stale association revision refuses the reviewed contract set", async () => {
+    const link = await resolveFeatureForLaunch({ cwd: repoDir, featureId })
+    expect(link).toBeDefined()
+    const stale: FeaturePlanLink = { ...link!, associationRevision: link!.associationRevision - 1 }
+    await expect(revalidateFeatureLink({ cwd: repoDir, link: stale })).rejects.toThrow(/association advanced/)
+  })
+
+  test("a changed intended base refuses", async () => {
+    const link = await resolveFeatureForLaunch({ cwd: repoDir, featureId })
+    expect(link).toBeDefined()
+    const stale: FeaturePlanLink = { ...link!, baseRef: "some/other-base" }
+    await expect(revalidateFeatureLink({ cwd: repoDir, link: stale })).rejects.toThrow(/intended base changed/)
+  })
+
+  test("a removed worktree refuses as a missing context", async () => {
+    const link = await resolveFeatureForLaunch({ cwd: repoDir, featureId })
+    expect(link).toBeDefined()
+    const removed = await findWorktreeDirForBranch("feat/add-widget", repoDir)
+    expect(removed?.endsWith("/wt")).toBe(true)
+    await git(["checkout", "-q", "--detach"], worktreeDir)
+    const result = await execFile("git", ["worktree", "remove", worktreeDir], { cwd: repoDir, allowFailure: true })
+    if (result.exitCode !== 0) {
+      await git(["checkout", "-q", "feat/add-widget"], worktreeDir)
+      throw new Error(`worktree remove failed: ${result.stderr}`)
+    }
+    try {
+      await expect(revalidateFeatureLink({ cwd: repoDir, link: link! })).rejects.toThrow(/context changed since review/)
+    } finally {
+      // Recreate the worktree for the remaining expectations.
+      const reAdd = await execFile("git", ["worktree", "add", worktreeDir, "feat/add-widget"], { cwd: repoDir, allowFailure: true })
+      if (reAdd.exitCode !== 0) throw new Error(`re-add failed: ${reAdd.stderr}`)
+    }
+    expect(await currentBranch(worktreeDir)).toBe("feat/add-widget")
+  })
+})

--- a/test/feature-lifecycle-refs.test.ts
+++ b/test/feature-lifecycle-refs.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { execFile, resolveCommit } from "../src/git"
+import {
+  featureCandidateRef,
+  featureTipRef,
+  isLandingReachableFrom,
+  protectFeatureRef,
+  readProtectedRef,
+  zeroRefOldValue,
+} from "../src/feature-lifecycle/refs"
+
+/**
+ * Task 1.4: protected feature/attempt refs are create-only, a pre-existing
+ * mismatched ref is refused (never overwritten), and idempotent replays of
+ * the same evidence succeed.
+ */
+
+const dirs: string[] = []
+let repoDir: string
+const featureId = "5f0a3c1e-8b2d-4c6a-9e0f-1a2b3c4d5e6f"
+const attemptId = "9a8b7c6d-5e4f-4a3b-2c1d-0e9f8a7b6c5d"
+
+beforeAll(async () => {
+  repoDir = await mkdtemp(join(tmpdir(), "convoy-lifecycle-refs-"))
+  dirs.push(repoDir)
+  await Bun.write(join(repoDir, "README.md"), "# repo\n")
+  const init = Bun.spawn(["git", "init", "-q", "-b", "main", repoDir], { stderr: "pipe" })
+  const initErr = await new Response(init.stderr).text()
+  if ((await init.exited) !== 0) throw new Error(`git init failed: ${initErr}`)
+  for (const args of [["add", "."], ["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init"]]) {
+    const proc = Bun.spawn(["git", ...args], { cwd: repoDir, stdout: "ignore", stderr: "pipe" })
+    const err = await new Response(proc.stderr).text()
+    if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")} failed: ${err}`)
+  }
+})
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function commitFile(message: string): Promise<string> {
+  const name = `file-${Math.random().toString(36).slice(2)}.txt`
+  await Bun.write(join(repoDir, name), message)
+  await execFile("git", ["add", "."], { cwd: repoDir })
+  await execFile("git", ["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", message], { cwd: repoDir })
+  return (await resolveCommit("HEAD", repoDir))!
+}
+
+describe("protected feature refs (task 1.4)", () => {
+  test("ref layout uses the opaque feature/attempt UUIDs", () => {
+    expect(featureTipRef(featureId, attemptId)).toBe(`refs/convoy/features/${featureId}/${attemptId}/feature-tip`)
+    expect(featureCandidateRef(featureId, attemptId)).toBe(`refs/convoy/features/${featureId}/${attemptId}/candidate`)
+  })
+
+  test("create-only: the first protect lands, the same evidence replays, a mismatch refuses", async () => {
+    const tip1 = await commitFile("evidence-1")
+    await protectFeatureRef(featureTipRef(featureId, attemptId), tip1, repoDir)
+    expect(await readProtectedRef(featureTipRef(featureId, attemptId), repoDir)).toBe(tip1)
+
+    // Idempotent replay of the same evidence is a no-op success.
+    await protectFeatureRef(featureTipRef(featureId, attemptId), tip1, repoDir)
+
+    // Different evidence at the same ref: refused, original value preserved.
+    const tip2 = await commitFile("evidence-2")
+    await expect(protectFeatureRef(featureTipRef(featureId, attemptId), tip2, repoDir)).rejects.toThrow(/refusing to overwrite/)
+    expect(await readProtectedRef(featureTipRef(featureId, attemptId), repoDir)).toBe(tip1)
+
+    // The candidate namespace is independent.
+    await protectFeatureRef(featureCandidateRef(featureId, attemptId), tip2, repoDir)
+    expect(await readProtectedRef(featureCandidateRef(featureId, attemptId), repoDir)).toBe(tip2)
+  })
+
+  test("the create-only write goes through an all-zero expected old value", () => {
+    expect(zeroRefOldValue).toBe("0000000000000000000000000000000000000000")
+  })
+
+  test("landing reachability: ancestor true, unrelated/missing false", async () => {
+    const landing = await commitFile("landing")
+    expect(await isLandingReachableFrom(landing, "main", repoDir)).toBe(true)
+    expect(await isLandingReachableFrom("f".repeat(40), "main", repoDir)).toBe(false)
+    // An orphan branch is not reachable from main.
+    const orphan = Bun.spawn(["git", "checkout", "--orphan", "orphan-branch"], { cwd: repoDir, stdout: "ignore" })
+    await orphan.exited
+    await Bun.write(join(repoDir, "orphan.txt"), "orphan")
+    await execFile("git", ["add", "."], { cwd: repoDir })
+    await execFile("git", ["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "orphan root"], { cwd: repoDir })
+    const orphanTip = (await resolveCommit("HEAD", repoDir))!
+    expect(await isLandingReachableFrom(orphanTip, "main", repoDir)).toBe(false)
+    await Bun.spawn(["git", "checkout", "-q", "main"], { cwd: repoDir }).exited
+  })
+})

--- a/test/feature-lifecycle-resolver.test.ts
+++ b/test/feature-lifecycle-resolver.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { execFile } from "../src/git"
+import { ensureRepositoryRecord, isFound, lifecycleCommonDir, lifecycleRoot } from "../src/feature-lifecycle/store"
+import { writeFeatureRecord, type FeatureRecord } from "../src/feature-lifecycle/records"
+import { planningPathWithin, resolveFeature } from "../src/feature-lifecycle/resolver"
+
+/**
+ * Task 2.3: the one shared resolver — explicit ID → verified context →
+ * unique explicit filters → unresolved candidates — with invalid selectors
+ * refusing instead of falling through to a heuristic.
+ */
+
+const dirs: string[] = []
+let repoDir: string
+let worktreeDir: string
+let commonDir: string
+
+const featureAId = "aaaaaaaa-0000-4000-8000-000000000001"
+const featureBId = "aaaaaaaa-0000-4000-8000-000000000002"
+
+async function git(args: string[], cwd: string): Promise<void> {
+  const result = await execFile("git", args, { cwd, allowFailure: true })
+  if (result.exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${result.stderr || result.stdout}`)
+}
+
+function feature(id: string, overrides: Partial<FeatureRecord> = {}): FeatureRecord {
+  return {
+    schemaVersion: 1,
+    featureId: id,
+    repositoryId: "",
+    displayName: `feature-${id.slice(0, 4)}`,
+    associationRevision: 1,
+    contracts: [{ changeId: "add-widget", kind: "active", sourcePath: "openspec/changes/add-widget", provenance: "adopt", selectedAtRevision: 1 }],
+    intendedBaseRef: "main",
+    runIds: [],
+    closeAttemptIds: [],
+    history: [],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+beforeAll(async () => {
+  repoDir = await mkdtemp(join(tmpdir(), "convoy-lifecycle-resolver-"))
+  dirs.push(repoDir)
+  await Bun.write(join(repoDir, "README.md"), "# repo\n")
+  await git(["init", "-q", "-b", "main"], repoDir)
+  await git(["add", "."], repoDir)
+  await git(["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init"], repoDir)
+  worktreeDir = join(await mkdtemp(join(tmpdir(), "convoy-lifecycle-resolver-wt-")), "wt")
+  dirs.push(worktreeDir)
+  // The feature branch is born in the worktree (the main checkout stays on main).
+  const added = await execFile("git", ["worktree", "add", "-b", "feat/add-widget", worktreeDir], { cwd: repoDir, allowFailure: true })
+  if (added.exitCode !== 0) throw new Error(`git worktree add failed: ${added.stderr || added.stdout}`)
+  commonDir = (await lifecycleCommonDir(repoDir))!
+  const repoRecord = await ensureRepositoryRecord(commonDir)
+  if (!isFound(repoRecord)) throw new Error("repository record missing")
+
+  // Feature A: associated with the worktree branch, no recorded path (pathless
+  // context verifies from the worktree inventory alone).
+  const a = feature(featureAId, {
+    repositoryId: repoRecord.value.repositoryId,
+    context: { branch: "feat/add-widget" },
+  })
+  // Feature B: associated with a different change on a branch that is nowhere
+  // checked out — never verified, only selectable by filters.
+  const b = feature(featureBId, {
+    repositoryId: repoRecord.value.repositoryId,
+    displayName: "elsewhere",
+    contracts: [{ changeId: "change-elsewhere", kind: "active", sourcePath: "openspec/changes/change-elsewhere", provenance: "adopt", selectedAtRevision: 1 }],
+    context: { branch: "team/alice/elsewhere" },
+  })
+  await writeFeatureRecord(commonDir, a, 0)
+  await writeFeatureRecord(commonDir, b, 0)
+})
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("shared resolver (task 2.3)", () => {
+  test("explicit feature ID verifies and agrees with matching selectors", async () => {
+    const resolved = await resolveFeature({ cwd: repoDir, commonDir, featureId: featureAId, changeId: "add-widget" })
+    expect(resolved.status).toBe("verified")
+    if (resolved.status !== "verified") return
+    expect(resolved.feature.featureId).toBe(featureAId)
+    expect(resolved.context.branch).toBe("feat/add-widget")
+    expect(resolved.context.checkoutPath).toBeTruthy()
+  })
+
+  test("a mistyped change selector never falls through to a heuristic", async () => {
+    const resolved = await resolveFeature({ cwd: repoDir, commonDir, featureId: featureAId, changeId: "other-change" })
+    expect(resolved.status).toBe("ambiguous")
+    if (resolved.status === "ambiguous") expect(resolved.reason).toMatch(/not one of feature/)
+  })
+
+  test("a contradictory branch selector is ambiguous, not silently re-resolved", async () => {
+    const resolved = await resolveFeature({ cwd: repoDir, commonDir, featureId: featureAId, branch: "some/other" })
+    expect(resolved.status).toBe("ambiguous")
+  })
+
+  test("an unknown or malformed explicit ID is missing — never heuristic fallback", async () => {
+    expect((await resolveFeature({ cwd: repoDir, commonDir, featureId: "99999999-9999-4999-8999-999999999999" })).status).toBe("missing")
+    expect((await resolveFeature({ cwd: repoDir, commonDir, featureId: "not-a-uuid" })).status).toBe("missing")
+  })
+
+  test("verified context association resolves from the current checkout", async () => {
+    const resolved = await resolveFeature({ cwd: worktreeDir, commonDir })
+    expect(resolved.status).toBe("verified")
+    if (resolved.status !== "verified") return
+    expect(resolved.feature.featureId).toBe(featureAId)
+  })
+
+  test("a change filter selects the unique feature that carries it", async () => {
+    const resolved = await resolveFeature({ cwd: repoDir, commonDir, changeId: "add-widget" })
+    expect(resolved.status).toBe("verified")
+  })
+
+  test("a missing context (branch nowhere checked out) is reported as missing, not dropped", async () => {
+    const resolved = await resolveFeature({ cwd: repoDir, commonDir, featureId: featureBId })
+    expect(resolved.status).toBe("missing")
+    if (resolved.status === "missing") expect(resolved.reason).toMatch(/not checked out/)
+  })
+
+  test("an uninitialized store resolves to unassociated without creating anything", async () => {
+    const fresh = await mkdtemp(join(tmpdir(), "convoy-lifecycle-resolver-fresh-"))
+    dirs.push(fresh)
+    const proc = Bun.spawn(["git", "init", "-q", "-b", "main", fresh])
+    await proc.exited
+    const freshCommon = (await lifecycleCommonDir(fresh))!
+    const { stat } = await import("node:fs/promises")
+    const resolved = await resolveFeature({ cwd: fresh, commonDir: freshCommon })
+    expect(resolved.status).toBe("unassociated")
+    // Browsing created no registry.
+    let created = false
+    try {
+      await stat(join(freshCommon, "convoy", "repository.json"))
+    } catch {
+      created = false
+    }
+    expect(created).toBe(false)
+  })
+})
+
+describe("planning path validation (task 2.3/D3)", () => {
+  test("paths must stay inside the planning root", () => {
+    expect(planningPathWithin("/repo", "openspec/changes/x")).toBe("openspec/changes/x")
+    expect(planningPathWithin("/repo", "./openspec/changes/x")).toBe("openspec/changes/x")
+    expect(planningPathWithin("/repo", "../outside")).toBeUndefined()
+    expect(planningPathWithin("/repo", "/absolute")).toBeUndefined()
+    expect(planningPathWithin("/repo", "")).toBeUndefined()
+  })
+})

--- a/test/feature-lifecycle-store.test.ts
+++ b/test/feature-lifecycle-store.test.ts
@@ -1,0 +1,261 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  ensureRepositoryRecord,
+  isFound,
+  lifecycleCommonDir,
+  lifecycleRoot,
+  readRepositoryRecord,
+  withFeatureLock,
+  writeJsonFile,
+  type RepositoryRecord,
+} from "../src/feature-lifecycle/store"
+import {
+  listFeatureIds,
+  listReceiptIds,
+  readAttemptJournal,
+  readFeatureRecord,
+  readReceipt,
+  validateFeatureRecord,
+  validateReceipt,
+  writeFeatureRecord,
+  writeReceiptIfAbsent,
+  type FeatureRecord,
+  type LandingReceipt,
+} from "../src/feature-lifecycle/records"
+
+/**
+ * Task 1.1/1.2/1.3: the versioned store's typed reads, atomic feature
+ * records with conflict detection, and immutable attempt journals/receipts.
+ * Every reader must distinguish missing/corrupt/unsupported/unreadable, and
+ * a lost-update write must be refused rather than overwrite concurrent work.
+ */
+
+const dirs: string[] = []
+let repoDir: string
+let commonDir: string
+
+beforeAll(async () => {
+  repoDir = await mkdtemp(join(tmpdir(), "convoy-lifecycle-store-"))
+  dirs.push(repoDir)
+  const init = Bun.spawn(["git", "init", "-q", "-b", "main", repoDir])
+  await init.exited
+  await Bun.write(join(repoDir, "README.md"), "# repo\n")
+  for (const args of [["add", "."], ["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init"]]) {
+    const proc = Bun.spawn(["git", ...args], { cwd: repoDir, stdout: "ignore" })
+    await proc.exited
+  }
+  commonDir = (await lifecycleCommonDir(repoDir))!
+})
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+function sampleFeature(overrides: Partial<FeatureRecord> = {}): FeatureRecord {
+  return {
+    schemaVersion: 1,
+    featureId: "5f0a3c1e-8b2d-4c6a-9e0f-1a2b3c4d5e6f",
+    repositoryId: "7c2b1a0d-3e4f-4a5b-8c9d-0e1f2a3b4c5d",
+    displayName: "add-widget",
+    associationRevision: 1,
+    contracts: [{ changeId: "add-widget", kind: "active", sourcePath: "openspec/changes/add-widget", provenance: "adopt", selectedAtRevision: 1 }],
+    intendedBaseRef: "main",
+    context: { branch: "feat/add-widget", checkoutPath: "/tmp/does-not-matter" },
+    runIds: [],
+    closeAttemptIds: [],
+    history: [{ at: 1, kind: "adopted", summary: "adopted add-widget", revision: 1 }],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+function sampleReceipt(overrides: Partial<LandingReceipt> = {}): LandingReceipt {
+  return {
+    schemaVersion: 1,
+    attemptId: "9a8b7c6d-5e4f-4a3b-2c1d-0e9f8a7b6c5d",
+    featureId: "5f0a3c1e-8b2d-4c6a-9e0f-1a2b3c4d5e6f",
+    repositoryId: "7c2b1a0d-3e4f-4a5b-8c9d-0e1f2a3b4c5d",
+    associationRevision: 2,
+    branch: "feat/add-widget",
+    baseRef: "main",
+    baseSha: "a".repeat(40),
+    featureTip: "b".repeat(40),
+    preparedTree: "c".repeat(40),
+    candidateSha: "d".repeat(40),
+    landingSha: "e".repeat(40),
+    landingAt: 42,
+    ...overrides,
+  }
+}
+
+describe("feature-lifecycle store: typed reads (task 1.1)", () => {
+  test("repository record is missing before initialization and unreadable ≠ missing", async () => {
+    const missing = await readRepositoryRecord(commonDir)
+    expect(missing.status).toBe("missing")
+
+    // A directory in place of the record is an I/O-level failure, not absence.
+    await Bun.write(join(lifecycleRoot(commonDir), "keep"), "x")
+    const { mkdir } = await import("node:fs/promises")
+    await mkdir(join(lifecycleRoot(commonDir), "repository.json"), { recursive: true })
+    const unreadable = await readRepositoryRecord(commonDir)
+    expect(unreadable.status).toBe("unreadable")
+    await rm(join(lifecycleRoot(commonDir), "repository.json"), { recursive: true, force: true })
+    await rm(join(lifecycleRoot(commonDir), "keep"), { force: true })
+  })
+
+  test("corrupt JSON is corrupt with a reason, never 'missing'", async () => {
+    await writeJsonFile(join(lifecycleRoot(commonDir), "repository.json"), { repositoryId: "not-a-uuid" })
+    const corrupt = await readRepositoryRecord(commonDir)
+    expect(corrupt.status).toBe("corrupt")
+    if (corrupt.status === "corrupt") expect(corrupt.reason).toBeTruthy()
+  })
+
+  test("a newer schema version is unsupported, never interpreted (task 1.1/1.3)", async () => {
+    await writeJsonFile(join(lifecycleRoot(commonDir), "repository.json"), { schemaVersion: 999, repositoryId: "7c2b1a0d-3e4f-4a5b-8c9d-0e1f2a3b4c5d", createdAt: 1 })
+    const unsupported = await readRepositoryRecord(commonDir)
+    expect(unsupported.status).toBe("unsupported")
+    expect((unsupported as { schemaVersion?: unknown }).schemaVersion).toBe(999)
+  })
+
+  test("ensureRepositoryRecord creates exactly once and never overwrites an existing record", async () => {
+    // A fresh repository so earlier tests' intentional corruption doesn't count.
+    const fresh = await mkdtemp(join(tmpdir(), "convoy-lifecycle-fresh-"))
+    dirs.push(fresh)
+    const init = Bun.spawn(["git", "init", "-q", "-b", "main", fresh])
+    await init.exited
+    const freshCommon = (await lifecycleCommonDir(fresh))!
+    const first = await ensureRepositoryRecord(freshCommon)
+    expect(first.status).toBe("found")
+    const id = (first as { value: RepositoryRecord }).value.repositoryId
+    const again = await ensureRepositoryRecord(freshCommon)
+    expect((again as { value: RepositoryRecord }).value.repositoryId).toBe(id)
+    // A foreign record is returned untouched, not replaced.
+    await writeJsonFile(join(lifecycleRoot(freshCommon), "repository.json"), { schemaVersion: 999, repositoryId: id, createdAt: 1 })
+    const foreign = await ensureRepositoryRecord(freshCommon)
+    expect(foreign.status).toBe("unsupported")
+  })
+
+  test("read failures are typed for feature records too", async () => {
+    const featureId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+    const read = await readFeatureRecord(commonDir, featureId)
+    expect(read.status).toBe("missing")
+  })
+})
+
+describe("feature records: validation and conflict detection (task 1.2)", () => {
+  test("validateFeatureRecord rejects foreign or malformed shapes", () => {
+    expect(validateFeatureRecord(undefined)).toBeUndefined()
+    expect(validateFeatureRecord("nope")).toBeUndefined()
+    expect(validateFeatureRecord({ ...sampleFeature(), schemaVersion: 99 })).toBeUndefined()
+    expect(validateFeatureRecord({ ...sampleFeature(), featureId: "not-a-uuid" })).toBeUndefined()
+    expect(validateFeatureRecord({ ...sampleFeature(), associationRevision: 0 })).toBeUndefined()
+    expect(validateFeatureRecord({ ...sampleFeature(), contracts: [{ changeId: "x", kind: "unknown", sourcePath: "p", provenance: "a", selectedAtRevision: 1 }] })).toBeUndefined()
+  })
+
+  test("an embedded identity that disagrees with the record's path is corrupt (task 1.3)", async () => {
+    const foreignId = "bbbbbbbb-cccc-4ddd-8eee-ffffffffffff"
+    const record = sampleFeature({ featureId: foreignId })
+    const written = await writeFeatureRecord(commonDir, record, 0)
+    expect(isFound(written)).toBe(true)
+    // Reading a different id finds nothing — the id directory defines identity.
+    const other = await readFeatureRecord(commonDir, sampleFeature().featureId)
+    expect(other.status).toBe("missing")
+  })
+
+  test("a lost-update write is refused: stale expectedRevision never overwrites (task 1.2)", async () => {
+    const featureId = "cccccccc-dddd-4eee-8fff-0123456789ab"
+    const base = sampleFeature({ featureId })
+    const first = await writeFeatureRecord(commonDir, base, 0)
+    expect(isFound(first)).toBe(true)
+    // A concurrent editor bumps the revision.
+    const concurrent = sampleFeature({ featureId, associationRevision: 2, displayName: "concurrent" })
+    const second = await writeFeatureRecord(commonDir, concurrent, 1)
+    expect(isFound(second)).toBe(true)
+    // The stale writer (still expecting revision 1) is refused.
+    const stale = sampleFeature({ featureId, associationRevision: 2, displayName: "stale-writer" })
+    const refused = await writeFeatureRecord(commonDir, stale, 1)
+    expect(refused.status).toBe("found")
+    if (refused.status === "found") expect(refused.value.displayName).toBe("concurrent")
+    const onDisk = await readFeatureRecord(commonDir, featureId)
+    expect(isFound(onDisk) && onDisk.value.displayName).toBe("concurrent")
+  })
+
+  test("listFeatureIds only surfaces UUID directories", async () => {
+    const ids = await listFeatureIds(commonDir)
+    expect(ids.length).toBeGreaterThanOrEqual(2)
+    for (const id of ids) expect(id).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  test("withFeatureLock serializes and always releases (task 1.2/feature-lifecycle concurrency)", async () => {
+    const featureDir = join(lifecycleRoot(commonDir), "features", "dddddddd-eeee-4fff-8aaa-123456789abc")
+    let inLock = false
+    let overlap = false
+    const run = async (label: string) =>
+      withFeatureLock(featureDir, async () => {
+        if (inLock) overlap = true
+        inLock = true
+        await new Promise((resolve) => setTimeout(resolve, 30))
+        inLock = false
+        return label
+      })
+    const [a, b] = await Promise.all([run("a"), run("b")])
+    expect(overlap).toBe(false)
+    expect([a, b].sort()).toEqual(["a", "b"])
+    // The lock file is gone afterwards.
+    let lockGone = false
+    try {
+      await stat(join(featureDir, ".lock"))
+    } catch {
+      lockGone = true
+    }
+    expect(lockGone).toBe(true)
+  })
+})
+
+describe("attempt journals and receipts (task 1.3)", () => {
+  test("a journal with foreign embedded identity is corrupt", async () => {
+    const featureId = sampleFeature().featureId
+    const attemptId = "12345678-90ab-4cde-8f01-234567890abc"
+    // Written under this feature's path but naming a foreign feature: the
+    // embedded identity disagrees with the record's location (task 1.3).
+    const { writeJsonFile, lifecycleRoot } = await import("../src/feature-lifecycle/store")
+    await writeJsonFile(join(lifecycleRoot(commonDir), "features", featureId, "attempts", attemptId, "journal.json"), {
+      schemaVersion: 1,
+      attemptId,
+      featureId: "99999999-9999-4999-8999-999999999999",
+      repositoryId: sampleFeature().repositoryId,
+      associationRevision: 1,
+      phase: "prepared",
+      contracts: [],
+      baseRef: "main",
+      baseSha: "a".repeat(40),
+      branch: "feat/x",
+      recordedAt: 1,
+      updatedAt: 1,
+    })
+    const read = await readAttemptJournal(commonDir, featureId, attemptId)
+    expect(read.status).toBe("corrupt")
+  })
+
+  test("receipts are immutable: writeReceiptIfAbsent refuses a second write (task 1.3/D8)", async () => {
+    const featureId = "eeeeeeee-ffff-4aaa-8bbb-234567890abc"
+    const receipt = sampleReceipt({ featureId })
+    expect(await writeReceiptIfAbsent(commonDir, receipt)).toBe(true)
+    const rewritten = sampleReceipt({ featureId, landingSha: "f".repeat(40) })
+    expect(await writeReceiptIfAbsent(commonDir, rewritten)).toBe(false)
+    const read = await readReceipt(commonDir, featureId, receipt.attemptId)
+    expect(isFound(read) && read.value.landingSha).toBe(receipt.landingSha)
+    expect(validateReceipt(await readFile(join(commonDir, "convoy", "features", featureId, "receipts", `${receipt.attemptId}.json`), "utf8").then(JSON.parse))).toBeTruthy()
+    expect(listReceiptIds(commonDir, featureId).then((ids) => ids.length)).resolves.toBe(1)
+  })
+
+  test("validateReceipt rejects malformed receipts", () => {
+    expect(validateReceipt({ ...sampleReceipt(), landingSha: "" })).toBeUndefined()
+    expect(validateReceipt({ ...sampleReceipt(), featureId: "nope" })).toBeUndefined()
+  })
+})

--- a/test/finalization-run-records.test.ts
+++ b/test/finalization-run-records.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { listRuns, loadRunSummary } from "../src/runs"
+import { listRuns, loadRunSummary, readRunIndexEntry } from "../src/runs"
 
 /**
  * The cleanup-surviving run-record index (capability run-finalization, task
@@ -82,5 +82,65 @@ describe("run discovery merges the run-record index", () => {
     await writeFile(join(home, ".convoy", "run-records", "20260905-150000-ba1.json"), "{not json")
     const runs = await listRuns()
     expect(runs.find((run) => run.runID === "20260905-150000-ba1")).toBeUndefined()
+  })
+
+  test("the cleanup-surviving index preserves the reviewed feature link (task 5.1)", async () => {
+    const home = await mkdtemp(join(tmpdir(), "convoy-home-"))
+    dirs.push(home)
+    savedHome = process.env.CONVOY_HOME
+    process.env.CONVOY_HOME = home
+
+    await writeRunIndex(home, {
+      schemaVersion: 1,
+      runID,
+      title: "Feature-backed run",
+      worktreeDir: "/repo/worktrees/feat/add-widget",
+      branch: "feat/add-widget",
+      feature: {
+        featureId: "aaaaaaaa-0000-4000-8000-00000000abc1",
+        associationRevision: 3,
+        branch: "feat/add-widget",
+        baseRef: "main",
+        contracts: ["add-widget"],
+      },
+      disposition: "compacted",
+      state: "completed",
+      recordedAt: 1,
+      updatedAt: 2,
+    })
+
+    const record = await readRunIndexEntry(runID)
+    expect(record).toBeDefined()
+    expect(record!.feature).toEqual({
+      featureId: "aaaaaaaa-0000-4000-8000-00000000abc1",
+      associationRevision: 3,
+      branch: "feat/add-widget",
+      baseRef: "main",
+      contracts: ["add-widget"],
+    })
+  })
+
+  test("a malformed feature link is dropped without inventing identity (task 5.1)", async () => {
+    const home = await mkdtemp(join(tmpdir(), "convoy-home-"))
+    dirs.push(home)
+    savedHome = process.env.CONVOY_HOME
+    process.env.CONVOY_HOME = home
+
+    // writeRunIndex writes under the module-level runID; a fresh home keeps it
+    // isolated from the happy-parse test above.
+    await writeRunIndex(home, {
+      schemaVersion: 1,
+      runID,
+      title: "Run with a malformed feature link",
+      // featureId is not a string, so the link is dropped rather than
+      // interpreted — readers never invent identity.
+      feature: { featureId: 42, associationRevision: "nope", branch: ["bad"] },
+      state: "completed",
+    })
+
+    const record = await readRunIndexEntry(runID)
+    expect(record).toBeDefined()
+    expect(record!.feature).toBeUndefined()
+    expect(record!.state).toBe("completed")
   })
 })

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, test } from "bun:test"
+import { afterAll, describe, expect, test } from "bun:test"
+import { rm } from "node:fs/promises"
 
 import { createPublishSeam, type PublishRunner, type RunResult } from "../src/publish"
+import type { FeatureRecord } from "../src/feature-lifecycle/records"
 
 /**
  * The deliberate `Create pull request` action (capability run-finalization,
@@ -139,5 +141,123 @@ describe("publish apply pushes normally and locates before creating", () => {
     expect(result.ok).toBe(false)
     if (!result.ok) expect(result.message).toContain("the branch was pushed to origin/feat/widget")
     expect(calls.some((call) => call.command === "git" && call.args[0] === "push")).toBe(true)
+  })
+})
+
+describe("publication revalidates the reviewed feature link (task 5.2)", () => {
+  const dirs: string[] = []
+
+  /** A real repo with a registered feature whose branch is checked out in a worktree. */
+  async function makeFeatureRepo(featureId: string): Promise<string> {
+    const { execFile } = await import("../src/git")
+    const { mkdir, mkdtemp: mkd, writeFile } = await import("node:fs/promises")
+    const { tmpdir } = await import("node:os")
+    const { join } = await import("node:path")
+    const main = join(await mkd(join(tmpdir(), "convoy-publish-feature-")), "main")
+    dirs.push(main)
+    await mkdir(main, { recursive: true })
+    await execFile("git", ["init", "-q", "-b", "main"], { cwd: main })
+    await writeFile(join(main, "README.md"), "x\n")
+    await execFile("git", ["add", "."], { cwd: main })
+    await execFile("git", ["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init"], { cwd: main })
+    // The feature's branch is checked out in a worktree so the association verifies.
+    const { realpath } = await import("node:fs/promises")
+    const wt = join(await mkd(join(tmpdir(), "convoy-publish-feature-wt-")), "wt")
+    dirs.push(wt)
+    await execFile("git", ["worktree", "add", "-b", "feat/widget", wt], { cwd: main, allowFailure: true })
+    const { ensureRepositoryRecord, isFound, lifecycleCommonDir, withFeatureLock } = await import("../src/feature-lifecycle/store")
+    const { writeFeatureRecord } = await import("../src/feature-lifecycle/records")
+    const commonDir = (await lifecycleCommonDir(main))!
+    const repoRecord = await ensureRepositoryRecord(commonDir)
+    if (!isFound(repoRecord)) throw new Error("no repo record")
+    const record: FeatureRecord = {
+      schemaVersion: 1,
+      featureId,
+      repositoryId: repoRecord.value.repositoryId,
+      displayName: "add-widget",
+      associationRevision: 2,
+      contracts: [{ changeId: "add-widget", kind: "active", sourcePath: "openspec/changes/add-widget", provenance: "adopt", selectedAtRevision: 2 }],
+      intendedBaseRef: "main",
+      context: { branch: "feat/widget", checkoutPath: await realpath(wt) },
+      runIds: [],
+      closeAttemptIds: [],
+      history: [],
+      createdAt: 1,
+      updatedAt: 1,
+    }
+    await withFeatureLock(join(commonDir, "convoy", "features", featureId), () => writeFeatureRecord(commonDir, record, 0))
+    return main
+  }
+
+  async function withRunDir(feature: unknown): Promise<string> {
+    const { mkdtemp: mkd, writeFile: wf } = await import("node:fs/promises")
+    const { tmpdir } = await import("node:os")
+    const { join } = await import("node:path")
+    const dir = await mkd(join(tmpdir(), "convoy-publish-rundir-"))
+    dirs.push(dir)
+    if (feature !== undefined) {
+      await wf(
+        join(dir, "metadata.json"),
+        JSON.stringify({
+          schemaVersion: 5,
+          runID: "20260101-000000-x",
+          targetDir: ".",
+          createdAt: 1,
+          updatedAt: 1,
+          control: { state: "completed" },
+          phases: {},
+          feature,
+        }),
+      )
+    }
+    return dir
+  }
+
+  test("a feature-backed run refuses publication when its link no longer verifies", async () => {
+    const main = await makeFeatureRepo("11111111-2222-4333-8444-555555555555")
+    const runDir = await withRunDir({
+      featureId: "99999999-2222-4333-8444-555555555555",
+      repositoryId: "88888888-2222-4333-8444-555555555555",
+      associationRevision: 1,
+      contracts: ["add-widget"],
+      baseRef: "main",
+      branch: "feat/widget",
+    })
+    const { seam } = seamWith({}, runDir)
+    void seam
+    // Re-create the seam with the real cwd so the gate reaches the store.
+    const real = createPublishSeam({ cwd: main, runDir, run: fakeRunner({}, []) })
+    const prepared = await real.prepare()
+    expect(prepared.ok).toBe(false)
+    if (!prepared.ok) expect(prepared.message).toMatch(/never pushes the branch now occupying the historical path/)
+  })
+
+  test("a verified feature link revalidates and publication proceeds", async () => {
+    const main = await makeFeatureRepo("11111111-2222-4333-8444-555555555556")
+    const runDir = await withRunDir({
+      featureId: "11111111-2222-4333-8444-555555555556",
+      repositoryId: "88888888-2222-4333-8444-555555555555",
+      associationRevision: 2,
+      contracts: ["add-widget"],
+      baseRef: "main",
+      branch: "feat/widget",
+    })
+    const calls: Array<{ command: string; args: string[] }> = []
+    const real = createPublishSeam({ cwd: main, runDir, run: fakeRunner({}, calls) })
+    const prepared = await real.prepare()
+    expect(prepared.ok).toBe(true)
+    if (!prepared.ok) return
+    expect(prepared.plan.branch).toBe("feat/widget")
+  })
+
+  test("a run without a feature link keeps the no-spec publication flow", async () => {
+    const runDir = await withRunDir(undefined)
+    const real = createPublishSeam({ cwd: "/repo", runDir, run: fakeRunner({}, []) })
+    const prepared = await real.prepare()
+    expect(prepared.ok).toBe(true)
+  })
+
+  afterAll(async () => {
+    await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true }).catch(() => {})))
   })
 })

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, describe, expect, test } from "bun:test"
+import { afterAll, afterEach, describe, expect, test } from "bun:test"
 import { mkdir, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -54,6 +54,21 @@ import { writeCommitSidecar } from "../src/step-commit"
 import { qualityDimensionWeights } from "../src/quality-score"
 
 const recoveryDirs: string[] = []
+
+// A RunShutdown that has requested an abort arms a 15s force-exit timer
+// (process.exit(130)) inside the test process. A test that never disposes its
+// shutdown therefore leaves a live bomb behind: the unref'd timer fires once
+// bun has moved on to other files, killing the whole suite mid-run. Track
+// every shutdown a test creates and dispose the survivors after each test.
+const liveShutdowns: RunShutdown[] = []
+function trackedShutdown(): RunShutdown {
+  const shutdown = new RunShutdown()
+  liveShutdowns.push(shutdown)
+  return shutdown
+}
+afterEach(() => {
+  for (const shutdown of liveShutdowns.splice(0)) shutdown.dispose()
+})
 
 function deferred() {
   let resolve!: () => void
@@ -543,7 +558,7 @@ describe("run phase gate", () => {
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -595,7 +610,7 @@ describe("run phase gate", () => {
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -649,7 +664,7 @@ describe("run phase gate", () => {
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -701,7 +716,7 @@ describe("run phase gate", () => {
       prepared,
       undefined,
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -737,7 +752,7 @@ describe("run phase gate", () => {
         return Promise.resolve("abort")
       },
     }
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     const trip = {
       reason: "max-steps" as const,
       message: "phase reached 200 model steps without finishing (cap 200). The phase was aborted to stop a runaway session.",
@@ -788,7 +803,7 @@ describe("run phase gate", () => {
         prepared,
         undefined,
         noopProgress,
-        new RunShutdown(),
+        trackedShutdown(),
         createGitLock(),
         undefined,
         {
@@ -824,7 +839,7 @@ describe("run phase gate", () => {
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -870,7 +885,7 @@ describe("run phase gate", () => {
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -925,7 +940,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -963,7 +978,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
         prepared,
         { head: "baseline" },
         progress,
-        new RunShutdown(),
+        trackedShutdown(),
         createGitLock(),
         { serverUrl: "http://127.0.0.1:1" },
         {
@@ -991,7 +1006,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
       prepared,
       { head: "baseline" },
       noopProgress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -1020,7 +1035,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
       prepared,
       { head: "baseline" },
       noopProgress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -1072,7 +1087,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
         prepared,
         { head: "baseline" },
         progress,
-        new RunShutdown(),
+        trackedShutdown(),
         createGitLock(),
         { serverUrl: "http://127.0.0.1:1" },
         {
@@ -1123,7 +1138,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
         prepared,
         { head: "baseline" },
         progress,
-        new RunShutdown(),
+        trackedShutdown(),
         createGitLock(),
         { serverUrl: "http://127.0.0.1:1" },
         {
@@ -1156,7 +1171,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
       askHumanReview: () => Promise.resolve("abort"),
     }
 
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     try {
       await expect(
         runPhaseUntilResolved(
@@ -1196,7 +1211,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
         prepared,
         { head: "baseline" },
         noopProgress,
-        new RunShutdown(),
+        trackedShutdown(),
         createGitLock(),
         { serverUrl: "http://127.0.0.1:1" },
         {
@@ -1229,7 +1244,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
         prepared,
         undefined,
         progress,
-        new RunShutdown(),
+        trackedShutdown(),
         createGitLock(),
         { serverUrl: "http://127.0.0.1:1" },
         {
@@ -1275,7 +1290,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -1345,7 +1360,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -1407,7 +1422,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -1475,7 +1490,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
         prepared,
         { head: "baseline" },
         progress,
-        new RunShutdown(),
+        trackedShutdown(),
         createGitLock(),
         { serverUrl: "http://127.0.0.1:1" },
         {
@@ -1514,7 +1529,7 @@ ${JSON.stringify({ dimensions: { prd: 90, tests: 90, security: 90, maintainabili
       prepared,
       { head: "baseline" },
       progress,
-      new RunShutdown(),
+      trackedShutdown(),
       createGitLock(),
       { serverUrl: "http://127.0.0.1:1" },
       {
@@ -1628,7 +1643,7 @@ describe("RunShutdown multi-session tracking", () => {
   }
 
   test("tracks one active session per phase independently", () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     const aborted: string[] = []
     shutdown.setActiveSession(fakeSession("patterns", "ses_1", aborted))
     shutdown.setActiveSession(fakeSession("security", "ses_2", aborted))
@@ -1642,7 +1657,7 @@ describe("RunShutdown multi-session tracking", () => {
   })
 
   test("abortActiveSessions aborts every currently-tracked session", async () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     const aborted: string[] = []
     shutdown.setActiveSession(fakeSession("patterns", "ses_1", aborted))
     shutdown.setActiveSession(fakeSession("security", "ses_2", aborted))
@@ -1653,7 +1668,7 @@ describe("RunShutdown multi-session tracking", () => {
   })
 
   test("concurrent callers share the same in-flight abort", async () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     const aborted: string[] = []
     shutdown.setActiveSession(fakeSession("patterns", "ses_1", aborted))
 
@@ -2672,7 +2687,7 @@ describe("loopGuard seam regressions", () => {
       model: { providerID: "openai", modelID: "gpt-5.5" },
       attachments: [],
       progress: noopProgress,
-      shutdown: new RunShutdown(),
+      shutdown: trackedShutdown(),
       attempt: 1,
       loopGuardConfig: resolveLoopGuard({ maxPhaseCost: false }),
     })
@@ -2724,7 +2739,7 @@ describe("loopGuard seam regressions", () => {
       model: { providerID: "openai", modelID: "gpt-5.5" },
       attachments: [],
       progress: { ...noopProgress, phaseActivity: (_name, detail) => void activities.push(detail) },
-      shutdown: new RunShutdown(),
+      shutdown: trackedShutdown(),
       attempt: 1,
       loopGuardConfig: resolveLoopGuard({ maxSteps: 200 }),
     })
@@ -2787,7 +2802,7 @@ describe("loopGuard seam regressions", () => {
           activities.push(`${level}:${detail}`)
         },
       },
-      shutdown: new RunShutdown(),
+      shutdown: trackedShutdown(),
       attempt: 1,
       loopGuardConfig: resolveLoopGuard({ maxSteps: 200 }),
     })
@@ -2854,7 +2869,7 @@ describe("loopGuard seam regressions", () => {
           targetDir: "/repo",
           model: { providerID: "openai", modelID: "gpt-5.5" },
           progress: noopProgress,
-          shutdown: new RunShutdown(),
+          shutdown: trackedShutdown(),
           sessionID: "ses_1",
           loopGuard,
         },
@@ -2936,7 +2951,7 @@ describe("applyCompletionCheckpoint lastAssistantParts", () => {
     targetDir: "/repo",
     model: { providerID: "openai", modelID: "gpt-5.5" },
     progress: noopProgress,
-    shutdown: new RunShutdown(),
+    shutdown: trackedShutdown(),
     sessionID: "ses_1",
     loopGuard: new LoopGuard(resolveLoopGuard()),
   })
@@ -3071,7 +3086,7 @@ describe("applyReportCheckpoint", () => {
     targetDir: "/repo",
     model: { providerID: "openai", modelID: "gpt-5.5" },
     progress: noopProgress,
-    shutdown: new RunShutdown(),
+    shutdown: trackedShutdown(),
     sessionID: "ses_1",
     loopGuard: new LoopGuard(resolveLoopGuard()),
   })
@@ -3119,7 +3134,7 @@ describe("applyReportCheckpoint", () => {
         targetDir: "/repo",
         model: { providerID: "openai", modelID: "gpt-5.5" },
         progress: noopProgress,
-        shutdown: new RunShutdown(),
+        shutdown: trackedShutdown(),
         sessionID: "ses_1",
         loopGuard: new LoopGuard(resolveLoopGuard()),
       },
@@ -3169,7 +3184,7 @@ describe("applyReportCheckpoint", () => {
         reportPrepared,
         { head: "baseline" },
         progress,
-        new RunShutdown(),
+        trackedShutdown(),
         createGitLock(),
         { serverUrl: "http://127.0.0.1:1" },
         {
@@ -3281,27 +3296,27 @@ describe("isIgnorableRejection", () => {
 
 describe("RunShutdown methods", () => {
   test("signal returns an AbortSignal", () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     expect(shutdown.signal).toBeInstanceOf(Object)
     expect(shutdown.signal.aborted).toBe(false)
     shutdown.dispose()
   })
 
   test("aborted reflects the underlying controller state", () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     expect(shutdown.aborted).toBe(false)
     shutdown.dispose()
   })
 
   test("abortError returns UserAbortError when no reason is set", () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     const error = shutdown.abortError()
     expect(isUserAbortError(error)).toBe(true)
     shutdown.dispose()
   })
 
   test("abortError returns the signal reason when it is a UserAbortError", () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     const signal = shutdown.signal
     const err = new UserAbortError("test abort")
     // Manually abort the controller to set the reason
@@ -3312,7 +3327,7 @@ describe("RunShutdown methods", () => {
   })
 
   test("abortError falls back to fallback when available", () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     const fallback = new UserAbortError("fallback")
     const error = shutdown.abortError(fallback)
     expect(isUserAbortError(error)).toBe(true)
@@ -3321,13 +3336,13 @@ describe("RunShutdown methods", () => {
   })
 
   test("throwIfRequested does not throw before abort", () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     expect(() => shutdown.throwIfRequested()).not.toThrow()
     shutdown.dispose()
   })
 
   test("setActiveSession and clearActiveSession manage session map", async () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     const session = {
       client: {} as never,
       sessionID: "ses_1",
@@ -3345,7 +3360,7 @@ describe("RunShutdown methods", () => {
   })
 
   test("abortActiveSessions resolves when no sessions are tracked", async () => {
-    const shutdown = new RunShutdown()
+    const shutdown = trackedShutdown()
     await shutdown.abortActiveSessions()
     shutdown.dispose()
   })

--- a/test/specs-actions-menu.test.ts
+++ b/test/specs-actions-menu.test.ts
@@ -1,0 +1,223 @@
+import { afterAll, beforeAll, expect, test } from "bun:test"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createTestRenderer } from "@opentui/core/testing"
+
+import { SpecsBrowser } from "../src/specs-browser"
+import type { LifecycleFeatureRow, SpecsChangeEntry, SpecsView } from "../src/specs"
+
+/**
+ * The dispatchable Actions menu (task 6.4, SC-3): close review is reachable
+ * from root and ordinary detail — including when the worktree is gone —
+ * blocked actions stay inspectable with their reasons, and footer truncation
+ * keeps the discoverable `! actions` entry.
+ */
+
+function keyEvent(name: string, options: { ctrl?: boolean; shift?: boolean } = {}) {
+  return {
+    name,
+    ctrl: options.ctrl ?? false,
+    meta: false,
+    shift: options.shift ?? false,
+    option: false,
+    sequence: name,
+    number: false,
+    raw: name,
+    eventType: "keypress" as const,
+    source: "raw" as const,
+    preventDefault: () => {},
+    stopPropagation: () => {},
+  } as any
+}
+
+let root: string
+
+beforeAll(async () => {
+  root = await mkdtemp(join(tmpdir(), "convoy-specs-actions-"))
+  const dir = join(root, "openspec", "changes", "add-widget")
+  const specsDir = join(root, "openspec", "specs", "cli")
+  await mkdir(dir, { recursive: true })
+  await mkdir(specsDir, { recursive: true })
+  await writeFile(join(dir, "proposal.md"), "# Add widget\n")
+  await writeFile(join(dir, "tasks.md"), "- [x] one\n")
+  await writeFile(join(specsDir, "spec.md"), "# Cli spec\n")
+})
+
+afterAll(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+/** The change fixture and its registered feature row; `overrides` shapes the lifecycle facts per test. */
+function changeEntry(): SpecsChangeEntry {
+  return {
+    kind: "change",
+    id: "add-widget",
+    title: "Add widget",
+    artifacts: [{ section: "proposal", file: join(root, "openspec", "changes", "add-widget", "proposal.md") }],
+  }
+}
+
+function featureRow(overrides: Partial<LifecycleFeatureRow> = {}): LifecycleFeatureRow {
+  return {
+    featureId: "11111111-2222-3333-4444-555555555555",
+    displayName: "add-widget",
+    branch: "feat/add-widget",
+    summary: "Ready to close",
+    blockers: [],
+    tasks: { done: 2, total: 2 },
+    liveRuns: 0,
+    integration: "pending",
+    contracts: [{ changeId: "add-widget", state: "active" }],
+    actions: [
+      { id: "close", label: "Close review", enabled: true, blockers: [] },
+      { id: "continue", label: "Continue implementation", enabled: true, blockers: [] },
+      { id: "history", label: "Open history", enabled: true, blockers: [] },
+    ],
+    ...overrides,
+  }
+}
+
+function viewWith(feature: LifecycleFeatureRow, width = 120): SpecsView {
+  return { targetDir: root, present: true, changes: [changeEntry()], specs: [], features: [feature] }
+}
+
+async function openBrowser(view: SpecsView, width = 120, height = 40) {
+  const testRenderer = await createTestRenderer({ width, height })
+  const instance = new SpecsBrowser(testRenderer.renderer, view)
+  await testRenderer.renderOnce()
+  return {
+    ...testRenderer,
+    instance,
+    press(key: string, options: { ctrl?: boolean; shift?: boolean } = {}) {
+      testRenderer.renderer.keyInput.emit("keypress", keyEvent(key, options))
+    },
+  }
+}
+
+async function close(session: Awaited<ReturnType<typeof openBrowser>>) {
+  session.press("c", { ctrl: true })
+  await session.instance.result.catch(() => {})
+}
+
+/** The first selectable row is the feature row (Features leads the board). */
+async function selectFeatureRow(session: Awaited<ReturnType<typeof openBrowser>>) {
+  // Rows start past headers; with one feature the cursor already sits on it.
+}
+
+test("! opens the Actions menu on a feature row and Enter dispatches close review by feature id", async () => {
+  const session = await openBrowser(viewWith(featureRow()))
+  await selectFeatureRow(session)
+
+  session.press("!")
+  await session.renderOnce()
+  const frame = session.captureCharFrame()
+  expect(frame).toContain("Actions — add-widget")
+  expect(frame).toContain("Close review")
+
+  session.press("return")
+  await expect(session.instance.result).resolves.toEqual({ type: "close-feature", featureId: "11111111-2222-3333-4444-555555555555" })
+})
+
+test("x on a worktree-less feature row dispatches close review by identity instead of dying silently", async () => {
+  // No checkoutPath: the old close-change handoff required it and no-oped.
+  const session = await openBrowser(viewWith(featureRow({ checkoutPath: undefined })))
+  await selectFeatureRow(session)
+
+  session.press("x")
+  await expect(session.instance.result).resolves.toEqual({ type: "close-feature", featureId: "11111111-2222-3333-4444-555555555555" })
+})
+
+test("the ordinary detail view's menu offers the same close action as the root", async () => {
+  const session = await openBrowser(viewWith(featureRow()))
+  await selectFeatureRow(session)
+
+  // Enter opens the feature's history view (the detail level).
+  session.press("return")
+  await session.renderOnce()
+  session.press("!")
+  await session.renderOnce()
+  expect(session.captureCharFrame()).toContain("Close review")
+
+  session.press("return")
+  await expect(session.instance.result).resolves.toEqual({ type: "close-feature", featureId: "11111111-2222-3333-4444-555555555555" })
+})
+
+test("a blocked close review stays inspectable with its blockers and never dispatches", async () => {
+  const blocked = featureRow({
+    summary: "Implementation complete · blocked",
+    actions: [
+      { id: "close", label: "Close review", enabled: false, blockers: ["2 live runs are attached to feat/add-widget — wait for or stop them first"], remediation: ["resolve: 2 live runs are attached to feat/add-widget — wait for or stop them first"] },
+      { id: "history", label: "Open history", enabled: true, blockers: [] },
+    ],
+  })
+  const session = await openBrowser(viewWith(blocked))
+
+  // The menu starts on the first enabled dispatchable entry (history); move
+  // up to the blocked Close review.
+  session.press("!")
+  await session.renderOnce()
+  session.press("up")
+  await session.renderOnce()
+  const frame = session.captureCharFrame()
+  expect(frame).toContain("Close review — blocked")
+  expect(frame).toContain("live runs")
+
+  // Enter on the blocked entry must not dispatch anything: the menu stays open.
+  session.press("return")
+  await session.renderOnce()
+  expect(session.captureCharFrame()).toContain("Actions — add-widget")
+
+  // Escape closes the menu; q/q leave the subject and quit.
+  session.press("escape")
+  await session.renderOnce()
+  session.press("q")
+  await session.renderOnce()
+  session.press("q")
+  await expect(session.instance.result).resolves.toEqual({ type: "exit" })
+})
+
+test("the pinned ! actions hint survives footer truncation in a narrow terminal", async () => {
+  const crowded = featureRow({
+    actions: [
+      { id: "close", label: "Close review", enabled: true, blockers: [] },
+      { id: "continue", label: "Continue implementation", enabled: true, blockers: [] },
+      { id: "history", label: "Open history", enabled: true, blockers: [] },
+      { id: "bind", label: "Rebind context", enabled: false, blockers: ["the worktree for \"feat/add-widget\" moved"], remediation: ["run `convoy feature bind <feature-id> --branch <name> --worktree <path>` from the surviving checkout"] },
+    ],
+  })
+  const session = await openBrowser(viewWith(crowded), 62, 40)
+
+  const frame = session.captureCharFrame()
+  // Many hints compete for the narrow footer, but the menu entry is pinned.
+  expect(frame).toContain("actions")
+  expect(frame).toContain("!")
+
+  // And the menu itself still opens and dispatches.
+  session.press("!")
+  await session.renderOnce()
+  session.press("return")
+  await expect(session.instance.result).resolves.toEqual({ type: "close-feature", featureId: "11111111-2222-3333-4444-555555555555" })
+})
+
+test("the fullscreen reader keeps its copy keys and never opens the menu", async () => {
+  const session = await openBrowser(viewWith(featureRow()))
+  await selectFeatureRow(session)
+
+  session.press("return")
+  await session.renderOnce()
+  session.press("v")
+  await session.renderOnce()
+  session.press("!")
+  await session.renderOnce()
+  const frame = session.captureCharFrame()
+  expect(frame).toContain("c copy")
+  expect(frame).not.toContain("Actions — add-widget")
+
+  session.press("escape")
+  await session.renderOnce()
+  session.press("q")
+  await session.renderOnce()
+  session.press("q")
+  await expect(session.instance.result).resolves.toEqual({ type: "exit" })
+})

--- a/test/specs-board.test.ts
+++ b/test/specs-board.test.ts
@@ -3,7 +3,7 @@ import { createTestRenderer } from "@opentui/core/testing"
 
 import { SpecsBrowser } from "../src/specs-browser"
 import type { FeatureRow, WorktreeWithoutSpec } from "../src/control-board"
-import type { SpecsChangeEntry, SpecsResolution, SpecsView } from "../src/specs"
+import type { LifecycleFeatureRow, SpecsChangeEntry, SpecsResolution, SpecsView } from "../src/specs"
 
 function keyEvent(name: string, options: { ctrl?: boolean; shift?: boolean; sequence?: string } = {}) {
   return {
@@ -231,5 +231,154 @@ describe("compact stacking", () => {
       testRenderer.renderer.keyInput.emit("keypress", keyEvent("c", { ctrl: true }))
       await instance.result.catch(() => {})
     }
+  })
+})
+
+// ── registered lifecycle features (tasks 6.3/6.4/6.5) ───────────────────────
+
+function lifecycleRow(overrides: Partial<LifecycleFeatureRow> = {}): LifecycleFeatureRow {
+  return {
+    featureId: "aaaaaaaa-0000-4000-8000-000000000009",
+    displayName: "add-widget",
+    branch: "feat/add-widget",
+    checkoutPath: "/wt/add-widget",
+    summary: "Ready to close",
+    blockers: [],
+    tasks: { done: 11, total: 11 },
+    liveRuns: 0,
+    integration: "pending",
+    contracts: [{ changeId: "add-widget", state: "active" }],
+    actions: [
+      { id: "close", label: "Close review", enabled: true, blockers: [] },
+      { id: "continue", label: "Continue implementation", enabled: true, blockers: [] },
+    ],
+    ...overrides,
+  }
+}
+
+function viewWithFeatures(features: LifecycleFeatureRow[]): SpecsView {
+  return {
+    targetDir: "/repo",
+    present: true,
+    changes: [],
+    specs: [],
+    features,
+    worktreesWithoutSpec: [],
+  }
+}
+
+describe("registered lifecycle features on the board", () => {
+  test("the Features section renders first with summaries and the assessment detail", async () => {
+    const frame = await frameOf(viewWithFeatures([lifecycleRow()]))
+    const lines = frame.split("\n")
+    const features = lines.findIndex((line) => line.includes("FEATURES"))
+    expect(features).toBeGreaterThanOrEqual(0)
+    // The Features section leads the board — before Worktrees/Canonical
+    // headers (absent here) and before any Active Changes rows.
+    expect(frame.indexOf("FEATURES")).toBeLessThan(frame.indexOf("add-widget"))
+    expect(frame).toContain("Ready to close")
+    expect(frame).toContain("feat/add-widget")
+  })
+
+  test("a blocked feature's detail exposes its blockers with reasons (task 6.4)", async () => {
+    const view = viewWithFeatures([
+      lifecycleRow({
+        summary: "In implementation",
+        blockers: ["1 live run(s) attached"],
+        actions: [{ id: "close", label: "Close review", enabled: false, blockers: ["1 live run(s) attached"] }],
+      }),
+    ])
+    const frame = await frameOf(view)
+    expect(frame).toContain("In implementation")
+    expect(frame).toContain("Close review")
+    expect(frame).toContain("blocked")
+    expect(frame).toContain("1 live run(s) attached")
+  })
+
+  test("x on a feature row dispatches the close handoff through its verified context (task 6.4)", async () => {
+    const session = await openBoard(viewWithFeatures([lifecycleRow()]))
+    session.press("x")
+    await expect(session.instance.result).resolves.toEqual({
+      type: "close-change",
+      changeID: "add-widget",
+      worktreeDir: "/wt/add-widget",
+      branch: "feat/add-widget",
+    })
+  })
+
+  test("Enter on a completed feature opens its History view with receipts (task 6.3)", async () => {
+    const completed = lifecycleRow({
+      summary: "Completed",
+      integration: "verified" as const,
+      contracts: [{ changeId: "add-widget", state: "verified-archived" }],
+      receipts: [{ attemptId: "dddddddd-0000-4000-8000-00000000abc3", landingSha: "e".repeat(40), landingReachable: true }],
+      history: [{ at: 1_700_000_000_000, kind: "recovered", summary: "adopted legacy landing" }],
+    })
+    const session = await openBoard(viewWithFeatures([completed]))
+    session.press("return")
+    await session.renderOnce()
+    const frame = session.captureCharFrame()
+    expect(frame).toContain("add-widget — history")
+    expect(frame).toContain("Landing receipts")
+    expect(frame).toContain("reachable from the base (verified)")
+    expect(frame).toContain("Association history")
+    // Leaving the history detail restores the feature row (identity preserved).
+    session.press("escape")
+    await session.renderOnce()
+    expect(session.captureCharFrame()).toContain("FEATURES")
+    session.press("c", { ctrl: true })
+    await session.instance.result.catch(() => {})
+  })
+
+  test("refresh reloads external changes from the real repo (task 6.5)", async () => {
+    const { execFile: nodeExecFile } = await import("node:child_process")
+    const { mkdir, mkdtemp, writeFile } = await import("node:fs/promises")
+    const { tmpdir } = await import("node:os")
+    const { join } = await import("node:path")
+    const { promisify } = await import("node:util")
+    const exec = promisify(nodeExecFile)
+    const root = await mkdtemp(join(tmpdir(), "convoy-board-refresh-"))
+    const main = join(root, "main")
+    const wt = join(root, "wt")
+    await mkdir(main, { recursive: true })
+    await exec("git", ["init", "-b", "main"], { cwd: main })
+    await writeFile(join(main, "README.md"), "# repo\n")
+    await exec("git", ["add", "."], { cwd: main })
+    await exec("git", ["-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init"], { cwd: main })
+    await exec("git", ["worktree", "add", "-b", "feat/add-widget", wt], { cwd: main })
+    const changeDir = join(wt, "openspec", "changes", "add-widget")
+    await mkdir(changeDir, { recursive: true })
+    await writeFile(join(changeDir, "proposal.md"), "# Add widget\n")
+    await writeFile(join(changeDir, "tasks.md"), "- [x] one\n- [x] two\n")
+
+    const { featureAdopt } = await import("../src/feature-lifecycle/commands")
+    await featureAdopt({ cwd: main, branch: "feat/add-widget", changeIds: ["add-widget"], base: "main" })
+
+    // Stub the real openspec CLI so task counting is deterministic: the
+    // checkbox fallback parses tasks.md directly.
+    const { chmod } = await import("node:fs/promises")
+    const stubDir = join(root, "bin")
+    await mkdir(stubDir, { recursive: true })
+    await writeFile(join(stubDir, "openspec"), "#!/bin/sh\nexit 1\n")
+    await chmod(join(stubDir, "openspec"), 0o755)
+    const savedPath = process.env.PATH
+    process.env.PATH = `${stubDir}:${savedPath}`
+    const restorePath = () => {
+      if (savedPath !== undefined) process.env.PATH = savedPath
+    }
+
+    const { loadSpecsView } = await import("../src/specs")
+    const session = await openBoard(await loadSpecsView(main))
+    expect(session.captureCharFrame()).toContain("Ready to close")
+
+    // An external edit marks a task incomplete; refresh must show it.
+    await writeFile(join(changeDir, "tasks.md"), "- [x] one\n- [ ] two\n")
+    session.press("r")
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    const frame = session.captureCharFrame()
+    restorePath()
+    expect(frame).toContain("In implementation")
+    session.press("c", { ctrl: true })
+    await session.instance.result.catch(() => {})
   })
 })

--- a/test/specs-lifecycle.test.ts
+++ b/test/specs-lifecycle.test.ts
@@ -1,0 +1,143 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import { execFile as nodeExecFile } from "node:child_process"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+import { loadLifecycleFeatureRows, loadSpecsView, printSpecsList } from "../src/specs"
+import { featureAdopt } from "../src/feature-lifecycle/commands"
+
+/**
+ * Tasks 6.1/6.3 (data + headless level): the specs view exposes registered
+ * lifecycle features with their shared-assessment summaries alongside the
+ * active changes, and the piped listing prints them with blockers — without
+ * ever writing the registry.
+ */
+
+const exec = promisify(nodeExecFile)
+const dirs: string[] = []
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  await exec("git", args, { cwd })
+}
+
+async function makeRepo(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "convoy-specs-lifecycle-"))
+  dirs.push(root)
+  const main = join(root, "main")
+  const wt = join(root, "wt")
+  await mkdir(main, { recursive: true })
+  await git(main, "init", "-b", "main")
+  await writeFile(join(main, "README.md"), "# repo\n")
+  await git(main, "add", ".")
+  await git(main, "-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init")
+  await git(main, "worktree", "add", "-b", "feat/add-widget", wt)
+  const changeDir = join(wt, "openspec", "changes", "add-widget")
+  await mkdir(changeDir, { recursive: true })
+  await writeFile(join(changeDir, "proposal.md"), "# Add widget\n")
+  await writeFile(join(changeDir, "tasks.md"), "- [x] one\n- [x] two\n")
+  return main
+}
+
+beforeAll(async () => {
+  const home = await mkdtemp(join(tmpdir(), "convoy-specs-lifecycle-home-"))
+  dirs.push(home)
+  process.env.CONVOY_HOME = home
+})
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+describe("specs view lifecycle rows (tasks 6.1/6.3)", () => {
+  test("registered features appear with assessment summaries; unregistered work stays unassociated", async () => {
+    const main = await makeRepo()
+    // Nothing registered yet: no feature rows.
+    expect(await loadLifecycleFeatureRows(main)).toEqual([])
+
+    const wt = join(main, "..", "wt")
+    const { feature } = await featureAdopt({ cwd: main, branch: "feat/add-widget", changeIds: ["add-widget"], base: "main" })
+    const rows = await loadLifecycleFeatureRows(main)
+    expect(rows).toHaveLength(1)
+    expect(rows![0]!.featureId).toBe(feature.featureId)
+    expect(rows![0]!.displayName).toBe("add-widget")
+    expect(rows![0]!.branch).toBe("feat/add-widget")
+    // Complete tasks and a verified context: ready to close.
+    expect(rows![0]!.summary).toBe("Ready to close")
+    expect(rows![0]!.tasks).toEqual({ done: 2, total: 2 })
+  })
+
+  test("loadSpecsView includes lifecycle rows and the empty board still opens for features alone", async () => {
+    const main = await makeRepo()
+    await featureAdopt({ cwd: main, branch: "feat/add-widget", changeIds: ["add-widget"], base: "main" })
+    const view = await loadSpecsView(main)
+    expect(view.features).toHaveLength(1)
+    expect(view.features![0]!.summary).toBe("Ready to close")
+  })
+
+  test("headless listing prints feature summaries and blockers without control sequences", async () => {
+    const main = await makeRepo()
+    await featureAdopt({ cwd: main, branch: "feat/add-widget", changeIds: ["add-widget"], base: "main" })
+    const view = await loadSpecsView(main)
+    const chunks: string[] = []
+    const originalWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((chunk: unknown) => {
+      chunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    try {
+      printSpecsList({ present: view.present, changes: view.changes, specs: view.specs, features: view.features, worktreesWithoutSpec: view.worktreesWithoutSpec })
+    } finally {
+      process.stdout.write = originalWrite
+    }
+    const output = chunks.join("")
+    expect(output).toContain("features:")
+    expect(output).toContain("add-widget")
+    expect(output).toContain("Ready to close")
+    expect(output).toContain("tasks 2/2")
+    expect(output).not.toMatch(/\u001b\[/)
+  })
+
+  test("discovery and listing write no registry files (assert store untouched)", async () => {
+    const main = await makeRepo()
+    await featureAdopt({ cwd: main, branch: "feat/add-widget", changeIds: ["add-widget"], base: "main" })
+    const { lifecycleCommonDir } = await import("../src/feature-lifecycle/store")
+    const commonDir = (await lifecycleCommonDir(main))!
+    const { readdir } = await import("node:fs/promises")
+    const before = await readdir(join(commonDir, "convoy"), { recursive: true })
+    await loadLifecycleFeatureRows(main)
+    await loadSpecsView(main)
+    const after = await readdir(join(commonDir, "convoy"), { recursive: true })
+    expect(after.sort()).toEqual(before.sort())
+  })
+
+  test("the verified associated source supplies artifacts, even on an arbitrary branch with a launch-checkout husk (task 6.2)", async () => {
+    const root = await mkdtemp(join(tmpdir(), "convoy-specs-lifecycle-62-"))
+    dirs.push(root)
+    const main = join(root, "main")
+    const wt = join(root, "wt")
+    await mkdir(main, { recursive: true })
+    await git(main, "init", "-b", "main")
+    await writeFile(join(main, "README.md"), "# repo\n")
+    await git(main, "add", ".")
+    await git(main, "-c", "user.email=t@x", "-c", "user.name=T", "commit", "-m", "init")
+    await git(main, "worktree", "add", "-b", "team/alice/release-42", wt)
+    // Full change in the worktree…
+    const changeDir = join(wt, "openspec", "changes", "add-widget")
+    await mkdir(changeDir, { recursive: true })
+    await writeFile(join(changeDir, "proposal.md"), "# Add widget (real)\n")
+    await writeFile(join(changeDir, "tasks.md"), "- [x] one\n")
+    // …and only a husk in the launch checkout.
+    await mkdir(join(main, "openspec", "changes", "add-widget"), { recursive: true })
+
+    await featureAdopt({ cwd: main, branch: "team/alice/release-42", changeIds: ["add-widget"], base: "main" })
+    const view = await loadSpecsView(main)
+    const entry = view.changes.find((change) => change.id === "add-widget")
+    expect(entry).toBeDefined()
+    expect(entry!.title).toBe("Add widget (real)")
+    // Artifacts are addressed absolutely, so they read from any cwd.
+    const proposal = entry!.artifacts.find((artifact) => artifact.section === "proposal")
+    expect(proposal?.file.startsWith("/")).toBe(true)
+  })
+})

--- a/test/specs-tui.test.ts
+++ b/test/specs-tui.test.ts
@@ -202,6 +202,68 @@ test("i iterates on the selected change from the root list", async () => {
   await expect(session.instance.result).resolves.toEqual({ type: "iterate-change", changeID: "add-login" })
 })
 
+test("a feature's history view never dispatches apply or iterate, even when its display name names an active change", async () => {
+  const view = sampleView()
+  view.features = [
+    {
+      featureId: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+      displayName: "add-login", // deliberately equals the active change id above
+      summary: "In implementation",
+      blockers: [],
+      liveRuns: 0,
+      integration: "pending",
+      contracts: [{ changeId: "add-login", state: "active" }],
+    },
+  ]
+  const session = await openBrowser(view)
+
+  // The cursor opens on the feature row; enter shows its read-only history.
+  session.press("return")
+  await session.renderOnce()
+  await settle()
+  await session.renderOnce()
+  const history = session.captureCharFrame()
+  // The title leads with the display name; the feature uuid never headlines it.
+  expect(history).toContain("add-login — history")
+  expect(history).not.toContain("— add-login — history")
+
+  // Apply/iterate are change-level actions: on the history view they neither
+  // launch the same-named change nor end the browser.
+  session.press("a")
+  await session.renderOnce().catch(() => {})
+  session.press("i")
+  await session.renderOnce().catch(() => {})
+  session.press("escape")
+  await session.renderOnce()
+  expect(session.captureCharFrame()).toContain("FEATURES")
+
+  // Quit still resolves exit — proving neither shortcut finished the browser.
+  session.press("q")
+  await expect(session.instance.result).resolves.toEqual({ type: "exit" })
+})
+
+test("a selected feature row's details panel shares the change rows' label anatomy", async () => {
+  const view = sampleView()
+  view.features = [
+    {
+      featureId: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+      displayName: "add-login",
+      branch: "feat/add-login",
+      checkoutPath: "/tmp/wt-add-login",
+      summary: "Association needed",
+      blockers: [],
+      liveRuns: 0,
+      integration: "pending",
+      contracts: [{ changeId: "add-login", state: "active" }],
+    },
+  ]
+  const frame = await frameOf(view)
+  expect(frame).toContain("status: Association needed")
+  expect(frame).toContain("branch: feat/add-login")
+  expect(frame).toContain("worktree: /tmp/wt-add-login")
+  expect(frame).toContain("contract: add-login (active)")
+})
+
 test("selection crosses sections: enter on a canonical spec reads it", async () => {
   const view = sampleView()
   view.changes = [{ kind: "change", id: "only-change", title: "Only change", artifacts: [] }]

--- a/test/spin-registration.test.ts
+++ b/test/spin-registration.test.ts
@@ -1,0 +1,196 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test"
+import { execFile as nodeExecFile } from "node:child_process"
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
+import { printSpinHandoff, runSpin } from "../src/spin"
+import { isFound, lifecycleCommonDir, readRepositoryRecord } from "../src/feature-lifecycle/store"
+import { listFeatureIds, readFeatureRecord } from "../src/feature-lifecycle/records"
+import { resolveFeature } from "../src/feature-lifecycle/resolver"
+
+/**
+ * Task 4.1 (capability feature-spin): successful spin registers an explicit
+ * feature association — intent before transfer, committed association before
+ * success output — without changing conventional names or transfer behavior.
+ */
+
+const exec = promisify(nodeExecFile)
+const dirs: string[] = []
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await exec("git", args, { cwd })
+  return stdout.trim()
+}
+
+async function makeRepo(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "convoy-spin-register-"))
+  dirs.push(dir)
+  await git(dir, "init", "-b", "main")
+  await git(dir, "config", "user.email", "operator@example.com")
+  await git(dir, "config", "user.name", "Operator")
+  await writeFile(join(dir, "README.md"), "# repo\n")
+  await git(dir, "add", ".")
+  await git(dir, "commit", "-m", "chore: init")
+  return dir
+}
+
+async function proposeUncommittedChange(repo: string, id: string): Promise<void> {
+  const changeDir = join(repo, "openspec", "changes", id)
+  await mkdir(join(changeDir, "specs", "cli"), { recursive: true })
+  await writeFile(join(changeDir, "proposal.md"), `# ${id}\n`)
+  await writeFile(join(changeDir, "specs", "cli", "spec.md"), "## ADDED Requirements\n### Requirement: It works\n")
+}
+
+async function freshEnv(): Promise<void> {
+  const home = await mkdtemp(join(tmpdir(), "convoy-spin-reg-home-"))
+  dirs.push(home)
+  process.env.CONVOY_HOME = home
+}
+
+afterAll(async () => {
+  await Promise.all(dirs.map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+beforeEach(() => {
+  void 0
+})
+
+describe("spin registration (task 4.1)", () => {
+  test("successful spin registers the association and the handoff names it", async () => {
+    await freshEnv()
+    const repo = await makeRepo()
+    await proposeUncommittedChange(repo, "add-widget")
+
+    const result = await runSpin({ targetDir: repo })
+    expect(result.featureId).toMatch(/^[0-9a-f-]{36}$/)
+
+    const commonDir = (await lifecycleCommonDir(repo))!
+    const record = await readFeatureRecord(commonDir, result.featureId)
+    expect(record.status).toBe("found")
+    if (!isFound(record)) return
+    expect(record.value.context?.branch).toBe(result.branch)
+    expect(record.value.contracts.map((contract) => contract.changeId)).toEqual(["add-widget"])
+    expect(record.value.intendedBaseRef).toBe("main")
+
+    // All worktrees of the repo resolve the same association (spec scenario).
+    const fromWorktree = await resolveFeature({ cwd: result.worktreeDir, commonDir })
+    expect(fromWorktree.status).toBe("verified")
+    if (fromWorktree.status === "verified") expect(fromWorktree.feature.featureId).toBe(result.featureId)
+
+    // The handoff output identifies the feature.
+    const chunks: string[] = []
+    const originalWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((chunk: unknown) => {
+      chunks.push(String(chunk))
+      return true
+    }) as typeof process.stdout.write
+    try {
+      printSpinHandoff(result)
+    } finally {
+      process.stdout.write = originalWrite
+    }
+    expect(chunks.join("")).toContain(result.featureId)
+    expect(chunks.join("")).toContain("/move")
+
+    // Nothing was committed in the worktree (spin transfer unchanged).
+    const status = await git(result.worktreeDir, "status", "--porcelain")
+    expect(status).toContain("openspec/")
+  })
+
+  test("association persistence failure prevents the success handoff and exposes recovery context", async () => {
+    await freshEnv()
+    const repo = await makeRepo()
+    await proposeUncommittedChange(repo, "add-widget")
+
+    // Make the store's parent unwritable so the committed-phase write fails
+    // after the worktree and transfer succeeded: the first feature-store
+    // write is the intent (allowed), later ones are blocked.
+    const commonDir = (await lifecycleCommonDir(repo))!
+    const originalWrite = Bun.write as (path: string, data?: unknown) => Promise<number | undefined>
+    let writes = 0
+    let blocked = 0
+    ;(Bun as unknown as { write: unknown }).write = (path: string, data: unknown) => {
+      if (typeof path === "string" && path.includes(join("convoy", "features"))) {
+        writes += 1
+        if (writes > 1) {
+          blocked += 1
+          return Promise.reject(new Error("disk full (simulated)"))
+        }
+      }
+      return originalWrite(path, data)
+    }
+    try {
+      await runSpin({ targetDir: repo })
+      expect.unreachable("spin should have failed when the association could not be persisted")
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      expect(message).toMatch(/persisting the feature association failed/)
+      expect(message).toMatch(/worktree:/)
+      expect(message).toMatch(/transferred files:/)
+      expect(message).toMatch(/convoy feature show/)
+      expect(message).toMatch(/Nothing was committed/)
+    } finally {
+      ;(Bun as unknown as { write: unknown }).write = originalWrite as unknown as typeof Bun.write
+    }
+    expect(blocked).toBeGreaterThan(0)
+  })
+
+  test("retry after a partial result adopts the recorded intent instead of duplicating", async () => {
+    await freshEnv()
+    const repo = await makeRepo()
+    await proposeUncommittedChange(repo, "add-widget")
+
+    // Phase 1: fail at the committed phase (intent exists, transfer done):
+    // allow the intent write, block every later feature-store write.
+    const commonDir = (await lifecycleCommonDir(repo))!
+    const originalWrite = Bun.write as (path: string, data?: unknown) => Promise<number | undefined>
+    let writes = 0
+    ;(Bun as unknown as { write: unknown }).write = (path: string, data: unknown) => {
+      if (typeof path === "string" && path.includes(join("convoy", "features"))) {
+        writes += 1
+        if (writes > 1) return Promise.reject(new Error("disk full (simulated)"))
+      }
+      return originalWrite(path, data)
+    }
+    let firstError: string | undefined
+    let worktreeDir: string | undefined
+    try {
+      await runSpin({ targetDir: repo })
+    } catch (error) {
+      firstError = error instanceof Error ? error.message : String(error)
+      worktreeDir = firstError.match(/worktree: (\S+)/)?.[1]
+    } finally {
+      ;(Bun as unknown as { write: unknown }).write = originalWrite as unknown as typeof Bun.write
+    }
+    expect(firstError).toBeTruthy()
+    expect(worktreeDir).toBeTruthy()
+
+    // The intent record exists exactly once.
+    const ids = await listFeatureIds(commonDir)
+    expect(ids).toHaveLength(1)
+
+    // Phase 2: a spin for the same change/branch now resumes the intent.
+    const { registerSpinFeature } = await import("../src/feature-lifecycle/commands")
+    const resumed = await registerSpinFeature({ cwd: repo, changeId: "add-widget", branch: "feat/add-widget", worktreeDir: worktreeDir!, baseRef: "main", phase: "committed" })
+    expect(resumed.resumed).toBe(true)
+    expect(resumed.feature.featureId).toBe(ids[0])
+  })
+
+  test("refusal before creation persists no feature (store stays uninitialized)", async () => {
+    await freshEnv()
+    const repo = await makeRepo()
+    await proposeUncommittedChange(repo, "one")
+    await proposeUncommittedChange(repo, "two")
+    try {
+      await runSpin({ targetDir: repo })
+      expect.unreachable("ambiguous changes must stop spin")
+    } catch (error) {
+      expect((error as Error).message).toMatch(/--change/)
+    }
+    const commonDir = (await lifecycleCommonDir(repo))!
+    expect((await readRepositoryRecord(commonDir)).status).toBe("missing")
+    expect(await listFeatureIds(commonDir)).toEqual([])
+  })
+})

--- a/test/spin.test.ts
+++ b/test/spin.test.ts
@@ -237,6 +237,7 @@ describe("spin", () => {
         movedFiles: ["openspec/changes/add-widget/proposal.md"],
         committedOnBase: false,
         prefix: "feat",
+        featureId: "00000000-0000-4000-8000-000000000001",
       })
     } finally {
       process.stdout.write = originalWrite
@@ -263,6 +264,7 @@ describe("spin", () => {
         movedFiles: [],
         committedOnBase: true,
         prefix: "feat",
+        featureId: "00000000-0000-4000-8000-000000000002",
       })
     } finally {
       process.stdout.write = originalWrite


### PR DESCRIPTION
Implements the `stable-feature-lifecycle` OpenSpec change: features get a stable repository-scoped identity that survives merges, renames, worktree removal, and early archiving.

## What's included

- **Stable feature identities**: new `src/feature-lifecycle/` domain (store, discovery, resolver, launch, observe, assessment, archive verification) persists feature↔context associations — change contract, implementation context, base, run, and close-attempt records — in repo-local storage. Persisted intent and evidence, never a cached authoritative status.
- **Explicit registration and adoption**: spin and accepted run launch persist the association; inspect/adopt/rebind commands cover legacy or externally changed contexts. Conventional names remain defaults, never ownership proof.
- **One shared resolver (breaking)**: branch-name/Markdown/list-order ownership inference and silent close-target guesses are replaced by a single assessment shared by the control board, specs viewer, launcher, run publication, and close. Blocked actions are explained, and targets are revalidated before mutation.
- **Identity-based close**: preflight on the resolved target, positively verified archive completion, preserved whole-branch squash semantics, idempotent recovery of interrupted landings, immutable receipts, and evidence-gated cleanup that is safe across renames, retries, and partial cleanup.
- **Discoverability**: archived-but-unintegrated and integrated-but-uncleaned features stay visible on the board and specs viewer, reading artifacts from their verified source.

## Breaking

- Local CLI/TUI selection: mutation requires a verified association or explicit adoption. Existing `--branch`, `--change`, and `--resume` flags keep working, but only as selectors — no safety bypass.

## Tests

- 19 new suites: unit, end-to-end, and fault-injection coverage for the store, resolver, refs, assessment, commands, archive verification, launch, close identity/recovery, and specs board/viewer/TUI lifecycle behavior (63 files changed, +9598/−270).
