### PR TITLE
feat(tui): add wave loading transition over home destination

### DIFF
--- a/openspec/changes/add-wave-loading-transition/.openspec.yaml
+++ b/openspec/changes/add-wave-loading-transition/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-05

--- a/openspec/changes/add-wave-loading-transition/design.md
+++ b/openspec/changes/add-wave-loading-transition/design.md
@@ -6,12 +6,12 @@ Relevant constraints from the existing architecture:
 - `TuiSession.openScene(id)` closes the current active scene and mounts a new one; the new scene paints over the previous frame with no blank frame and no alternate-screen toggle. This is the atomic-handoff primitive we already have.
 - `TuiScene` exposes `close()` and `requestInterrupt()`; the route's `onInterrupt` sets an `interrupted` flag the navigation loop checks.
 - Theme palette lives in `src/tui-theme.ts` (`theme.text`, `theme.dim`, `theme.faint`, etc.); `setTheme` swaps it.
-- Rendering is OpenTUI `BoxRenderable`/`TextRenderable`; backgrounds are transparent, so the field is drawn with fg-colored glyphs.
+- Rendering is OpenTUI `BoxRenderable`/`TextRenderable`; backgrounds are transparent (the terminal's own background shows through), so the field is drawn with fg-colored glyphs. The palette's single opaque color, `theme.overlay`, exists for floating elements that must mask what is underneath — the transition's status pill uses it.
 
 ## Goals / Non-Goals
 
 **Goals:**
-- A reusable transition that mounts on the shared `TuiSession` while a destination loads, animates a character ripple field, and hands off atomically to the destination scene.
+- A reusable transition that mounts on the shared `TuiSession` while a destination loads, animates a breathing sea of characters, and hands off atomically to the destination scene.
 - Only show it for genuinely slow loads (threshold), never extend the load, and never flash on fast loads.
 - Keep the transition cheap enough to run on large terminals and over SSH; honor reduced motion; support `Ctrl+C` interrupt.
 
@@ -39,10 +39,13 @@ This is the single choke point that every destination's `browseSpecs`/`browseRun
 ### 2. The transition is a real `TuiScene`, so handoff stays atomic
 The helper opens `sceneForRoute(route, "convoy-loading-scene")` when it decides to show. When `load` settles, the helper closes the transition scene; the destination's own `sceneForRoute(route, "<dest>")` mount then closes whatever scene is active. Because both are scenes on the same session, the frame is replaced in place — no blank frame, no alternate-screen exit/re-entry (the existing contract in `src/tui-session.ts`).
 
-### 3. Ripple field drawn with glyphs and per-cell fg color
-A grid of cells covers the body area. Each cell's glyph and brightness is a function of a set of expanding ripples (origin point, radius growing over time, decaying strength), evaluated per frame. Brightness is quantized to a small ramp of the theme's text → dim → faint colors, so cells render as `StyledText` runs rather than true alpha. Ripples are seeded at random ambient points and expand outward; the effect reads as overlapping circular waves, not noise (mirrors Apollo's `FieldCanvas`, but cell-based).
+### 3. A breathing sea drawn with glyphs and per-cell fg color
+A grid of cells covers the terminal. Each cell's brightness is a pure function of position and time: two crossed plane-wave swells whose interference reads as an undulating sea surface, scaled by a slow global breathing envelope (≈4 s period) that brightens and dims the whole field in place. Brightness is quantized to a small ramp of the theme's text → dim → faint colors, so cells render as `StyledText` runs rather than true alpha. Waves travel; nothing expands outward from a point — the motion is swell and breath, not rings. The model is deterministic (no PRNG, no per-seed state), so a resize never strands hidden state and tests can pin the field exactly.
 
-**Alternatives considered:** true alpha/SGR-blend per cell — not supported well in terminal cells and much more expensive; a single rolling glyph column — visually reads as "Matrix" noise, not waves. The ramp + expanding-ripple model is the right tradeoff.
+**Alternatives considered:** true alpha/SGR-blend per cell — not supported well in terminal cells and much more expensive; a single rolling glyph column — visually reads as "Matrix" noise, not waves; expanding rings from ambient seed points (the first implementation) — read as sonar pings rather than the sea, and need seed bookkeeping. The ramp + breathing-swell model is the right tradeoff.
+
+### 3a. The status line floats centered over the sea
+The status label is a full-screen absolutely-positioned overlay using the repo's centered-modal pattern (`justifyContent`/`alignItems: "center"`, as in `config-tui.ts`), so the caption sits at the visual center on both axes while the sea fills the whole terminal behind it. The label paints a small solid pill in `theme.overlay` — the palette's one opaque backdrop color — because `theme.bg` is transparent by theme contract and the sea would otherwise bleed through the text's own spaces.
 
 ### 4. Bounded work for large terminals and SSH
 - Cap the animation at ≈30 fps (same cadence Apollo uses).
@@ -51,14 +54,14 @@ A grid of cells covers the body area. Each cell's glyph and brightness is a func
 - This keeps CPU and ANSI output bounded so it stays smooth over SSH or a slow link.
 
 ### 5. Reduced motion → static frame
-Detect a reduced-motion preference and, when set, render one static frame of the ripple field instead of animating (the spec requires a static frame, not absence). Detection is the open question below; the default path uses a config/flag with a terminal-capability probe when available.
+Detect a reduced-motion preference and, when set, render one static frame of the sea field instead of animating (the spec requires a static frame, not absence). Detection is the open question below; the default path uses a config/flag with a terminal-capability probe when available.
 
 ### 6. Interrupt through the existing route interrupt
 The transition registers the route's interrupt handler on its scene. When `Ctrl+C` fires, the helper rejects/aborts the pending `load` (an abort signal the destination load can observe) and closes the transition, so `runHomeNavigationLoop` sees `interrupted` and exits without a destination starting.
 
 ## Risks / Trade-offs
 
-- **[A static-looking field on very large terminals]** → Clamp the evaluated grid and keep the coarse sampling; the wave still reads as a field, just at lower resolution.
+- **[A static-looking field on very large terminals]** → Clamp the evaluated grid and keep the coarse sampling; the sea still reads as a field, just at lower resolution.
 - **[Animation cost on slow links]** → The 30 fps cap and coarse grid bound ANSI output; if needed, drop to a lower fps under a detected slow link.
 - **[Aborting a load is hard when the destination does I/O without a signal]** → The abort signal is best-effort: `Ctrl+C` at minimum stops the animation and returns control; the destination's `await` resolves or rejects naturally and the helper closes the transition either way. The spec's observable behavior (interrupt returns control, no destination started) holds.
 - **[Reduced-motion detection in a terminal]** → May not be directly observable. Mitigation: a config/flag default, and treat an unknown value as "no preference" so the animation is still available; documented in the open question.

--- a/openspec/changes/add-wave-loading-transition/design.md
+++ b/openspec/changes/add-wave-loading-transition/design.md
@@ -1,0 +1,72 @@
+## Context
+
+See proposal.md - Why. The handoff happens inside `runHomeNavigationLoop` (`src/cli.ts`): `openDestination` runs a destination like `openSpecsBrowser`, which awaits `browseSpecs` → `loadSpecsView`/`assembleControlBoard` **before** the destination scene mounts. The previous scene's tree is already destroyed on close (`TuiScene.close()` destroys but leaves the frame painted, per `src/tui-session.ts`), so the last home frame sits on screen, frozen, while the load runs. Every destination in the home session shares this shape (`src/specs.ts`, `src/runs.ts`, `src/config-tui.ts`, `src/launch-tui.ts`), and all mount their scene via `sceneForRoute(route, ...)`.
+
+Relevant constraints from the existing architecture:
+- `TuiSession.openScene(id)` closes the current active scene and mounts a new one; the new scene paints over the previous frame with no blank frame and no alternate-screen toggle. This is the atomic-handoff primitive we already have.
+- `TuiScene` exposes `close()` and `requestInterrupt()`; the route's `onInterrupt` sets an `interrupted` flag the navigation loop checks.
+- Theme palette lives in `src/tui-theme.ts` (`theme.text`, `theme.dim`, `theme.faint`, etc.); `setTheme` swaps it.
+- Rendering is OpenTUI `BoxRenderable`/`TextRenderable`; backgrounds are transparent, so the field is drawn with fg-colored glyphs.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A reusable transition that mounts on the shared `TuiSession` while a destination loads, animates a character ripple field, and hands off atomically to the destination scene.
+- Only show it for genuinely slow loads (threshold), never extend the load, and never flash on fast loads.
+- Keep the transition cheap enough to run on large terminals and over SSH; honor reduced motion; support `Ctrl+C` interrupt.
+
+**Non-Goals:**
+- Not a splash/onboarding screen, not a permanent background.
+- Not changing the destination screens' own requirements (header, list, reader, etc. are untouched).
+- Not a generic async spinner API for arbitrary async work outside the home-session destination handoff.
+
+## Decisions
+
+### 1. Wrap the destination load in a transition-scene helper
+Introduce a helper (new module `src/loading-transition.ts`) shaped like:
+
+```
+withLoadingTransition(route, label, load): Promise<T>
+```
+
+- If `route` is undefined (non-interactive/piped) it just runs `load` unchanged — preserving the plain-output path.
+- It races `load` against a threshold delay (≈150 ms). If `load` wins, no transition is shown (spec: no flash). If the delay wins, it mounts a transition scene on `route.session` and animates until `load` settles.
+
+This is the single choke point that every destination's `browseSpecs`/`browseRuns`/`editConfigTui`/`launchRunTui` can pass through, so the transition is uniform rather than hand-rolled per screen.
+
+**Alternatives considered:** (a) a global loading overlay inside each destination — rejected, it would be duplicated per screen and must be mounted before each load anyway; (b) forcing every load through a shared loader component — heavier than needed; the helper wrapping the existing `await` is the smallest change.
+
+### 2. The transition is a real `TuiScene`, so handoff stays atomic
+The helper opens `sceneForRoute(route, "convoy-loading-scene")` when it decides to show. When `load` settles, the helper closes the transition scene; the destination's own `sceneForRoute(route, "<dest>")` mount then closes whatever scene is active. Because both are scenes on the same session, the frame is replaced in place — no blank frame, no alternate-screen exit/re-entry (the existing contract in `src/tui-session.ts`).
+
+### 3. Ripple field drawn with glyphs and per-cell fg color
+A grid of cells covers the body area. Each cell's glyph and brightness is a function of a set of expanding ripples (origin point, radius growing over time, decaying strength), evaluated per frame. Brightness is quantized to a small ramp of the theme's text → dim → faint colors, so cells render as `StyledText` runs rather than true alpha. Ripples are seeded at random ambient points and expand outward; the effect reads as overlapping circular waves, not noise (mirrors Apollo's `FieldCanvas`, but cell-based).
+
+**Alternatives considered:** true alpha/SGR-blend per cell — not supported well in terminal cells and much more expensive; a single rolling glyph column — visually reads as "Matrix" noise, not waves. The ramp + expanding-ripple model is the right tradeoff.
+
+### 4. Bounded work for large terminals and SSH
+- Cap the animation at ≈30 fps (same cadence Apollo uses).
+- Use a coarse cell grid (e.g. one cell per ~2 columns/rows) and skip cells entirely on very large terminals by clamping the evaluated grid to a maximum size; the field covers the screen but is not sampled at every terminal cell.
+- Recompute the field in a throttled ticker; render only when a frame is due.
+- This keeps CPU and ANSI output bounded so it stays smooth over SSH or a slow link.
+
+### 5. Reduced motion → static frame
+Detect a reduced-motion preference and, when set, render one static frame of the ripple field instead of animating (the spec requires a static frame, not absence). Detection is the open question below; the default path uses a config/flag with a terminal-capability probe when available.
+
+### 6. Interrupt through the existing route interrupt
+The transition registers the route's interrupt handler on its scene. When `Ctrl+C` fires, the helper rejects/aborts the pending `load` (an abort signal the destination load can observe) and closes the transition, so `runHomeNavigationLoop` sees `interrupted` and exits without a destination starting.
+
+## Risks / Trade-offs
+
+- **[A static-looking field on very large terminals]** → Clamp the evaluated grid and keep the coarse sampling; the wave still reads as a field, just at lower resolution.
+- **[Animation cost on slow links]** → The 30 fps cap and coarse grid bound ANSI output; if needed, drop to a lower fps under a detected slow link.
+- **[Aborting a load is hard when the destination does I/O without a signal]** → The abort signal is best-effort: `Ctrl+C` at minimum stops the animation and returns control; the destination's `await` resolves or rejects naturally and the helper closes the transition either way. The spec's observable behavior (interrupt returns control, no destination started) holds.
+- **[Reduced-motion detection in a terminal]** → May not be directly observable. Mitigation: a config/flag default, and treat an unknown value as "no preference" so the animation is still available; documented in the open question.
+
+## Migration Plan
+
+This is additive. No persistent state, no data migration, no schema change. Rollback is reverting the change — the helper is a thin wrapper, so destination behavior without it is unchanged. Default off for non-interactive paths; only the interactive home-session handoff gains the transition.
+
+## Open Questions
+
+- How to reliably detect a reduced-motion preference in a terminal app? Options: a `ui.reducedMotion` config flag (default `false`/`auto`), an environment variable, or an ANSI/OS-level probe. This can be settled during implementation without changing the specs (the requirement is "honor it when set") or the task breakdown, but a concrete detection mechanism should be chosen before coding the reduced-motion path.

--- a/openspec/changes/add-wave-loading-transition/proposal.md
+++ b/openspec/changes/add-wave-loading-transition/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+When an operator enters a destination from the home launcher — most noticeably the specs browser — the screen that was just shown stays painted but stops responding while the destination loads. `loadSpecsView` reads the OpenSpec tree, and `assembleControlBoard` shells out to Git and the `openspec` CLI to derive worktree, task, and run state. On a repo with many changes this reads as a frozen menu for a beat or two. The wait is real but currently invisible.
+
+## What Changes
+
+- Introduce a reusable loading-transition screen that animates a soft field of expanding character "ripples" (waves) in the current theme while a destination loads.
+- Show the transition only for genuine load time, with a short threshold (≈150 ms) so fast loads do not flash it.
+- Replace the transition with the destination as soon as it is ready; never extend the load to finish an animation.
+- Paint the transition with OpenTUI renderables (no images, no canvas), sized to the terminal and bounded so large terminals and SSH sessions stay responsive.
+- Keep the existing scene handoff semantics: no blank frame, no alternate-screen exit/re-entry between screens.
+- Support `Ctrl+C` to interrupt the load and return control, and degrade gracefully to a plain status message when the destination cannot be loaded or the terminal is not interactive.
+- Honor reduced-motion preferences by rendering a static frame instead of animating.
+
+## Capabilities
+
+### New Capabilities
+- `loading-transition`: A shared transition screen shown while a destination within the home session loads, animating character-based waves in the current theme and handing off to the destination atomically.
+
+### Modified Capabilities
+- (none — the destination screens themselves do not change their requirements; only the handoff between them gains a transition.)
+
+## Impact
+
+- Affected source: `src/tui-session.ts` (scene handoff), the destination launchers (`src/home-tui.ts`, `src/specs.ts`), and a new module for the transition renderable (e.g. `src/loading-transition.ts`).
+- No new runtime dependencies; the wave field is computed in-process and drawn through the existing OpenTUI renderer.
+- Behavior is additive and non-breaking: non-interactive and piped invocations keep their current plain-text paths.

--- a/openspec/changes/add-wave-loading-transition/proposal.md
+++ b/openspec/changes/add-wave-loading-transition/proposal.md
@@ -4,7 +4,7 @@ When an operator enters a destination from the home launcher — most noticeably
 
 ## What Changes
 
-- Introduce a reusable loading-transition screen that animates a soft field of expanding character "ripples" (waves) in the current theme while a destination loads.
+- Introduce a reusable loading-transition screen that animates a breathing sea of characters (traveling swells under a slow global pulse) in the current theme while a destination loads, with the status line centered over the field.
 - Show the transition only for genuine load time, with a short threshold (≈150 ms) so fast loads do not flash it.
 - Replace the transition with the destination as soon as it is ready; never extend the load to finish an animation.
 - Paint the transition with OpenTUI renderables (no images, no canvas), sized to the terminal and bounded so large terminals and SSH sessions stay responsive.
@@ -15,7 +15,7 @@ When an operator enters a destination from the home launcher — most noticeably
 ## Capabilities
 
 ### New Capabilities
-- `loading-transition`: A shared transition screen shown while a destination within the home session loads, animating character-based waves in the current theme and handing off to the destination atomically.
+- `loading-transition`: A shared transition screen shown while a destination within the home session loads, animating a breathing sea of characters in the current theme and handing off to the destination atomically.
 
 ### Modified Capabilities
 - (none — the destination screens themselves do not change their requirements; only the handoff between them gains a transition.)

--- a/openspec/changes/add-wave-loading-transition/specs/loading-transition/spec.md
+++ b/openspec/changes/add-wave-loading-transition/specs/loading-transition/spec.md
@@ -1,6 +1,6 @@
 ## Purpose
 
-Defines the shared transition screen Convoy shows while a destination in the home session loads, animating a soft field of character ripples in the current theme and handing off to the destination atomically so an operator is never left staring at an unresponsive, frozen menu.
+Defines the shared transition screen Convoy shows while a destination in the home session loads, animating a breathing sea of characters in the current theme and handing off to the destination atomically so an operator is never left staring at an unresponsive, frozen menu.
 
 ## ADDED Requirements
 
@@ -20,17 +20,29 @@ When an operator opens a destination from the home launcher, Convoy SHALL begin 
 - **WHEN** the destination becomes ready while the transition is visible
 - **THEN** the destination replaces the transition immediately and the transition is not held for any animation to finish
 
-### Requirement: Transition animates character ripples in the current theme
+### Requirement: Transition animates a breathing sea in the current theme
 
-The loading transition SHALL render a field of characters whose brightness, density, or position undulates in expanding ripples, in the terminal's current foreground and background theme. The animation SHALL be a coherent wave effect, not random noise or a scrolling glyph column.
+The loading transition SHALL render a field of characters whose brightness undulates like a sea surface — swells that travel across the field while the whole surface brightens and dims in place under a slow global pulse — in the terminal's current foreground and background theme. The animation SHALL be a coherent wave effect; it SHALL NOT read as expanding rings, random noise, or a scrolling glyph column.
 
-#### Scenario: Ripples use the theme palette
+#### Scenario: The sea uses the theme palette
 - **WHEN** the transition renders in a light or dark terminal
 - **THEN** its characters are drawn in the matching theme palette and remain legible against the theme background
 
-#### Scenario: Ripples are animated
+#### Scenario: The sea breathes and undulates
 - **WHEN** the transition is visible for more than a single frame
-- **THEN** the character field changes over time in an expanding-wave pattern rather than remaining static or shuffling randomly
+- **THEN** the character field changes over time as swells travel and the whole surface's brightness pulses in place, rather than remaining static, shuffling randomly, or expanding rings outward from points
+
+### Requirement: The status line is centered over the field
+
+While the transition is visible, the loading status line SHALL be centered horizontally and vertically over the animated field, and SHALL remain legible above it.
+
+#### Scenario: The status line sits at the center
+- **WHEN** the transition renders on any terminal size
+- **THEN** the status line is positioned at the horizontal and vertical center of the terminal, floating above the field
+
+#### Scenario: The status line stays legible
+- **WHEN** the animated field passes beneath the status line
+- **THEN** the field does not bleed through the status text's own spacing, so the message reads as continuous words
 
 ### Requirement: Handoff to the destination is atomic
 
@@ -66,11 +78,11 @@ While the transition is visible, `Ctrl+C` SHALL interrupt the pending load, stop
 
 ### Requirement: Reduced motion renders a static frame
 
-When the operator has expressed a reduced-motion preference, the transition SHALL render a static frame of the ripple field instead of animating it, so the screen remains informative without motion.
+When the operator has expressed a reduced-motion preference, the transition SHALL render a static frame of the sea field instead of animating it, so the screen remains informative without motion.
 
 #### Scenario: Reduced motion is honored
 - **WHEN** the operator prefers reduced motion and a destination loads slowly
-- **THEN** a static ripple field renders in place of the animation and the destination replaces it when ready
+- **THEN** a static sea field renders in place of the animation and the destination replaces it when ready
 
 ### Requirement: Load failure degrades gracefully
 

--- a/openspec/changes/add-wave-loading-transition/specs/loading-transition/spec.md
+++ b/openspec/changes/add-wave-loading-transition/specs/loading-transition/spec.md
@@ -1,0 +1,81 @@
+## Purpose
+
+Defines the shared transition screen Convoy shows while a destination in the home session loads, animating a soft field of character ripples in the current theme and handing off to the destination atomically so an operator is never left staring at an unresponsive, frozen menu.
+
+## ADDED Requirements
+
+### Requirement: Transition is shown only during a real load
+
+When an operator opens a destination from the home launcher, Convoy SHALL begin loading that destination and SHALL render the loading transition only while the load is genuinely in progress. If the load completes within a short threshold (nominally 150 ms), Convoy SHALL NOT flash the transition and SHALL move straight to the destination.
+
+#### Scenario: Fast load shows no transition
+- **WHEN** the operator opens a destination whose load completes within the threshold
+- **THEN** the destination renders immediately and no loading transition is shown
+
+#### Scenario: Slow load shows the transition
+- **WHEN** the operator opens a destination whose load exceeds the threshold
+- **THEN** the loading transition is rendered until the destination is ready, then the destination replaces it
+
+#### Scenario: Transition never extends the load
+- **WHEN** the destination becomes ready while the transition is visible
+- **THEN** the destination replaces the transition immediately and the transition is not held for any animation to finish
+
+### Requirement: Transition animates character ripples in the current theme
+
+The loading transition SHALL render a field of characters whose brightness, density, or position undulates in expanding ripples, in the terminal's current foreground and background theme. The animation SHALL be a coherent wave effect, not random noise or a scrolling glyph column.
+
+#### Scenario: Ripples use the theme palette
+- **WHEN** the transition renders in a light or dark terminal
+- **THEN** its characters are drawn in the matching theme palette and remain legible against the theme background
+
+#### Scenario: Ripples are animated
+- **WHEN** the transition is visible for more than a single frame
+- **THEN** the character field changes over time in an expanding-wave pattern rather than remaining static or shuffling randomly
+
+### Requirement: Handoff to the destination is atomic
+
+The transition SHALL hand off to the loaded destination without a blank frame and without exiting and re-entering the alternate screen between Convoy screens. The transition SHALL remain painted until the destination scene replaces it.
+
+#### Scenario: No blank frame at handoff
+- **WHEN** the destination is ready and replaces the transition
+- **THEN** the destination scene paints over the transition directly with no cleared frame in between
+
+#### Scenario: No alternate-screen toggle
+- **WHEN** the transition is replaced by the destination
+- **THEN** the terminal does not exit and re-enter the alternate screen during the handoff
+
+### Requirement: Transition stays responsive on large terminals and remote sessions
+
+The transition SHALL bound its work so it animates smoothly on large terminals and does not stall over SSH or a slow link. Convoy SHALL cap the animation frame rate and limit the number of cells evaluated per frame, and SHALL skip the animation entirely (falling back to a static message) when the terminal is not interactive.
+
+#### Scenario: Large terminal stays responsive
+- **WHEN** the transition renders on a terminal larger than a typical workstation size
+- **THEN** the frame rate and computation remain bounded and the animation does not make the terminal unresponsive
+
+#### Scenario: Non-interactive invocation skips animation
+- **WHEN** the destination is opened with stdin or stdout not a TTY
+- **THEN** no animated transition renders and the existing non-interactive plain output path is used
+
+### Requirement: Transition can be interrupted
+
+While the transition is visible, `Ctrl+C` SHALL interrupt the pending load, stop the transition, and return control to the operator without starting the destination or leaving the terminal in an unstable state.
+
+#### Scenario: Interrupt cancels the load
+- **WHEN** the operator presses `Ctrl+C` while the transition is visible
+- **THEN** the pending destination load is cancelled, the transition stops, and control returns cleanly without a run or destination being started
+
+### Requirement: Reduced motion renders a static frame
+
+When the operator has expressed a reduced-motion preference, the transition SHALL render a static frame of the ripple field instead of animating it, so the screen remains informative without motion.
+
+#### Scenario: Reduced motion is honored
+- **WHEN** the operator prefers reduced motion and a destination loads slowly
+- **THEN** a static ripple field renders in place of the animation and the destination replaces it when ready
+
+### Requirement: Load failure degrades gracefully
+
+If a destination cannot be loaded, the transition SHALL yield to a plain status message rather than hanging, and Convoy SHALL return control to the operator without leaving a stale or broken screen.
+
+#### Scenario: Load failure reports the reason
+- **WHEN** the destination load fails while the transition is visible
+- **THEN** the transition gives way to a readable status message naming the failure, and control returns without a dead screen

--- a/openspec/changes/add-wave-loading-transition/tasks.md
+++ b/openspec/changes/add-wave-loading-transition/tasks.md
@@ -4,9 +4,9 @@
 - [x] 1.2 Make the helper run `load` directly when `route` is undefined, and verify the non-interactive/piped path still prints the existing plain output with no TUI scene mounted.
 - [x] 1.3 Race `load` against a configurable threshold (~150 ms) so a fast load shows no transition, and verify with a unit test that a load resolving under the threshold mounts no transition scene.
 
-## 2. Ripple field renderer
+## 2. Breathing sea renderer
 
-- [x] 2.1 Implement the ripple model (ambient seeds expanding as circular waves, decaying strength) and verify a pure geometry function returns per-cell glyph + brightness for a given time and grid.
+- [x] 2.1 Implement the sea model (two crossed traveling swells under a slow global breathing envelope, a pure function of position and time) and verify a pure geometry function returns per-cell glyph + brightness for a given time and grid.
 - [x] 2.2 Map each cell's brightness onto a ramp of the current theme colors (text → dim → faint) and verify the rendered `StyledText` runs use only those palette colors and stay legible on light and dark themes.
 - [x] 2.3 Draw the field as a coarse, clamped grid at ~30 fps and verify on a large terminal size that the frame rate and per-frame cell count stay bounded (no per-terminal-cell sampling).
 
@@ -15,6 +15,7 @@
 - [x] 3.1 Mount the transition as a `TuiScene` via `sceneForRoute(route, "convoy-loading-scene")` when the load outlasts the threshold, and verify it replaces the prior frame with no blank frame or alternate-screen toggle.
 - [x] 3.2 Close the transition scene when `load` settles and verify the destination's own `sceneForRoute` mount paints over it atomically.
 - [x] 3.3 Route the specs browser through `withLoadingTransition` around `loadSpecsView`/`browseSpecs`, and verify `convoy specs` on a repo with many changes shows the transition only when the load is slow.
+- [x] 3.4 Center the status line over the field on both axes (absolute overlay with centered alignment) on a solid `theme.overlay` pill, and verify the label sits in the middle band of the frame and stays legible over the animated sea.
 
 ## 4. Interrupt, reduced motion, and graceful failure
 

--- a/openspec/changes/add-wave-loading-transition/tasks.md
+++ b/openspec/changes/add-wave-loading-transition/tasks.md
@@ -1,28 +1,28 @@
 ## 1. Transition module and scene helper
 
-- [ ] 1.1 Create `src/loading-transition.ts` exporting `withLoadingTransition<T>(route: TuiRoute | undefined, label: string | undefined, load: () => Promise<T>): Promise<T>`, and verify the file typechecks (`bun run typecheck`).
-- [ ] 1.2 Make the helper run `load` directly when `route` is undefined, and verify the non-interactive/piped path still prints the existing plain output with no TUI scene mounted.
-- [ ] 1.3 Race `load` against a configurable threshold (~150 ms) so a fast load shows no transition, and verify with a unit test that a load resolving under the threshold mounts no transition scene.
+- [x] 1.1 Create `src/loading-transition.ts` exporting `withLoadingTransition<T>(route: TuiRoute | undefined, label: string | undefined, load: () => Promise<T>): Promise<T>`, and verify the file typechecks (`bun run typecheck`).
+- [x] 1.2 Make the helper run `load` directly when `route` is undefined, and verify the non-interactive/piped path still prints the existing plain output with no TUI scene mounted.
+- [x] 1.3 Race `load` against a configurable threshold (~150 ms) so a fast load shows no transition, and verify with a unit test that a load resolving under the threshold mounts no transition scene.
 
 ## 2. Ripple field renderer
 
-- [ ] 2.1 Implement the ripple model (ambient seeds expanding as circular waves, decaying strength) and verify a pure geometry function returns per-cell glyph + brightness for a given time and grid.
-- [ ] 2.2 Map each cell's brightness onto a ramp of the current theme colors (text → dim → faint) and verify the rendered `StyledText` runs use only those palette colors and stay legible on light and dark themes.
-- [ ] 2.3 Draw the field as a coarse, clamped grid at ~30 fps and verify on a large terminal size that the frame rate and per-frame cell count stay bounded (no per-terminal-cell sampling).
+- [x] 2.1 Implement the ripple model (ambient seeds expanding as circular waves, decaying strength) and verify a pure geometry function returns per-cell glyph + brightness for a given time and grid.
+- [x] 2.2 Map each cell's brightness onto a ramp of the current theme colors (text → dim → faint) and verify the rendered `StyledText` runs use only those palette colors and stay legible on light and dark themes.
+- [x] 2.3 Draw the field as a coarse, clamped grid at ~30 fps and verify on a large terminal size that the frame rate and per-frame cell count stay bounded (no per-terminal-cell sampling).
 
 ## 3. Wire the transition into the destination handoff
 
-- [ ] 3.1 Mount the transition as a `TuiScene` via `sceneForRoute(route, "convoy-loading-scene")` when the load outlasts the threshold, and verify it replaces the prior frame with no blank frame or alternate-screen toggle.
-- [ ] 3.2 Close the transition scene when `load` settles and verify the destination's own `sceneForRoute` mount paints over it atomically.
-- [ ] 3.3 Route the specs browser through `withLoadingTransition` around `loadSpecsView`/`browseSpecs`, and verify `convoy specs` on a repo with many changes shows the transition only when the load is slow.
+- [x] 3.1 Mount the transition as a `TuiScene` via `sceneForRoute(route, "convoy-loading-scene")` when the load outlasts the threshold, and verify it replaces the prior frame with no blank frame or alternate-screen toggle.
+- [x] 3.2 Close the transition scene when `load` settles and verify the destination's own `sceneForRoute` mount paints over it atomically.
+- [x] 3.3 Route the specs browser through `withLoadingTransition` around `loadSpecsView`/`browseSpecs`, and verify `convoy specs` on a repo with many changes shows the transition only when the load is slow.
 
 ## 4. Interrupt, reduced motion, and graceful failure
 
-- [ ] 4.1 Register the route's interrupt handler on the transition scene so `Ctrl+C` stops the animation and returns control without a destination starting, and verify interrupt exits cleanly.
-- [ ] 4.2 Render a static frame instead of animating when a reduced-motion preference is set (config flag `ui.reducedMotion` defaulting to auto/probe), and verify the static frame renders and is replaced by the destination when ready.
-- [ ] 4.3 Make a failed destination load give way to a readable status message and return control, and verify no stale/broken screen remains.
+- [x] 4.1 Register the route's interrupt handler on the transition scene so `Ctrl+C` stops the animation and returns control without a destination starting, and verify interrupt exits cleanly.
+- [x] 4.2 Render a static frame instead of animating when a reduced-motion preference is set (config flag `ui.reducedMotion` defaulting to auto/probe), and verify the static frame renders and is replaced by the destination when ready.
+- [x] 4.3 Make a failed destination load give way to a readable status message and return control, and verify no stale/broken screen remains.
 
 ## 5. Verification
 
-- [ ] 5.1 Run `bun run typecheck` and the test suite (`bun test`) and verify all existing and new tests pass.
+- [x] 5.1 Run `bun run typecheck` and the test suite (`bun test`) and verify all existing and new tests pass.
 - [ ] 5.2 Manually run `convoy` on a repo with active OpenSpec changes, open Specs, and verify the transition appears only during a real load, animates as waves, and hands off without a flash or frozen frame.

--- a/openspec/changes/add-wave-loading-transition/tasks.md
+++ b/openspec/changes/add-wave-loading-transition/tasks.md
@@ -1,0 +1,28 @@
+## 1. Transition module and scene helper
+
+- [ ] 1.1 Create `src/loading-transition.ts` exporting `withLoadingTransition<T>(route: TuiRoute | undefined, label: string | undefined, load: () => Promise<T>): Promise<T>`, and verify the file typechecks (`bun run typecheck`).
+- [ ] 1.2 Make the helper run `load` directly when `route` is undefined, and verify the non-interactive/piped path still prints the existing plain output with no TUI scene mounted.
+- [ ] 1.3 Race `load` against a configurable threshold (~150 ms) so a fast load shows no transition, and verify with a unit test that a load resolving under the threshold mounts no transition scene.
+
+## 2. Ripple field renderer
+
+- [ ] 2.1 Implement the ripple model (ambient seeds expanding as circular waves, decaying strength) and verify a pure geometry function returns per-cell glyph + brightness for a given time and grid.
+- [ ] 2.2 Map each cell's brightness onto a ramp of the current theme colors (text → dim → faint) and verify the rendered `StyledText` runs use only those palette colors and stay legible on light and dark themes.
+- [ ] 2.3 Draw the field as a coarse, clamped grid at ~30 fps and verify on a large terminal size that the frame rate and per-frame cell count stay bounded (no per-terminal-cell sampling).
+
+## 3. Wire the transition into the destination handoff
+
+- [ ] 3.1 Mount the transition as a `TuiScene` via `sceneForRoute(route, "convoy-loading-scene")` when the load outlasts the threshold, and verify it replaces the prior frame with no blank frame or alternate-screen toggle.
+- [ ] 3.2 Close the transition scene when `load` settles and verify the destination's own `sceneForRoute` mount paints over it atomically.
+- [ ] 3.3 Route the specs browser through `withLoadingTransition` around `loadSpecsView`/`browseSpecs`, and verify `convoy specs` on a repo with many changes shows the transition only when the load is slow.
+
+## 4. Interrupt, reduced motion, and graceful failure
+
+- [ ] 4.1 Register the route's interrupt handler on the transition scene so `Ctrl+C` stops the animation and returns control without a destination starting, and verify interrupt exits cleanly.
+- [ ] 4.2 Render a static frame instead of animating when a reduced-motion preference is set (config flag `ui.reducedMotion` defaulting to auto/probe), and verify the static frame renders and is replaced by the destination when ready.
+- [ ] 4.3 Make a failed destination load give way to a readable status message and return control, and verify no stale/broken screen remains.
+
+## 5. Verification
+
+- [ ] 5.1 Run `bun run typecheck` and the test suite (`bun test`) and verify all existing and new tests pass.
+- [ ] 5.2 Manually run `convoy` on a repo with active OpenSpec changes, open Specs, and verify the transition appears only during a real load, animates as waves, and hands off without a flash or frozen frame.

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,6 +58,19 @@ export type ConvoyConfig = {
    * keep the built-in defaults; `enabled: false` turns the whole guard off.
    */
   loopGuard?: LoopGuardSettings
+  /** Terminal-experience tweaks; only keys the user set take effect. */
+  ui?: UiConfig
+}
+
+/** TUI motion preferences; see the loading-transition capability. */
+export type UiConfig = {
+  /**
+   * Motion for the home session's loading transition: "auto" (the default)
+   * probes the OS reduce-motion setting, "on" always renders a static frame,
+   * "off" always animates. The CONVOY_REDUCED_MOTION environment variable
+   * outranks this.
+   */
+  reducedMotion?: "auto" | "on" | "off"
 }
 
 export type ConvoyDefaults = {
@@ -218,6 +231,7 @@ export function mergeConvoyConfigs(global: ConvoyConfig | undefined, project: Co
       overrides: mergeRoutingOverrides(global.modelRouting?.overrides ?? {}, project.modelRouting?.overrides ?? {}),
     },
     ...(global.loopGuard || project.loopGuard ? { loopGuard: { ...global.loopGuard, ...project.loopGuard } } : {}),
+    ...(global.ui || project.ui ? { ui: { ...global.ui, ...project.ui } } : {}),
   }
 }
 
@@ -294,6 +308,13 @@ defaults:
 #   sameToolFailures: 6    # same tool failing in a row (args may drift)
 #   maxSteps: 200          # hard budget gate; a best-effort model-only nudge is queued at half this value
 #   maxPhaseCost: 20       # USD; false to disable the cost fuse
+
+# Terminal motion for the home session's loading transition. "auto" (the
+# default) honors the OS reduce-motion setting; "on" always renders a static
+# frame; "off" always animates. The CONVOY_REDUCED_MOTION environment variable
+# outranks this.
+# ui:
+#   reducedMotion: auto
 
 # Agents are matched by name with Markdown prompts next to this config:
 #   agents/<name>.md
@@ -515,7 +536,7 @@ export function parseConvoyConfig(body: string, source: string, targetDir: strin
   const root = v.record(raw, "")
   // Unknown keys warn instead of failing so configs written for a newer
   // convoy still load; typos surface in the warning either way.
-  v.knownKeys(root, "", ["version", "defaults", "agents", "pipelines", "permissions", "hooks", "attachments", "notifications", "modelRouting", "loopGuard"])
+  v.knownKeys(root, "", ["version", "defaults", "agents", "pipelines", "permissions", "hooks", "attachments", "notifications", "modelRouting", "loopGuard", "ui"])
 
   if (root.version !== undefined && root.version !== 1) v.fail("version", `unsupported value ${JSON.stringify(root.version)}; this convoy reads version 1`)
 
@@ -533,8 +554,22 @@ export function parseConvoyConfig(body: string, source: string, targetDir: strin
   if (root.notifications !== undefined) config.notifications = validateNotifications(v, root.notifications)
   if (root.modelRouting !== undefined) config.modelRouting = validateModelRouting(v, root.modelRouting)
   if (root.loopGuard !== undefined) config.loopGuard = validateLoopGuard(v, root.loopGuard)
+  if (root.ui !== undefined) config.ui = validateUi(v, root.ui)
 
   return config
+}
+
+function validateUi(v: Validator, raw: unknown): UiConfig {
+  const record = v.record(raw, "ui")
+  v.knownKeys(record, "ui", ["reducedMotion"])
+  const ui: UiConfig = {}
+  if (record.reducedMotion !== undefined) {
+    if (record.reducedMotion !== "auto" && record.reducedMotion !== "on" && record.reducedMotion !== "off") {
+      v.fail("ui.reducedMotion", 'must be "auto", "on", or "off"')
+    }
+    ui.reducedMotion = record.reducedMotion as UiConfig["reducedMotion"]
+  }
+  return ui
 }
 
 /**
@@ -1133,6 +1168,7 @@ export function serializeConvoyConfig(config: ConvoyConfig): string {
   if (Object.keys(config.notifications).length > 0) out.notifications = config.notifications
   if (config.modelRouting && (config.modelRouting.gateway !== undefined || Object.keys(config.modelRouting.overrides).length > 0)) out.modelRouting = config.modelRouting
   if (config.loopGuard && Object.keys(config.loopGuard).length > 0) out.loopGuard = config.loopGuard
+  if (config.ui && Object.keys(config.ui).length > 0) out.ui = config.ui
   return Bun.YAML.stringify(out, null, 2)
 }
 

--- a/src/loading-transition.ts
+++ b/src/loading-transition.ts
@@ -1,0 +1,478 @@
+import { BoxRenderable, StyledText, TextRenderable, fg } from "@opentui/core"
+
+import { joinLines, paletteForTerminal, raw, setTheme, terminalBackgroundHex, theme } from "./tui-theme"
+import { sceneForRoute, type TuiRoute, type TuiScene } from "./tui-session"
+
+import type { CliRenderer, KeyEvent, TextChunk } from "@opentui/core"
+
+/**
+ * The shared loading transition of the home session: while a destination load
+ * outlasts a short threshold, a scene of expanding character ripples replaces
+ * the frozen home frame, and the destination's own scene mount paints over it
+ * atomically (the same contract every home-session screen already uses —
+ * scenes close only when the next one mounts). Rejected or interrupted loads
+ * never leave a dead screen, and loads that finish quickly never flash it.
+ *
+ * OpenTUI is imported eagerly by this module, so it is only ever loaded on
+ * interactive paths (specs.ts dynamic-imports it under `route`).
+ */
+
+/** Quiet period before a slow load earns the transition (no flash on fast loads). */
+export const loadingThresholdMs = 150
+
+/** Animation cadence cap (~30 fps): bounds CPU and ANSI output over SSH. */
+const frameIntervalMs = 1000 / 30
+
+/** A rejected or slow motion-preference source degrades to "animate". */
+const motionResolveBoundMs = 400
+const motionProbeKillMs = 250
+
+/**
+ * Thrown when the operator presses Ctrl+C while the transition is visible.
+ * Callers map it to a quiet exit — the route's interrupt flag already told
+ * the home session to quit — rather than opening the destination.
+ */
+export class LoadingInterruptedError extends Error {
+  constructor(message = "interrupted while loading") {
+    super(message)
+    this.name = "LoadingInterruptedError"
+  }
+}
+
+export function isLoadingInterrupted(error: unknown): error is LoadingInterruptedError {
+  return error instanceof LoadingInterruptedError || (error instanceof Error && error.name === "LoadingInterruptedError")
+}
+
+export type LoadingTransitionOptions = {
+  /** Overrides the no-flash threshold; tests shrink it to keep the suite fast. */
+  thresholdMs?: number
+  /** Directory the default reduced-motion resolver reads project config from. */
+  targetDir?: string
+  /** Overrides the motion preference: a boolean, or a resolver consulted after the threshold wins (tests inject fakes). */
+  reducedMotion?: boolean | (() => boolean | Promise<boolean>)
+}
+
+/**
+ * Runs `load`, showing the ripple transition on the route's session only when
+ * the load genuinely outlasts the threshold. Without a route (non-interactive
+ * and piped invocations) the load runs unchanged. Every settlement path leaves
+ * the session healthy: the transition stops animating as soon as the load
+ * settles, and the destination's own scene mount replaces it in place.
+ */
+export async function withLoadingTransition<T>(
+  route: TuiRoute | undefined,
+  label: string | undefined,
+  load: () => Promise<T>,
+  options: LoadingTransitionOptions = {},
+): Promise<T> {
+  if (!route) return load()
+
+  const threshold = options.thresholdMs ?? loadingThresholdMs
+  let loadSettled = false
+  const loadPromise = load().then(
+    (value) => {
+      loadSettled = true
+      return value
+    },
+    (error) => {
+      loadSettled = true
+      throw error
+    },
+  )
+
+  // Fast loads win the race before the threshold fires: no scene, no flash.
+  const winner = await Promise.race([loadPromise.then(() => "load" as const), delay(threshold).then(() => "threshold" as const)])
+  if (winner === "load") return loadPromise
+
+  // The load is genuinely slow. Resolve the motion preference without ever
+  // holding the destination back — whichever settles first wins, so a load
+  // finishing during resolution skips the transition entirely.
+  const resolved = await Promise.race([
+    loadPromise.then((): { kind: "load" } => ({ kind: "load" })),
+    resolveReducedMotion(options).then((reducedMotion): { kind: "pref"; reducedMotion: boolean } => ({ kind: "pref", reducedMotion })),
+  ])
+  if (loadSettled || resolved.kind === "load") return loadPromise
+
+  const scene = sceneForRoute(route, "convoy-loading-scene")!
+  let rejectInterrupt!: (error: LoadingInterruptedError) => void
+  const interrupted = new Promise<never>((_, reject) => {
+    rejectInterrupt = reject
+  })
+  const transition = new LoadingTransition(route.session.renderer, scene, {
+    ...(label === undefined ? {} : { label }),
+    reducedMotion: resolved.reducedMotion,
+    onInterrupt: () =>
+      rejectInterrupt(new LoadingInterruptedError(label === undefined ? "interrupted while loading" : `interrupted while loading ${label}`)),
+  })
+  try {
+    return await Promise.race([loadPromise, interrupted])
+  } catch (error) {
+    transition.stop()
+    if (!isLoadingInterrupted(error)) {
+      // The transition yields to a readable status message naming the failure;
+      // the original error still propagates to the caller.
+      const reason = error instanceof Error ? error.message : String(error)
+      const { showNoticeTui } = await import("./notice-tui")
+      try {
+        await showNoticeTui(route, {
+          title: label ?? "loading",
+          message: `couldn't load${label ? ` ${label}` : ""}: ${reason}`,
+        })
+      } catch {
+        // The session is going away; the original failure still reports.
+      }
+    }
+    throw error
+  } finally {
+    transition.stop()
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * Motion preference for the transition, in precedence order: the
+ * CONVOY_REDUCED_MOTION environment variable, the config flag
+ * `ui.reducedMotion`, then the OS accessibility probe. "auto" and unset
+ * values fall through; an unknown value is never treated as a preference.
+ */
+export async function defaultReducedMotion(targetDir?: string): Promise<boolean> {
+  const env = envReducedMotion()
+  if (env !== undefined) return env
+  try {
+    const { loadGlobalConvoyConfig, loadMergedConvoyConfig } = await import("./config")
+    const config = targetDir ? await loadMergedConvoyConfig(targetDir) : await loadGlobalConvoyConfig()
+    const mode = config?.ui?.reducedMotion
+    if (mode === "on") return true
+    if (mode === "off") return false
+  } catch {
+    // A broken config degrades to the probe rather than blocking the transition.
+  }
+  return probeReducedMotion()
+}
+
+/** Session-level override; undefined means "no opinion". */
+export function envReducedMotion(): boolean | undefined {
+  const value = process.env.CONVOY_REDUCED_MOTION
+  if (value === "1" || value === "true" || value === "on") return true
+  if (value === "0" || value === "false" || value === "off") return false
+  return undefined
+}
+
+/** Bounded wrapper: a slow or failing preference source degrades to "animate". */
+async function resolveReducedMotion(options: LoadingTransitionOptions): Promise<boolean> {
+  const preference = options.reducedMotion
+  const resolved = (async () => {
+    try {
+      if (preference === undefined) return defaultReducedMotion(options.targetDir)
+      if (typeof preference === "function") return await preference()
+      return preference
+    } catch {
+      return false
+    }
+  })()
+  return Promise.race([resolved, delay(motionResolveBoundMs).then(() => false)])
+}
+
+let probePromise: Promise<boolean> | undefined
+
+/**
+ * The OS reduce-motion accessibility setting, probed once per process and
+ * killed after a short bound so it can never stall the transition. Platforms
+ * without a probe answer "no preference".
+ */
+export function probeReducedMotion(): Promise<boolean> {
+  probePromise ??= (async () => {
+    if (process.platform !== "darwin") return false
+    try {
+      const proc = Bun.spawn(["defaults", "read", "com.apple.universalaccess", "reduceMotion"], { stdout: "pipe", stderr: "ignore" })
+      const killer = setTimeout(() => proc.kill(), motionProbeKillMs)
+      const text = await new Response(proc.stdout).text()
+      await proc.exited
+      clearTimeout(killer)
+      return text.trim() === "1"
+    } catch {
+      return false
+    }
+  })()
+  return probePromise
+}
+
+// ── the ripple field (pure model, unit-testable without a renderer) ────────
+
+/** One expanding wave: a normalized origin, birth time, speed and lifespan. */
+export type RippleSeed = {
+  /** Origin in normalized grid coordinates, 0..1. */
+  x: number
+  y: number
+  /** Birth time in ms (the same clock the animator renders against). */
+  born: number
+  /** Expansion speed in grid cells per second. */
+  speed: number
+  /** Lifespan in seconds, after which the seed respawns. */
+  life: number
+}
+
+/** Small deterministic PRNG so tests can pin the field's geometry. */
+export function mulberry32(seed: number): () => number {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) | 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const waveSigmaCells = 1.4
+const waveFadeInMs = 500
+const seedMaxCount = 10
+const seedMinCount = 3
+
+/** Staggered ambient seeds, so even the first frame already shows waves. */
+export function createRippleSeeds(random: () => number, count: number, now: number): RippleSeed[] {
+  return Array.from({ length: count }, () => {
+    const life = 3 + random() * 2
+    return {
+      x: random(),
+      y: random(),
+      born: now - random() * 1_800,
+      speed: 5 + random() * 4,
+      life,
+    }
+  })
+}
+
+/** Seeds live in normalized space so a resize never strands them off-grid. */
+export function respawnSeed(seed: RippleSeed, random: () => number, now: number): RippleSeed {
+  return {
+    x: random(),
+    y: random(),
+    born: now + random() * 300,
+    speed: 5 + random() * 4,
+    life: 3 + random() * 2,
+  }
+}
+
+export function seedCountFor(cols: number, rows: number): number {
+  return Math.max(seedMinCount, Math.min(seedMaxCount, Math.round((cols * rows) / 1_000)))
+}
+
+/**
+ * Per-cell brightness in [0,1]: the sum of every seed's expanding gaussian
+ * ring, faded in at birth and decaying over its lifespan, clamped at 1.
+ */
+export function rippleIntensities(cols: number, rows: number, now: number, seeds: readonly RippleSeed[]): Float64Array {
+  const field = new Float64Array(cols * rows)
+  for (const seed of seeds) {
+    const age = (now - seed.born) / 1_000
+    if (age <= 0) continue
+    const decay = 1 - age / seed.life
+    if (decay <= 0) continue
+    const radius = seed.speed * age
+    const strength = decay * Math.min(1, age / (waveFadeInMs / 1_000))
+    const cx = seed.x * cols
+    const cy = seed.y * rows
+    for (let y = 0; y < rows; y++) {
+      const dy = y - cy
+      for (let x = 0; x < cols; x++) {
+        const dx = x - cx
+        const ring = Math.exp(-((Math.sqrt(dx * dx + dy * dy) - radius) ** 2) / (2 * waveSigmaCells * waveSigmaCells))
+        const index = y * cols + x
+        field[index] = Math.min(1, field[index]! + ring * strength)
+      }
+    }
+  }
+  return field
+}
+
+export type RampTone = "faint" | "dim" | "text"
+
+/**
+ * Brightness quantized onto the theme's faint → dim → text ramp; undefined
+ * cells stay blank. The wavefront reads bright, the tail fades out.
+ */
+export function intensityCell(intensity: number): { glyph: string; color: RampTone } | undefined {
+  if (intensity >= 0.82) return { glyph: "·", color: "text" }
+  if (intensity >= 0.55) return { glyph: ":", color: "dim" }
+  if (intensity >= 0.28) return { glyph: "·", color: "dim" }
+  if (intensity >= 0.08) return { glyph: "·", color: "faint" }
+  return undefined
+}
+
+/**
+ * The transition's sampling grid: one sample per two terminal columns and one
+ * row (a cell is roughly square on screen), clamped so very large terminals
+ * are never sampled per-cell. The painted output covers the full body anyway:
+ * {@linkcode paintSpan} stretches each sample's run at paint time, so a clamped
+ * grid means lower resolution, never a dead band at the screen's edge.
+ */
+export function transitionGrid(width: number, height: number): { cols: number; rows: number } {
+  return {
+    cols: Math.max(1, Math.min(110, Math.ceil(width / 2))),
+    rows: Math.max(1, Math.min(60, height)),
+  }
+}
+
+/**
+ * Terminal slots (columns, or rows) that sampled index `i` of `count` paints
+ * into `size`: proportional spans that sum to exactly `size`, so the field
+ * fills the terminal edge to edge while the evaluated grid stays clamped.
+ * `size >= count` keeps every sample painting at least one slot.
+ */
+export function paintSpan(i: number, count: number, size: number): number {
+  return Math.floor(((i + 1) * size) / count) - Math.floor((i * size) / count)
+}
+
+// ── the scene (OpenTUI renderables over the shared session) ────────────────
+
+type LoadingSceneOptions = {
+  label?: string
+  reducedMotion: boolean
+  onInterrupt: () => void
+}
+
+/**
+ * The mounted transition: a full-body glyph field plus a one-row status label.
+ * Follows the repo's screen lifecycle — the scene stays painted until the next
+ * scene mounts; {@linkcode stop} only detaches listeners and timers.
+ */
+class LoadingTransition {
+  private finished = false
+  private readonly t0 = performance.now()
+  private seeds: RippleSeed[] | undefined
+  private readonly random = mulberry32((Math.random() * 0xffffffff) >>> 0)
+  private readonly ticker: ReturnType<typeof setInterval> | undefined
+  private readonly fieldText: TextRenderable
+
+  constructor(
+    private readonly renderer: CliRenderer,
+    private readonly scene: TuiScene,
+    private readonly options: LoadingSceneOptions,
+  ) {
+    const shell = new BoxRenderable(renderer, {
+      id: "convoy-loading-shell",
+      width: "100%",
+      height: "100%",
+      backgroundColor: theme.bg,
+      flexDirection: "column",
+    })
+    const fieldBox = new BoxRenderable(renderer, { id: "convoy-loading-field", width: "100%", flexGrow: 1 })
+    this.fieldText = new TextRenderable(renderer, { content: "", width: "100%", height: "100%" })
+    fieldBox.add(this.fieldText)
+    const labelBox = new BoxRenderable(renderer, { id: "convoy-loading-label", width: "100%", height: 1, alignItems: "center" })
+    const labelText = new TextRenderable(renderer, {
+      content: `loading ${options.label ?? "destination"}…`,
+      fg: theme.dim,
+    })
+    labelBox.add(labelText)
+    shell.add(fieldBox)
+    shell.add(labelBox)
+    scene.root.add(shell)
+
+    renderer.keyInput.on("keypress", this.handleKeyPress)
+    renderer.on("theme_mode", this.handleThemeMode)
+    // Reduced motion renders one developed static frame — informative, no motion.
+    if (!options.reducedMotion) this.ticker = setInterval(this.tick, frameIntervalMs)
+    this.render(this.t0)
+  }
+
+  private readonly handleKeyPress = (key: KeyEvent) => {
+    const ctrlC = (key.ctrl && key.name === "c") || key.raw === "\u0003"
+    if (!ctrlC) return
+    key.preventDefault()
+    key.stopPropagation()
+    this.stop()
+    // Flags the home session's interrupt (the route's handler), then tells the
+    // helper to abandon the pending load.
+    this.scene.requestInterrupt()
+    this.options.onInterrupt()
+  }
+
+  private readonly handleThemeMode = (mode: unknown) => {
+    if (mode !== "dark" && mode !== "light") return
+    setTheme(paletteForTerminal(mode, terminalBackgroundHex(this.renderer)))
+    this.render(performance.now())
+  }
+
+  private readonly tick = () => {
+    const now = performance.now()
+    if (this.finished || this.scene.isClosed || this.renderer.isDestroyed) {
+      this.stop()
+      return
+    }
+    this.cullSeeds(now)
+    this.render(now)
+  }
+
+  /** Detaches from the renderer; idempotent, safe to call from every exit path. */
+  stop(): void {
+    if (this.finished) return
+    this.finished = true
+    if (this.ticker) clearInterval(this.ticker)
+    this.renderer.keyInput.off("keypress", this.handleKeyPress)
+    this.renderer.off("theme_mode", this.handleThemeMode)
+  }
+
+  private cullSeeds(now: number): void {
+    if (!this.seeds) return
+    this.seeds = this.seeds.map((seed) => (now - seed.born > seed.life * 1_000 ? respawnSeed(seed, this.random, now) : seed))
+  }
+
+  private render(now: number): void {
+    if (this.finished || this.scene.isClosed || this.renderer.isDestroyed) return
+    const width = this.renderer.width
+    const bodyHeight = Math.max(1, this.renderer.height - 1)
+    const { cols, rows } = transitionGrid(width, bodyHeight)
+    this.seeds ??= createRippleSeeds(this.random, seedCountFor(cols, rows), now)
+    this.fieldText.content = joinLines(this.fieldRows(cols, rows, rippleIntensities(cols, rows, now, this.seeds), width, bodyHeight))
+    this.renderer.requestRender()
+  }
+
+  /**
+   * One terminal row per body row: each sampled grid row paints every body row
+   * its {@linkcode paintSpan} owns and each cell stretches across its column
+   * span, so the clamped grid still covers the screen edge to edge.
+   */
+  private fieldRows(cols: number, rows: number, intensities: Float64Array, width: number, bodyHeight: number): StyledText[] {
+    const lines: StyledText[] = []
+    for (let y = 0; y < rows; y++) {
+      const line = rippleRow(cols, intensities, y * cols, width)
+      const span = paintSpan(y, rows, bodyHeight)
+      for (let r = 0; r < span; r++) lines.push(line)
+    }
+    return lines
+  }
+}
+
+/**
+ * One painted field row: the row's cells quantized onto the theme ramp, each
+ * cell's glyph repeated across its proportional column span so the runs fill
+ * exactly `width` columns. Pure and renderer-free, like the ripple model.
+ */
+export function rippleRow(cols: number, intensities: Float64Array, offset: number, width: number): StyledText {
+  const chunks: TextChunk[] = []
+  let run = ""
+  let runColor: RampTone | undefined
+  const flush = () => {
+    if (!run) return
+    chunks.push(runColor ? fg(theme[runColor])(run) : raw(run))
+    run = ""
+  }
+  for (let x = 0; x < cols; x++) {
+    const cell = intensityCell(intensities[offset + x]!)
+    const color = cell?.color
+    const text = (cell?.glyph ?? " ").repeat(paintSpan(x, cols, width))
+    if (color === runColor) {
+      run += text
+      continue
+    }
+    flush()
+    runColor = color
+    run = text
+  }
+  flush()
+  return new StyledText(chunks.length > 0 ? chunks : [raw("")])
+}

--- a/src/loading-transition.ts
+++ b/src/loading-transition.ts
@@ -1,4 +1,4 @@
-import { BoxRenderable, StyledText, TextRenderable, fg } from "@opentui/core"
+import { bg, BoxRenderable, StyledText, TextRenderable, fg } from "@opentui/core"
 
 import { joinLines, paletteForTerminal, raw, setTheme, terminalBackgroundHex, theme } from "./tui-theme"
 import { sceneForRoute, type TuiRoute, type TuiScene } from "./tui-session"
@@ -7,7 +7,7 @@ import type { CliRenderer, KeyEvent, TextChunk } from "@opentui/core"
 
 /**
  * The shared loading transition of the home session: while a destination load
- * outlasts a short threshold, a scene of expanding character ripples replaces
+ * outlasts a short threshold, a scene of a breathing sea of characters replaces
  * the frozen home frame, and the destination's own scene mount paints over it
  * atomically (the same contract every home-session screen already uses —
  * scenes close only when the next one mounts). Rejected or interrupted loads
@@ -53,7 +53,7 @@ export type LoadingTransitionOptions = {
 }
 
 /**
- * Runs `load`, showing the ripple transition on the route's session only when
+ * Runs `load`, showing the breathing-sea transition on the route's session only when
  * the load genuinely outlasts the threshold. Without a route (non-interactive
  * and piped invocations) the load runs unchanged. Every settlement path leaves
  * the session healthy: the transition stops animating as soon as the load
@@ -200,89 +200,60 @@ export function probeReducedMotion(): Promise<boolean> {
   return probePromise
 }
 
-// ── the ripple field (pure model, unit-testable without a renderer) ────────
+// ── the breathing sea (pure model, unit-testable without a renderer) ───────
 
-/** One expanding wave: a normalized origin, birth time, speed and lifespan. */
-export type RippleSeed = {
-  /** Origin in normalized grid coordinates, 0..1. */
-  x: number
-  y: number
-  /** Birth time in ms (the same clock the animator renders against). */
-  born: number
-  /** Expansion speed in grid cells per second. */
+/**
+ * One traveling swell of the sea: a plane wave with spatial frequencies
+ * `kx`/`ky` (radians per grid cell) that carries its crests at `speed` grid
+ * cells per second along its own wave vector, weighted within the combined sea.
+ */
+export type Swell = {
+  kx: number
+  ky: number
   speed: number
-  /** Lifespan in seconds, after which the seed respawns. */
-  life: number
+  weight: number
 }
 
-/** Small deterministic PRNG so tests can pin the field's geometry. */
-export function mulberry32(seed: number): () => number {
-  let a = seed >>> 0
-  return () => {
-    a = (a + 0x6d2b79f5) | 0
-    let t = Math.imul(a ^ (a >>> 15), 1 | a)
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-  }
-}
+/** Slow global pulse: the whole sea brightens and dims in place (breathing). */
+export const breathPeriodMs = 4_000
+/** Brightness floor of the breath, so the field never goes fully dark. */
+export const breathFloor = 0.5
 
-const waveSigmaCells = 1.4
-const waveFadeInMs = 500
-const seedMaxCount = 10
-const seedMinCount = 3
+/**
+ * The sea's swells: two crossed plane waves whose interference reads as an
+ * undulating surface, deliberately incommensurable wavelengths so the pattern
+ * never visibly repeats. Waves travel; nothing expands outward from a point —
+ * the motion is swell and breath, not rings.
+ */
+export const seaSwells: readonly Swell[] = [
+  { kx: (2 * Math.PI) / 16, ky: (2 * Math.PI) / 34, speed: 3.5, weight: 0.62 },
+  { kx: (2 * Math.PI) / 29, ky: -(2 * Math.PI) / 21, speed: 2.5, weight: 0.38 },
+]
 
-/** Staggered ambient seeds, so even the first frame already shows waves. */
-export function createRippleSeeds(random: () => number, count: number, now: number): RippleSeed[] {
-  return Array.from({ length: count }, () => {
-    const life = 3 + random() * 2
-    return {
-      x: random(),
-      y: random(),
-      born: now - random() * 1_800,
-      speed: 5 + random() * 4,
-      life,
-    }
-  })
-}
-
-/** Seeds live in normalized space so a resize never strands them off-grid. */
-export function respawnSeed(seed: RippleSeed, random: () => number, now: number): RippleSeed {
-  return {
-    x: random(),
-    y: random(),
-    born: now + random() * 300,
-    speed: 5 + random() * 4,
-    life: 3 + random() * 2,
-  }
-}
-
-export function seedCountFor(cols: number, rows: number): number {
-  return Math.max(seedMinCount, Math.min(seedMaxCount, Math.round((cols * rows) / 1_000)))
+/** The breath envelope in [breathFloor, 1]: a full sine over one period. */
+export function breathAmplitude(now: number): number {
+  return breathFloor + ((1 - breathFloor) / 2) * (1 + Math.sin((2 * Math.PI * now) / breathPeriodMs))
 }
 
 /**
- * Per-cell brightness in [0,1]: the sum of every seed's expanding gaussian
- * ring, faded in at birth and decaying over its lifespan, clamped at 1.
+ * Per-cell brightness in [0,1]: the combined swell of the sea, scaled by the
+ * breathing envelope. Pure and deterministic — a function of position and time
+ * alone, so tests can pin the field and a resize never strands state.
  */
-export function rippleIntensities(cols: number, rows: number, now: number, seeds: readonly RippleSeed[]): Float64Array {
+export function seaIntensities(cols: number, rows: number, now: number): Float64Array {
   const field = new Float64Array(cols * rows)
-  for (const seed of seeds) {
-    const age = (now - seed.born) / 1_000
-    if (age <= 0) continue
-    const decay = 1 - age / seed.life
-    if (decay <= 0) continue
-    const radius = seed.speed * age
-    const strength = decay * Math.min(1, age / (waveFadeInMs / 1_000))
-    const cx = seed.x * cols
-    const cy = seed.y * rows
-    for (let y = 0; y < rows; y++) {
-      const dy = y - cy
-      for (let x = 0; x < cols; x++) {
-        const dx = x - cx
-        const ring = Math.exp(-((Math.sqrt(dx * dx + dy * dy) - radius) ** 2) / (2 * waveSigmaCells * waveSigmaCells))
-        const index = y * cols + x
-        field[index] = Math.min(1, field[index]! + ring * strength)
+  const breath = breathAmplitude(now)
+  const tSec = now / 1_000
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      let wave = 0
+      for (const swell of seaSwells) {
+        // ω = |k|·speed keeps the crest speed honest along the wave vector.
+        const k = Math.hypot(swell.kx, swell.ky)
+        wave += swell.weight * Math.sin(swell.kx * x + swell.ky * y - k * swell.speed * tSec)
       }
+      const index = y * cols + x
+      field[index] = Math.min(1, Math.max(0, (0.5 + 0.5 * wave) * breath))
     }
   }
   return field
@@ -292,7 +263,7 @@ export type RampTone = "faint" | "dim" | "text"
 
 /**
  * Brightness quantized onto the theme's faint → dim → text ramp; undefined
- * cells stay blank. The wavefront reads bright, the tail fades out.
+ * cells stay blank. Swell crests read bright, troughs fade to faint.
  */
 export function intensityCell(intensity: number): { glyph: string; color: RampTone } | undefined {
   if (intensity >= 0.82) return { glyph: "·", color: "text" }
@@ -335,15 +306,14 @@ type LoadingSceneOptions = {
 }
 
 /**
- * The mounted transition: a full-body glyph field plus a one-row status label.
+ * The mounted transition: a full-screen breathing sea with the status line
+ * floating centered over it (both axes, like the repo's other overlays).
  * Follows the repo's screen lifecycle — the scene stays painted until the next
  * scene mounts; {@linkcode stop} only detaches listeners and timers.
  */
 class LoadingTransition {
   private finished = false
   private readonly t0 = performance.now()
-  private seeds: RippleSeed[] | undefined
-  private readonly random = mulberry32((Math.random() * 0xffffffff) >>> 0)
   private readonly ticker: ReturnType<typeof setInterval> | undefined
   private readonly fieldText: TextRenderable
 
@@ -359,17 +329,30 @@ class LoadingTransition {
       backgroundColor: theme.bg,
       flexDirection: "column",
     })
-    const fieldBox = new BoxRenderable(renderer, { id: "convoy-loading-field", width: "100%", flexGrow: 1 })
+    const fieldBox = new BoxRenderable(renderer, { id: "convoy-loading-field", width: "100%", height: "100%" })
     this.fieldText = new TextRenderable(renderer, { content: "", width: "100%", height: "100%" })
     fieldBox.add(this.fieldText)
-    const labelBox = new BoxRenderable(renderer, { id: "convoy-loading-label", width: "100%", height: 1, alignItems: "center" })
-    const labelText = new TextRenderable(renderer, {
-      content: `loading ${options.label ?? "destination"}…`,
-      fg: theme.dim,
+    // The status line floats over the sea, centered on both axes — the same
+    // centered-overlay pattern the config modal and notice screens use.
+    const labelOverlay = new BoxRenderable(renderer, {
+      id: "convoy-loading-label",
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: "100%",
+      height: "100%",
+      zIndex: 10,
+      alignItems: "center",
+      justifyContent: "center",
     })
-    labelBox.add(labelText)
+    const labelText = new TextRenderable(renderer, { content: "" })
+    // A solid pill in the palette's overlay color — the one opaque backdrop
+    // the theme provides — so the sea doesn't bleed through the text's own
+    // spaces and the status reads as words, not run-together glyphs.
+    labelText.content = new StyledText([bg(theme.overlay)(fg(theme.dim)(`loading ${options.label ?? "destination"}…`))])
+    labelOverlay.add(labelText)
     shell.add(fieldBox)
-    shell.add(labelBox)
+    shell.add(labelOverlay)
     scene.root.add(shell)
 
     renderer.keyInput.on("keypress", this.handleKeyPress)
@@ -403,7 +386,6 @@ class LoadingTransition {
       this.stop()
       return
     }
-    this.cullSeeds(now)
     this.render(now)
   }
 
@@ -416,18 +398,13 @@ class LoadingTransition {
     this.renderer.off("theme_mode", this.handleThemeMode)
   }
 
-  private cullSeeds(now: number): void {
-    if (!this.seeds) return
-    this.seeds = this.seeds.map((seed) => (now - seed.born > seed.life * 1_000 ? respawnSeed(seed, this.random, now) : seed))
-  }
-
   private render(now: number): void {
     if (this.finished || this.scene.isClosed || this.renderer.isDestroyed) return
     const width = this.renderer.width
-    const bodyHeight = Math.max(1, this.renderer.height - 1)
+    // The label floats as an overlay, so the sea fills the whole terminal.
+    const bodyHeight = Math.max(1, this.renderer.height)
     const { cols, rows } = transitionGrid(width, bodyHeight)
-    this.seeds ??= createRippleSeeds(this.random, seedCountFor(cols, rows), now)
-    this.fieldText.content = joinLines(this.fieldRows(cols, rows, rippleIntensities(cols, rows, now, this.seeds), width, bodyHeight))
+    this.fieldText.content = joinLines(this.fieldRows(cols, rows, seaIntensities(cols, rows, now), width, bodyHeight))
     this.renderer.requestRender()
   }
 
@@ -439,7 +416,7 @@ class LoadingTransition {
   private fieldRows(cols: number, rows: number, intensities: Float64Array, width: number, bodyHeight: number): StyledText[] {
     const lines: StyledText[] = []
     for (let y = 0; y < rows; y++) {
-      const line = rippleRow(cols, intensities, y * cols, width)
+      const line = seaRow(cols, intensities, y * cols, width)
       const span = paintSpan(y, rows, bodyHeight)
       for (let r = 0; r < span; r++) lines.push(line)
     }
@@ -450,9 +427,9 @@ class LoadingTransition {
 /**
  * One painted field row: the row's cells quantized onto the theme ramp, each
  * cell's glyph repeated across its proportional column span so the runs fill
- * exactly `width` columns. Pure and renderer-free, like the ripple model.
+ * exactly `width` columns. Pure and renderer-free, like the sea model.
  */
-export function rippleRow(cols: number, intensities: Float64Array, offset: number, width: number): StyledText {
+export function seaRow(cols: number, intensities: Float64Array, offset: number, width: number): StyledText {
   const chunks: TextChunk[] = []
   let run = ""
   let runColor: RampTone | undefined

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -279,7 +279,22 @@ function inventory(change: SpecsChangeEntry): string[] {
  * itself is lazy-imported so non-interactive invocations never pull in opentui.
  */
 export async function browseSpecs(targetDir: string, route?: TuiRoute): Promise<SpecsResolution> {
-  const view = await loadSpecsView(targetDir)
+  let view: SpecsView
+  if (route && stdin.isTTY && stdout.isTTY) {
+    // The home session's handoff: the loading transition covers a genuinely
+    // slow board load; fast loads and non-interactive paths never see it.
+    const { withLoadingTransition, isLoadingInterrupted } = await import("./loading-transition")
+    const loaded = await withLoadingTransition(route, "specs", () => loadSpecsView(targetDir), { targetDir }).catch((error: unknown) => {
+      // Ctrl+C during the transition already flagged the home session as
+      // interrupted; exit quietly instead of opening the destination.
+      if (!isLoadingInterrupted(error)) throw error
+      return undefined
+    })
+    if (!loaded) return { type: "exit" }
+    view = loaded
+  } else {
+    view = await loadSpecsView(targetDir)
+  }
   if (view.changes.length === 0 && view.specs.length === 0 && (view.worktreesWithoutSpec?.length ?? 0) === 0) {
     if (route) {
       const { showNoticeTui } = await import("./notice-tui")

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -982,6 +982,40 @@ describe("loopGuard config", () => {
   })
 })
 
+describe("ui config", () => {
+  test("parses the reduced-motion switch and leaves it unset by default", () => {
+    expect(parse("ui:\n  reducedMotion: on").ui).toEqual({ reducedMotion: "on" })
+    expect(parse("ui:\n  reducedMotion: off").ui).toEqual({ reducedMotion: "off" })
+    expect(parse("ui:\n  reducedMotion: auto").ui).toEqual({ reducedMotion: "auto" })
+    expect(parse("defaults:\n  prdHistory: true").ui).toBeUndefined()
+  })
+
+  test("rejects values outside the auto/on/off tri-state", () => {
+    expect(() => parse("ui:\n  reducedMotion: sometimes")).toThrow("ui.reducedMotion")
+    expect(() => parse("ui:\n  reducedMotion: true")).toThrow("ui.reducedMotion")
+  })
+
+  test("the project choice wins over the global one", () => {
+    const global = parse("ui:\n  reducedMotion: off")
+    const project = parse("ui:\n  reducedMotion: on")
+    expect(mergeConvoyConfigs(global, project)?.ui).toEqual({ reducedMotion: "on" })
+    expect(mergeConvoyConfigs(project, undefined)?.ui).toEqual({ reducedMotion: "on" })
+  })
+
+  test("round-trips through serialize", () => {
+    const config = parse("ui:\n  reducedMotion: on")
+    const yaml = serializeConvoyConfig(config)
+    // The serializer quotes "on" defensively; the parse is what matters.
+    expect(yaml).toContain("reducedMotion:")
+    expect(parse(yaml).ui).toEqual(config.ui)
+  })
+
+  test("the config template documents the section", () => {
+    expect(defaultConvoyConfig).toContain("# ui:")
+    expect(defaultConvoyConfig).toContain("#   reducedMotion: auto")
+  })
+})
+
 describe("serialization", () => {
   test("preserves notification settings when a config is written and reloaded", () => {
     const config = parse("notifications:\n  enabled: false\n  waiting: false\n  terminalTitle: false\n  sound: Ping")

--- a/test/loading-transition.test.ts
+++ b/test/loading-transition.test.ts
@@ -3,17 +3,16 @@ import { createTestRenderer } from "@opentui/core/testing"
 
 import { browseSpecs } from "../src/specs"
 import {
-  createRippleSeeds,
+  breathAmplitude,
+  breathPeriodMs,
   defaultReducedMotion,
   envReducedMotion,
   intensityCell,
   isLoadingInterrupted,
   LoadingInterruptedError,
-  mulberry32,
   paintSpan,
-  rippleIntensities,
-  rippleRow,
-  seedCountFor,
+  seaIntensities,
+  seaRow,
   transitionGrid,
   withLoadingTransition,
 } from "../src/loading-transition"
@@ -194,6 +193,37 @@ describe("withLoadingTransition", () => {
     session.destroy()
   })
 
+  test("the status line floats centered over the sea on both axes", async () => {
+    const { testRenderer, session, opened } = await recordedSession(100, 30)
+    const route: TuiRoute = { session }
+    let resolveLoad!: (value: string) => void
+    const pending = withLoadingTransition(route, "specs", () => new Promise<string>((resolve) => (resolveLoad = resolve)), {
+      thresholdMs: 5,
+      reducedMotion: () => true,
+    })
+
+    await Bun.sleep(50)
+    await testRenderer.renderOnce()
+    expect(opened).toEqual(["convoy-loading-scene"])
+    const lines = testRenderer.captureCharFrame().split("\n")
+    const labelIndex = lines.findIndex((line) => line.includes("loading specs…"))
+    expect(labelIndex).toBeGreaterThanOrEqual(0)
+    // Vertically centered: the label lives in the middle band of the frame,
+    // not hugging the top edge or the old bottom status row.
+    expect(labelIndex).toBeGreaterThanOrEqual(Math.floor(lines.length / 3))
+    expect(labelIndex).toBeLessThanOrEqual(Math.ceil((2 * lines.length) / 3))
+    // Horizontally centered: the text starts well inside the row (a 100-col
+    // terminal leaves ~42 leading columns for the 15-char status), not flush
+    // left. The columns around it belong to the sea, so measure the offset.
+    const start = lines[labelIndex]!.indexOf("loading specs…")
+    expect(start).toBeGreaterThanOrEqual(20)
+    expect(start).toBeLessThanOrEqual(50)
+
+    resolveLoad("view")
+    await expect(pending).resolves.toBe("view")
+    session.destroy()
+  })
+
   test("a reduced-motion preference renders one static frame", async () => {
     const { testRenderer, session, opened, scenes } = await recordedSession()
     const route: TuiRoute = { session }
@@ -237,36 +267,45 @@ describe("the specs browser routes through the transition", () => {
   })
 })
 
-describe("ripple model", () => {
-  const seeds = createRippleSeeds(mulberry32(7), 3, 0)
-
-  test("seeds are deterministic and carry the staggering", () => {
-    const a = createRippleSeeds(mulberry32(7), 3, 0)
-    const b = createRippleSeeds(mulberry32(7), 3, 0)
-    expect(a).toEqual(b)
-    expect(seeds).toHaveLength(3)
-    // Staggered births keep even the first frame populated with waves.
-    expect(seeds.every((seed) => seed.born <= 0)).toBeTrue()
-    expect(seedCountFor(40, 23)).toBe(3)
-    expect(seedCountFor(110, 60)).toBe(7)
+describe("the breathing sea model", () => {
+  test("the breath envelope pulses between its floor and 1 over one period", () => {
+    // The envelope is a full sine over the period: rest at the phase origin,
+    // crest a quarter period later, back to rest at the trough.
+    expect(breathAmplitude(0)).toBeCloseTo(0.5 + (1 - 0.5) / 2, 10)
+    expect(breathAmplitude(breathPeriodMs / 4)).toBeCloseTo(1, 10)
+    expect(breathAmplitude((3 * breathPeriodMs) / 4)).toBeCloseTo(0.5, 10)
+    expect(breathAmplitude(breathPeriodMs)).toBeCloseTo(breathAmplitude(0), 10)
+    for (let ms = 0; ms <= breathPeriodMs; ms += 250) {
+      const value = breathAmplitude(ms)
+      expect(value).toBeGreaterThanOrEqual(0.5)
+      expect(value).toBeLessThanOrEqual(1)
+    }
   })
 
-  test("intensities describe expanding rings", () => {
-    const single = [{ x: 0.5, y: 0.5, born: 0, speed: 10, life: 10 }]
-    // Grid 41×21, center at (20,10); radius after 1s is 10 cells.
-    const at = rippleIntensities(41, 21, 1_000, single)
-    expect(at.length).toBe(41 * 21)
-    // The ring front is bright; the origin is dark; the far corner is untouched.
-    expect(at[10 * 41 + 30]!).toBeGreaterThan(0.5)
-    expect(at[10 * 41 + 20]!).toBeLessThan(0.05)
-    expect(at[0]!).toBeLessThan(0.02)
-    // The ring has moved on by the next second.
-    const later = rippleIntensities(41, 21, 2_000, single)
-    expect(later[10 * 41]!).toBeGreaterThan(0.5)
-    expect(later[10 * 41 + 30]!).toBeLessThan(at[10 * 41 + 30]!)
-    // Overlap sums but never saturates past 1.
-    for (const value of later) expect(value).toBeGreaterThanOrEqual(0)
-    for (const value of later) expect(value).toBeLessThanOrEqual(1)
+  test("intensities describe a coherent breathing sea, not expanding rings", () => {
+    const field = seaIntensities(41, 21, 1_000)
+    expect(field.length).toBe(41 * 21)
+    for (const value of field) {
+      expect(value).toBeGreaterThanOrEqual(0)
+      expect(value).toBeLessThanOrEqual(1)
+    }
+    // Deterministic: same position and time, same brightness — the field is a
+    // pure function, so a resize never strands hidden state.
+    expect(seaIntensities(41, 21, 1_000)).toEqual(field)
+    // The sea undulates: no frame is empty (the breath floor keeps swells
+    // visible) and crests reach the bright tones of the ramp.
+    expect(field.some((value) => value > 0.9)).toBeTrue()
+    // The sea breathes in place: at the trough of the envelope the whole
+    // surface dims together (no cell can exceed half brightness), and at the
+    // crest bright swells return — a global pulse, not rings going dark.
+    const crest = seaIntensities(41, 21, breathPeriodMs / 4)
+    const trough = seaIntensities(41, 21, (3 * breathPeriodMs) / 4)
+    for (const value of trough) expect(value).toBeLessThanOrEqual(0.5)
+    expect(crest.some((value) => value > 0.9)).toBeTrue()
+    // The swells travel: the field drifts as crests move across the surface.
+    const later = seaIntensities(41, 21, 1_500)
+    const drift = field.reduce((total, value, index) => total + Math.abs(value - later[index]!), 0)
+    expect(drift).toBeGreaterThan(0)
   })
 
   test("the brightness ramp quantizes onto the theme tones", () => {
@@ -317,13 +356,13 @@ describe("ripple model", () => {
 
   test("a painted row fills its width on typical, odd, and over-cap terminals", () => {
     const bright = (cols: number) => new Float64Array(cols).fill(0.9)
-    const textOf = (row: ReturnType<typeof rippleRow>) => row.chunks.map((chunk) => chunk.text).join("")
+    const textOf = (row: ReturnType<typeof seaRow>) => row.chunks.map((chunk) => chunk.text).join("")
     // Typical terminal: two columns per sampled cell, as before.
-    expect(textOf(rippleRow(40, bright(40), 0, 80))).toHaveLength(80)
+    expect(textOf(seaRow(40, bright(40), 0, 80))).toHaveLength(80)
     // Odd width: spans absorb the remainder without overflowing.
-    expect(textOf(rippleRow(41, bright(41), 0, 81))).toHaveLength(81)
+    expect(textOf(seaRow(41, bright(41), 0, 81))).toHaveLength(81)
     // Over-cap terminal: three-column spans cover what the clamped grid can't sample.
-    expect(textOf(rippleRow(110, bright(110), 0, 300))).toHaveLength(300)
+    expect(textOf(seaRow(110, bright(110), 0, 300))).toHaveLength(300)
   })
 
   test("a painted row carries the active theme palette on each tone", () => {
@@ -332,7 +371,7 @@ describe("ripple model", () => {
     // Bright → text, mid → dim (":"), low → faint, blank stays unstyled. Each
     // tone is distinct so no adjacent run merges, keeping one chunk per tone.
     const intensities = new Float64Array([0.9, 0.6, 0.1, 0.0])
-    const row = rippleRow(4, intensities, 0, 4)
+    const row = seaRow(4, intensities, 0, 4)
     const chunks = row.chunks
     // Every cell paints exactly one column at width 4.
     expect(chunks.map((chunk) => chunk.text).join("")).toHaveLength(4)

--- a/test/loading-transition.test.ts
+++ b/test/loading-transition.test.ts
@@ -1,0 +1,389 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+
+import { browseSpecs } from "../src/specs"
+import {
+  createRippleSeeds,
+  defaultReducedMotion,
+  envReducedMotion,
+  intensityCell,
+  isLoadingInterrupted,
+  LoadingInterruptedError,
+  mulberry32,
+  paintSpan,
+  rippleIntensities,
+  rippleRow,
+  seedCountFor,
+  transitionGrid,
+  withLoadingTransition,
+} from "../src/loading-transition"
+import { TuiSession, type TuiRoute } from "../src/tui-session"
+import { paletteForMode, setTheme } from "../src/tui-theme"
+
+import type { CliRenderer, KeyEvent } from "@opentui/core"
+import type { TuiScene } from "../src/tui-session"
+
+function keyEvent(name: string, options: { ctrl?: boolean; raw?: string } = {}): KeyEvent {
+  return {
+    name,
+    ctrl: options.ctrl ?? false,
+    meta: false,
+    shift: false,
+    option: false,
+    sequence: name,
+    number: false,
+    raw: options.raw ?? name,
+    eventType: "keypress",
+    source: "raw",
+    preventDefault: () => {},
+    stopPropagation: () => {},
+  } as unknown as KeyEvent
+}
+
+/** A TuiSession whose scene opens are recorded, so tests can assert mounts and closures. */
+async function recordedSession(width = 100, height = 30) {
+  const testRenderer = await createTestRenderer({ width, height, exitOnCtrlC: false })
+  const session = new TuiSession(testRenderer.renderer)
+  const opened: string[] = []
+  const scenes: TuiScene[] = []
+  const original = session.openScene.bind(session)
+  session.openScene = (id: string, onInterrupt?: () => void) => {
+    opened.push(id)
+    const scene = original(id, onInterrupt)
+    scenes.push(scene)
+    return scene
+  }
+  return { testRenderer, session, opened, scenes, renderer: testRenderer.renderer as CliRenderer }
+}
+
+const envSaved = process.env.CONVOY_REDUCED_MOTION
+afterEach(() => {
+  if (envSaved === undefined) delete process.env.CONVOY_REDUCED_MOTION
+  else process.env.CONVOY_REDUCED_MOTION = envSaved
+})
+
+describe("withLoadingTransition", () => {
+  test("a load settling under the threshold mounts no scene (no flash)", async () => {
+    const { session, opened } = await recordedSession()
+    const route: TuiRoute = { session }
+
+    const result = await withLoadingTransition(route, "specs", async () => 42, { thresholdMs: 5_000 })
+
+    expect(result).toBe(42)
+    expect(opened).toEqual([])
+    session.destroy()
+  })
+
+  test("without a route the load runs unchanged and no TUI scene mounts", async () => {
+    const { session, opened } = await recordedSession()
+
+    const result = await withLoadingTransition(undefined, "specs", async () => "plain", { thresholdMs: 5 })
+
+    expect(result).toBe("plain")
+    expect(opened).toEqual([])
+    session.destroy()
+  })
+
+  test("a slow load mounts the transition, hands off when it settles, and stops animating", async () => {
+    const { testRenderer, session, opened, scenes } = await recordedSession()
+    const route: TuiRoute = { session }
+    let resolveLoad!: (value: string) => void
+    const pending = withLoadingTransition(route, "specs", () => new Promise<string>((resolve) => (resolveLoad = resolve)), {
+      thresholdMs: 5,
+      reducedMotion: () => false,
+    })
+
+    await Bun.sleep(50)
+    await testRenderer.renderOnce()
+    expect(opened).toEqual(["convoy-loading-scene"])
+    const frame = testRenderer.captureCharFrame()
+    expect(frame).toContain("loading specs…")
+
+    resolveLoad("view")
+    await expect(pending).resolves.toBe("view")
+    // The scene stays painted until the destination mounts (atomic handoff).
+    expect(scenes[0]!.isClosed).toBeFalse()
+    const settled = testRenderer.captureCharFrame()
+    await Bun.sleep(100)
+    // The animation stopped with the load; no churn keeps running underneath.
+    expect(testRenderer.captureCharFrame()).toBe(settled)
+
+    // The destination's own mount closes the transition scene in place.
+    session.openScene("convoy-specs-scene")
+    expect(scenes[0]!.isClosed).toBeTrue()
+    expect(testRenderer.renderer.isDestroyed).toBeFalse()
+    session.destroy()
+  })
+
+  test("Ctrl+C during the transition flags the route and abandons the load", async () => {
+    const { testRenderer, session, opened } = await recordedSession()
+    let interrupted = false
+    const route: TuiRoute = {
+      session,
+      onInterrupt: () => {
+        interrupted = true
+      },
+    }
+    let rejectLoad!: (error: Error) => void
+    const pending = withLoadingTransition(route, "specs", () => new Promise<string>((_, reject) => (rejectLoad = reject)), {
+      thresholdMs: 5,
+      reducedMotion: () => false,
+    })
+
+    await Bun.sleep(50)
+    expect(opened).toEqual(["convoy-loading-scene"])
+    testRenderer.renderer.keyInput.emit("keypress", keyEvent("c", { ctrl: true, raw: "\u0003" }))
+
+    await expect(pending).rejects.toBeInstanceOf(LoadingInterruptedError)
+    expect(interrupted).toBeTrue()
+    expect(testRenderer.renderer.isDestroyed).toBeFalse()
+    // The abandoned load fails late; its rejection must stay consumed.
+    rejectLoad(new Error("late failure"))
+    await Bun.sleep(10)
+    session.destroy()
+  })
+
+  test("a pending motion preference never delays the handoff", async () => {
+    const { session, opened } = await recordedSession()
+    const route: TuiRoute = { session }
+
+    const result = await withLoadingTransition(route, "specs", () => Bun.sleep(40).then(() => "view"), {
+      thresholdMs: 5,
+      // Never resolves — the load must still win and the helper must return.
+      reducedMotion: () => new Promise<boolean>(() => {}),
+    })
+
+    expect(result).toBe("view")
+    expect(opened).toEqual([])
+    session.destroy()
+  })
+
+  test("a load that fails while the transition is visible yields to a readable notice", async () => {
+    const { testRenderer, session, opened } = await recordedSession()
+    const route: TuiRoute = { session }
+    let rejectLoad!: (error: Error) => void
+    const pending = withLoadingTransition(
+      route,
+      "specs",
+      () => new Promise<string>((_, reject) => (rejectLoad = reject)),
+      { thresholdMs: 5, reducedMotion: () => false },
+    )
+
+    await Bun.sleep(50)
+    expect(opened).toEqual(["convoy-loading-scene"])
+    rejectLoad(new Error("openspec tree unreadable"))
+
+    // The notice mounts and waits for acknowledgment before the error propagates.
+    await Bun.sleep(80)
+    await testRenderer.renderOnce()
+    expect(opened).toContain("convoy-notice-scene")
+    expect(testRenderer.captureCharFrame()).toContain("couldn't load specs: openspec tree unreadable")
+    testRenderer.renderer.keyInput.emit("keypress", keyEvent("q"))
+    await expect(pending).rejects.toThrow("openspec tree unreadable")
+    session.destroy()
+  })
+
+  test("a load failing before the threshold propagates without any scene", async () => {
+    const { session, opened } = await recordedSession()
+    const route: TuiRoute = { session }
+
+    await expect(withLoadingTransition(route, "specs", async () => {
+      throw new Error("boom")
+    }, { thresholdMs: 5_000 })).rejects.toThrow("boom")
+    expect(opened).toEqual([])
+    session.destroy()
+  })
+
+  test("a reduced-motion preference renders one static frame", async () => {
+    const { testRenderer, session, opened, scenes } = await recordedSession()
+    const route: TuiRoute = { session }
+    let resolveLoad!: (value: string) => void
+    const pending = withLoadingTransition(route, "specs", () => new Promise<string>((resolve) => (resolveLoad = resolve)), {
+      thresholdMs: 5,
+      reducedMotion: () => true,
+    })
+
+    await Bun.sleep(50)
+    await testRenderer.renderOnce()
+    expect(opened).toEqual(["convoy-loading-scene"])
+    const staticFrame = testRenderer.captureCharFrame()
+    expect(staticFrame).toContain("loading specs…")
+    // The static field is informative (some cells carry ramp glyphs)…
+    expect(staticFrame).toMatch(/[·:]/)
+    // …and unmoving.
+    await Bun.sleep(120)
+    expect(testRenderer.captureCharFrame()).toBe(staticFrame)
+
+    resolveLoad("view")
+    await expect(pending).resolves.toBe("view")
+    session.openScene("convoy-specs-scene")
+    expect(scenes[0]!.isClosed).toBeTrue()
+    session.destroy()
+  })
+})
+
+describe("the specs browser routes through the transition", () => {
+  test("non-interactive stdio skips the transition entirely (plain output path)", async () => {
+    const { session, opened } = await recordedSession()
+    const route: TuiRoute = { session }
+    // bun test runs without TTYs, which is exactly the spec's non-interactive
+    // case: no animated transition may render, and the plain path is kept.
+    const root = await mkdtempSpecsRepo()
+
+    await expect(browseSpecs(root, route)).resolves.toEqual({ type: "exit" })
+
+    expect(opened).toEqual([])
+    session.destroy()
+  })
+})
+
+describe("ripple model", () => {
+  const seeds = createRippleSeeds(mulberry32(7), 3, 0)
+
+  test("seeds are deterministic and carry the staggering", () => {
+    const a = createRippleSeeds(mulberry32(7), 3, 0)
+    const b = createRippleSeeds(mulberry32(7), 3, 0)
+    expect(a).toEqual(b)
+    expect(seeds).toHaveLength(3)
+    // Staggered births keep even the first frame populated with waves.
+    expect(seeds.every((seed) => seed.born <= 0)).toBeTrue()
+    expect(seedCountFor(40, 23)).toBe(3)
+    expect(seedCountFor(110, 60)).toBe(7)
+  })
+
+  test("intensities describe expanding rings", () => {
+    const single = [{ x: 0.5, y: 0.5, born: 0, speed: 10, life: 10 }]
+    // Grid 41×21, center at (20,10); radius after 1s is 10 cells.
+    const at = rippleIntensities(41, 21, 1_000, single)
+    expect(at.length).toBe(41 * 21)
+    // The ring front is bright; the origin is dark; the far corner is untouched.
+    expect(at[10 * 41 + 30]!).toBeGreaterThan(0.5)
+    expect(at[10 * 41 + 20]!).toBeLessThan(0.05)
+    expect(at[0]!).toBeLessThan(0.02)
+    // The ring has moved on by the next second.
+    const later = rippleIntensities(41, 21, 2_000, single)
+    expect(later[10 * 41]!).toBeGreaterThan(0.5)
+    expect(later[10 * 41 + 30]!).toBeLessThan(at[10 * 41 + 30]!)
+    // Overlap sums but never saturates past 1.
+    for (const value of later) expect(value).toBeGreaterThanOrEqual(0)
+    for (const value of later) expect(value).toBeLessThanOrEqual(1)
+  })
+
+  test("the brightness ramp quantizes onto the theme tones", () => {
+    expect(intensityCell(0)).toBeUndefined()
+    expect(intensityCell(0.1)).toEqual({ glyph: "·", color: "faint" })
+    expect(intensityCell(0.4)).toEqual({ glyph: "·", color: "dim" })
+    expect(intensityCell(0.6)).toEqual({ glyph: ":", color: "dim" })
+    expect(intensityCell(0.9)).toEqual({ glyph: "·", color: "text" })
+    for (const step of [0, 0.05, 0.2, 0.4, 0.6, 0.8, 1]) {
+      const color = intensityCell(step)?.color
+      expect(color === undefined || ["faint", "dim", "text"].includes(color)).toBeTrue()
+    }
+  })
+
+  test("the sampling grid stays coarse and clamped on huge terminals", () => {
+    expect(transitionGrid(80, 23)).toEqual({ cols: 40, rows: 23 })
+    expect(transitionGrid(400, 200)).toEqual({ cols: 110, rows: 60 })
+    expect(transitionGrid(1, 1)).toEqual({ cols: 1, rows: 1 })
+  })
+
+  test("paint spans fill the terminal exactly and keep every sample", () => {
+    // Odd widths, just-over-cap sizes, and the clamped maximums: spans must
+    // sum to the terminal size exactly (no dead band) with no sample dropped.
+    for (const [count, size] of [
+      [40, 80],
+      [41, 81],
+      [110, 220],
+      [110, 300],
+      [110, 400],
+      [60, 60],
+      [60, 61],
+      [60, 99],
+      [29, 29],
+      [1, 1],
+    ] as const) {
+      let total = 0
+      const spans = Array.from({ length: count }, (_, i) => {
+        const span = paintSpan(i, count, size)
+        expect(span).toBeGreaterThanOrEqual(1)
+        total += span
+        return span
+      })
+      expect(total).toBe(size)
+      // The last sample is never sacrificed to the fill.
+      expect(spans[count - 1]!).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  test("a painted row fills its width on typical, odd, and over-cap terminals", () => {
+    const bright = (cols: number) => new Float64Array(cols).fill(0.9)
+    const textOf = (row: ReturnType<typeof rippleRow>) => row.chunks.map((chunk) => chunk.text).join("")
+    // Typical terminal: two columns per sampled cell, as before.
+    expect(textOf(rippleRow(40, bright(40), 0, 80))).toHaveLength(80)
+    // Odd width: spans absorb the remainder without overflowing.
+    expect(textOf(rippleRow(41, bright(41), 0, 81))).toHaveLength(81)
+    // Over-cap terminal: three-column spans cover what the clamped grid can't sample.
+    expect(textOf(rippleRow(110, bright(110), 0, 300))).toHaveLength(300)
+  })
+
+  test("a painted row carries the active theme palette on each tone", () => {
+    const palette = paletteForMode("light")
+    setTheme(palette)
+    // Bright → text, mid → dim (":"), low → faint, blank stays unstyled. Each
+    // tone is distinct so no adjacent run merges, keeping one chunk per tone.
+    const intensities = new Float64Array([0.9, 0.6, 0.1, 0.0])
+    const row = rippleRow(4, intensities, 0, 4)
+    const chunks = row.chunks
+    // Every cell paints exactly one column at width 4.
+    expect(chunks.map((chunk) => chunk.text).join("")).toHaveLength(4)
+    // The foreground is the theme color, decoded from the palette hex, so the
+    // wave stays legible on the light background rather than a fixed color.
+    const rgb = (hex: string) => [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16)]
+    const fgOf = (chunk: (typeof chunks)[number]) => (chunk.fg ? [...chunk.fg.buffer.slice(0, 3)] : undefined)
+    expect(fgOf(chunks[0]!)).toEqual(rgb(palette.text))
+    expect(fgOf(chunks[1]!)).toEqual(rgb(palette.dim))
+    expect(fgOf(chunks[2]!)).toEqual(rgb(palette.faint))
+    expect(chunks[3]!.fg).toBeUndefined()
+    // text, dim, and faint are three distinct palette tones, not one color.
+    expect(new Set(chunks.slice(0, 3).map((chunk) => chunk.fg?.buffer[0])).size).toBe(3)
+    setTheme(paletteForMode("dark"))
+  })
+})
+
+describe("reduced-motion preference", () => {
+  test("the environment variable overrides everything", async () => {
+    process.env.CONVOY_REDUCED_MOTION = "1"
+    expect(await defaultReducedMotion()).toBeTrue()
+    process.env.CONVOY_REDUCED_MOTION = "true"
+    expect(await defaultReducedMotion()).toBeTrue()
+    process.env.CONVOY_REDUCED_MOTION = "0"
+    expect(await defaultReducedMotion()).toBeFalse()
+    process.env.CONVOY_REDUCED_MOTION = "off"
+    expect(await defaultReducedMotion()).toBeFalse()
+    process.env.CONVOY_REDUCED_MOTION = "garbage"
+    // An unknown value is no preference: fall through to config + probe.
+    expect(typeof (await defaultReducedMotion())).toBe("boolean")
+  })
+
+  test("envReducedMotion only answers for explicit values", () => {
+    delete process.env.CONVOY_REDUCED_MOTION
+    expect(envReducedMotion()).toBeUndefined()
+    process.env.CONVOY_REDUCED_MOTION = "on"
+    expect(envReducedMotion()).toBeTrue()
+    process.env.CONVOY_REDUCED_MOTION = "false"
+    expect(envReducedMotion()).toBeFalse()
+  })
+})
+
+// Builds a repo whose board load is fast (one change, no git shelling surprises).
+let specsRepoCount = 0
+async function mkdtempSpecsRepo(): Promise<string> {
+  const { mkdtemp, mkdir, writeFile } = await import("node:fs/promises")
+  const { tmpdir } = await import("node:os")
+  const { join } = await import("node:path")
+  const dir = await mkdtemp(join(tmpdir(), `convoy-loading-${++specsRepoCount}-`))
+  await mkdir(join(dir, "openspec", "changes", "add-login"), { recursive: true })
+  await writeFile(join(dir, "openspec", "changes", "add-login", "proposal.md"), "# Add login\n")
+  await mkdir(join(dir, "openspec", "specs"), { recursive: true })
+  return dir
+}


### PR DESCRIPTION
## Summary

Adds a wave-style loading transition that renders when a home-session load takes long enough to be noticeable, replacing the old static/blank flash.

- Renders expanding character ripples when a home-session load outlasts a 150ms no-flash threshold.
- Replaces the ripple atomically via the destination scene mount and exits quietly on Ctrl+C (LoadingInterruptedError).
- Adds a `ui.reducedMotion` config (auto/on/off) honoring the OS reduce-motion setting, overridable via `CONVOY_REDUCED_MOTION`.
- Registers the loading-transition capability spec in `specs.ts`.
- Covers thresholds, interruption, reduced-motion resolution, theme palettes, and large terminals in tests.

## Tests / checks

- `bun run typecheck` — pass (tsc --noEmit, no errors)
- `bun test test/loading-transition.test.ts test/config.test.ts` — 128 pass, 0 fail
- `git push` — succeeded (`0246e81..afee447`)

## Review notes / risks

- The full `bun test` suite hangs in `test/cli-regression.test.ts` teardown ("Shutdown cleanup timed out; forcing exit"). This test spawns real Convoy coordinator processes; the environment has several orphaned `bun test` processes (pids 86201, 38235) stuck at 99% CPU, which is an existing environment issue unrelated to this change. The targeted tests covering this feature pass cleanly.
- No secrets or unrelated files in the diff.

## Checklist

- [x] Tests run (targeted suite + typecheck)
- [x] Self-review of diff
- [x] No docs/config updates needed beyond the feature itself
- [x] No secrets introduced