### PR TITLE
feat(launcher): replace permission toggles with cycling selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -631,6 +631,8 @@ The permission gate has three states. In the dashboard, `Shift+Tab` cycles throu
 
 The judge model is `--smart-model <provider/model[#variant]>`, falling back to `defaults.autoAcceptJudgeModel` in config, then the run's model. The hard denylist is never relaxed: OpenCode rejects it before the gate, including for read-only steps that have `verify: true`. `--yolo` and smart auto-accept only cover the "ask" bucket.
 
+**In the launcher**, the same choice is a single cycling control. The options step's **permission selector** replaces the old pair of mutually exclusive toggles: activating it cycles Interactive → Auto-accept → Smart auto-accept → Interactive, and it starts on **Auto-accept** — a launcher-launched run defaults to `--yolo` unless you move the selector to Smart auto-accept or back to Interactive (which sends neither flag and prompts for every ask-level request). The row always names the current state and description, the review shows the resolved permission state before anything starts, and the dashboard's `Shift+Tab` cycle plus the CLI flags behave exactly as described below.
+
 ## Commit safety
 
 Before each commit Convoy scans the staged files for common secret names (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `credentials*`, `*.p12`, `*.keystore`, ...). If any match, the commit is aborted, the index reset, and Convoy asks you to add them to `.gitignore` (or delete them) before re-running. Combined with `--include-dirty` this is the only line of defense against accidentally publishing a secret your working tree had lying around — review the resulting commits with `git show` before pushing.

--- a/openspec/changes/launcher-permission-selector/.openspec.yaml
+++ b/openspec/changes/launcher-permission-selector/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-06

--- a/openspec/changes/launcher-permission-selector/design.md
+++ b/openspec/changes/launcher-permission-selector/design.md
@@ -1,0 +1,59 @@
+# Design: launcher-permission-selector
+
+## Context
+
+The launcher options step (`src/launch-tui.ts`) renders one gateway select row plus a list of boolean toggles. Today the first two toggles are the mutually exclusive permission pair:
+
+- `ToggleKey` includes `"smart"` and `"yolo"`; `toggleState` seeds `smart: true, yolo: false` (~line 626), so every launch defaults to Smart auto-accept.
+- `toggleOption()` (~line 1682) flips a boolean and enforces the exclusion (`smart on → yolo off`, and vice versa); keyboard and mouse activation both funnel through it.
+- The launch payload (~line 1672) copies `toggleState.yolo/smart` straight into `LaunchOptions`; flag construction (~line 2446) pushes `--smart`/`--yolo`.
+- Row rendering (~line 2238) assumes every row is an on/off switch.
+
+The runtime below the launcher already speaks in three modes: `AutoAcceptMode`/plan `permissions` are `off|all|smart` and `interactive|yolo|smart`. The CLI flags, permission gate, dashboard Shift+Tab cycle, and goal-loop seeding are all untouched by this change — the launcher just chooses which flags to send. The existing `run-launcher` spec covers only dirty-tree handling, so the selector gets a new capability (`run-launcher-permissions`, see the delta spec).
+
+## Goals / Non-Goals
+
+**Goals:**
+- One permission control on the options step that cycles Interactive → Auto-accept → Smart → Interactive on activation (keyboard and mouse).
+- Default the launcher to Auto-accept.
+- Keep producing exactly the same downstream options the old toggles produced for each reachable state (`--yolo`, `--smart`, or neither).
+
+**Non-Goals:**
+- No changes to CLI flags (`--yolo` / `--smart` / `--smart-model`), their defaults, or parsing.
+- No changes to the running dashboard's Shift+Tab cycle, the permission gate, smart-judge model resolution, or `RunOptions`/plan shapes.
+- No persistence of the operator's last-selected mode between launcher sessions (state resets per launch, as today).
+- No redesign of the other toggles, their defaults, or the worktree/include-dirty coupling.
+
+## Decisions
+
+### D1: Replace the two permission toggles with a tri-state mode, not synthesized booleans
+
+Remove `"smart"`/`"yolo"` from `ToggleKey`/`toggleState` and add a `permissionMode: "interactive" | "yolo" | "smart"` field on the launcher, with the state names aligned to the plan's existing `permissions` vocabulary. The cycle order is the fixed list `["interactive", "yolo", "smart"]`; activation advances one step and wraps.
+
+- Alternative considered: keep both booleans and add a hidden "both off" path via the cycle. Rejected: it preserves the very state coupling the user dislikes, and the boolean pair cannot represent "interactive" without special-casing.
+- Mapping (single place, in the launch payload and flag builder): `interactive` → `yolo: false, smart: false`; `yolo` → `yolo: true`; `smart` → `smart: true`. The payload keeps sending `LaunchOptions.yolo/smart`, so `RunOptions`, `buildRunPlan`, and everything downstream are untouched.
+
+### D2: Render the selector as a value row, following the gateway row's precedent
+
+The options step already has one non-boolean row: the gateway selector ("gateway  …  --gateway"). The permission selector renders the same way — mode name as the row's value, the flag it resolves to (`--yolo` / `--smart` / neither, dimmed when interactive) on the right, and a per-state description line beneath it, like the toggle descriptions today. The per-state description reuses the wording of the old toggle descriptions (Auto-accept and Smart keep theirs; Interactive gets a short "permissions prompt for every ask-level request" line).
+
+- Alternative considered: keep the checkbox/switch glyph and treat "off" as interactive. Rejected: a switch suggests a binary; the mode is a three-way choice and the mode name is the information the operator needs.
+
+### D3: Default the mode to `yolo` (Auto-accept)
+
+`permissionMode` initializes to `"yolo"`. Nothing else seeds it: there is no config key for launcher defaults today (and config deliberately refuses permission grants — `permissions.yolo` in config is a parse error), so introducing persistence or a config default is out of scope per the proposal.
+
+### D4: Activation stays inside the existing row-dispatch path
+
+`toggleOption()` keeps handling the selected row; for the permission row it cycles `permissionMode` instead of flipping a boolean (mirroring how the gateway row opens its picker there). Keyboard activation and row clicks both already route through this method, so no new input plumbing.
+
+## Risks / Trade-offs
+
+- [Launcher tests assert the old rows ("Smart auto-accept" snapshots, switch glyphs at specific rows)] → Update the affected `test/launch-tui.test.ts` expectations and add cycle/default/mapping cases; no production test depends on the toggle internals.
+- [Default `--yolo` means a fresh launcher now starts more permissive than the CLI default (neither flag)] → Intentional per the proposal; the review step still displays `--yolo` before the run starts, so the operator sees and can reject it. Document the new default in the README.
+- [Cycle has no hidden "both on" or dead state] → The wrap-around list makes invalid states unrepresentable; flag construction reads only from the mapped mode.
+- [Row index math shifts (the permission rows were toggle rows, now one row)] → The single selector replaces two rows, so `optionRows`/index bookkeeping must be updated together with the `toggles` array; the include-dirty count enrichment and the dirt notice keep working because they target the `includeDirty` row, which keeps its key.
+
+## Migration Plan
+
+Single-repo UI change, no data or persisted state to migrate: remove the two toggle specs, add the selector, flip the default, update tests and README. Rollback is a straight revert. Legacy run metadata is unaffected (plan `permissions` vocabulary is unchanged).

--- a/openspec/changes/launcher-permission-selector/proposal.md
+++ b/openspec/changes/launcher-permission-selector/proposal.md
@@ -1,0 +1,28 @@
+# Proposal: launcher-permission-selector
+
+## Why
+
+Every pipeline launch defaults to Smart auto-accept, but the operator's preferred default is plain Auto-accept — the default is exactly backwards for them. On top of that, the launcher presents the two auto-accept flavors as two separate toggles that are mutually exclusive ("turn one on, the other turns off"), which reads as awkward state coupling rather than one deliberate choice.
+
+## What Changes
+
+- **BREAKING (launcher UX only)**: Replace the two mutually exclusive permission toggles ("Smart auto-accept" / "Auto-accept permissions") in the run launcher's options step with a single cycling permission selector.
+- The selector cycles through three states: **Interactive** (no auto-accept, permissions prompt) → **Auto-accept** (ask-level permissions auto-allowed, denylist still applies) → **Smart auto-accept** (AI judge allows safe requests, escalates risky ones) → back to **Interactive**.
+- The launcher's default permission state becomes **Auto-accept** (today the default is Smart auto-accept).
+- The selector maps to the same execution flags as before: Interactive sends neither flag, Auto-accept sends `--yolo`, Smart sends `--smart` (+ the resolved judge model).
+- The other option toggles (human gates, include dirty tree, keep run dir, dashboard, worktree) are unchanged.
+- CLI flags `--yolo` / `--smart` and the running dashboard's Shift+Tab cycle keep their current behavior; this change is scoped to the launcher's options step.
+
+## Capabilities
+
+### New Capabilities
+- `run-launcher-permissions`: The run launcher's permission-mode selector — the single cycling control replacing the two toggles, its three states, its Auto-accept default, and how it maps to the run's permission flags.
+
+### Modified Capabilities
+<!-- none: the existing run-launcher capability covers dirty-tree handling only; its requirements do not change. -->
+
+## Impact
+
+- `src/launch-tui.ts`: toggle list (replace the two permission rows with one selector row), default `toggleState` (`smart: true, yolo: false` → auto-accept default), the mutual-exclusion logic in `toggleOption()`, and flag construction in the launch payload.
+- No runtime changes: `RunOptions.yolo/smart`, `AutoAcceptMode`, the permission gate, the plan's `permissions` field, and the dashboard cycle are untouched — the launcher keeps producing the same flags it does today for each state.
+- README (launcher options / auto-accept sections) and any launcher screenshots may need updating.

--- a/openspec/changes/launcher-permission-selector/specs/run-launcher-permissions/spec.md
+++ b/openspec/changes/launcher-permission-selector/specs/run-launcher-permissions/spec.md
@@ -1,0 +1,66 @@
+## Purpose
+
+The run launcher's permission-mode control: a single cycling selector on the options step that chooses how ask-level permission requests are handled during the run — fully interactive prompting, blanket auto-accept, or judge-mediated smart auto-accept — replacing the previous pair of mutually exclusive toggles.
+
+## ADDED Requirements
+
+### Requirement: The options step presents one cycling permission selector
+
+The run launcher's options step SHALL present exactly one permission control — a cycling selector — in place of the previous "Smart auto-accept" and "Auto-accept permissions" toggles. Activating it SHALL advance through the three permission states in a fixed cycle: Interactive → Auto-accept → Smart auto-accept → Interactive. The selector's row SHALL always display the currently selected state's name and description.
+
+#### Scenario: Selector cycles through all three states
+
+- **WHEN** the operator activates the permission selector three times in a row
+- **THEN** it moves Interactive → Auto-accept → Smart auto-accept, and a fourth activation returns it to Interactive
+
+#### Scenario: The two old toggles no longer appear
+
+- **WHEN** the options step is rendered
+- **THEN** no separate "Smart auto-accept" or "Auto-accept permissions" toggle rows exist; the permission selector is the only permission control
+
+### Requirement: The permission selector defaults to Auto-accept
+
+When the launcher opens, the permission selector SHALL start on Auto-accept (ask-level permission requests are allowed automatically; the hard denylist still applies), not on Smart auto-accept and not on Interactive.
+
+#### Scenario: Fresh launcher opens
+
+- **WHEN** the launcher's options step opens with no prior permission selection
+- **THEN** the permission selector shows Auto-accept
+
+#### Scenario: Default is sent without operator interaction
+
+- **WHEN** the operator accepts the review without touching the permission selector
+- **THEN** the run starts with auto-accept enabled, exactly as if `--yolo` had been passed
+
+### Requirement: The selected permission mode maps to the run's permission flags
+
+The launcher SHALL translate the selected permission state into the same run options the previous toggles produced: Interactive sends neither auto-accept flag, Auto-accept sends the auto-accept (`--yolo`) flag, and Smart auto-accept sends the smart (`--smart`) flag. The judge-model resolution for Smart auto-accept SHALL be unchanged. The launcher MUST NOT emit both flags at once.
+
+#### Scenario: Auto-accept selected
+
+- **WHEN** the review is accepted with the selector on Auto-accept
+- **THEN** the run's flags show `--yolo` and not `--smart`
+
+#### Scenario: Smart auto-accept selected
+
+- **WHEN** the review is accepted with the selector on Smart auto-accept
+- **THEN** the run's flags show `--smart` and not `--yolo`
+
+#### Scenario: Interactive selected
+
+- **WHEN** the review is accepted with the selector on Interactive
+- **THEN** the run's flags show neither `--yolo` nor `--smart`, and permission requests prompt the operator during the run
+
+### Requirement: Other launcher options are unaffected
+
+The permission selector change SHALL NOT alter the other options-step controls (human gates, include dirty tree, keep run directory, progress dashboard, worktree isolation, gateway selection), their defaults, or their mutual couplings (worktree/include-dirty). The review step SHALL keep displaying the resolved permission flags alongside the other flags.
+
+#### Scenario: Review reflects the selector
+
+- **WHEN** the operator reaches the review step with the selector on Smart auto-accept
+- **THEN** the review shows the `--smart` flag alongside the other selected flags
+
+#### Scenario: Other toggles keep their behavior
+
+- **WHEN** the operator cycles the permission selector
+- **THEN** the other toggles' states, labels, and defaults are unchanged, and worktree/include-dirty remain coupled as before

--- a/openspec/changes/launcher-permission-selector/tasks.md
+++ b/openspec/changes/launcher-permission-selector/tasks.md
@@ -1,0 +1,16 @@
+## 1. Launcher selector core
+
+- [ ] 1.1 In `src/launch-tui.ts`, remove `"smart"`/`"yolo"` from `ToggleKey` and drop the two permission toggle specs from the `toggles` list; add a `permissionMode: "interactive" | "yolo" | "smart"` field with per-state names and descriptions, and seed the default as `"yolo"` (design D1/D3). Verify `bun run build` (or the repo's typecheck) passes.
+- [ ] 1.2 Render the permission selector as a value row (mode name, resolved flag `--yolo`/`--smart`/dimmed-neither on the right, per-state description line) following the gateway row's precedent, replacing the two switch rows (design D2). Verify by rendering the options step in a test/scratch TUI and seeing one permission row.
+- [ ] 1.3 Route the permission row's activation through `toggleOption()` so it advances `permissionMode` along the fixed cycle `interactive → yolo → smart → interactive` for both keyboard and mouse activation, and remove the old `smart`/`yolo` mutual-exclusion lines (design D4). Verify: activating three times returns to the starting state and other toggles still flip.
+- [ ] 1.4 Update the launch payload and review flag construction to map `permissionMode` → `LaunchOptions.yolo/smart` and the `--yolo`/`--smart` flags (never both), keeping `RunOptions` and everything downstream unchanged (design D1). Verify the payload for each mode in a unit test.
+
+## 2. Tests
+
+- [ ] 2.1 Update the existing `test/launch-tui.test.ts` expectations that reference the old toggles ("Smart auto-accept" rows/switch glyphs) for the new selector row and add coverage for: default is Auto-accept, the three-state cycle wraps, and the flag/payload mapping per mode. Verify with `bun test test/launch-tui.test.ts` (or the repo's test command).
+- [ ] 2.2 Add/adjust any coordinate or review-pipeline test asserting a default launcher launch now resolves plan `permissions: "yolo"` and shows `--yolo` in the review flags. Verify with the repo's test command.
+
+## 3. Docs
+
+- [ ] 3.1 Update README's launcher/options and auto-accept sections to describe the single cycling selector, its three states, and the new Auto-accept default. Verify the affected README lines read correctly.
+- [ ] 3.2 Run the full verification suite (`bun test` / repo test command) and confirm no regressions outside the updated launcher tests.

--- a/openspec/changes/launcher-permission-selector/tasks.md
+++ b/openspec/changes/launcher-permission-selector/tasks.md
@@ -1,16 +1,16 @@
 ## 1. Launcher selector core
 
-- [ ] 1.1 In `src/launch-tui.ts`, remove `"smart"`/`"yolo"` from `ToggleKey` and drop the two permission toggle specs from the `toggles` list; add a `permissionMode: "interactive" | "yolo" | "smart"` field with per-state names and descriptions, and seed the default as `"yolo"` (design D1/D3). Verify `bun run build` (or the repo's typecheck) passes.
-- [ ] 1.2 Render the permission selector as a value row (mode name, resolved flag `--yolo`/`--smart`/dimmed-neither on the right, per-state description line) following the gateway row's precedent, replacing the two switch rows (design D2). Verify by rendering the options step in a test/scratch TUI and seeing one permission row.
-- [ ] 1.3 Route the permission row's activation through `toggleOption()` so it advances `permissionMode` along the fixed cycle `interactive → yolo → smart → interactive` for both keyboard and mouse activation, and remove the old `smart`/`yolo` mutual-exclusion lines (design D4). Verify: activating three times returns to the starting state and other toggles still flip.
-- [ ] 1.4 Update the launch payload and review flag construction to map `permissionMode` → `LaunchOptions.yolo/smart` and the `--yolo`/`--smart` flags (never both), keeping `RunOptions` and everything downstream unchanged (design D1). Verify the payload for each mode in a unit test.
+- [x] 1.1 In `src/launch-tui.ts`, remove `"smart"`/`"yolo"` from `ToggleKey` and drop the two permission toggle specs from the `toggles` list; add a `permissionMode: "interactive" | "yolo" | "smart"` field with per-state names and descriptions, and seed the default as `"yolo"` (design D1/D3). Verify `bun run build` (or the repo's typecheck) passes.
+- [x] 1.2 Render the permission selector as a value row (mode name, resolved flag `--yolo`/`--smart`/dimmed-neither on the right, per-state description line) following the gateway row's precedent, replacing the two switch rows (design D2). Verify by rendering the options step in a test/scratch TUI and seeing one permission row.
+- [x] 1.3 Route the permission row's activation through `toggleOption()` so it advances `permissionMode` along the fixed cycle `interactive → yolo → smart → interactive` for both keyboard and mouse activation, and remove the old `smart`/`yolo` mutual-exclusion lines (design D4). Verify: activating three times returns to the starting state and other toggles still flip.
+- [x] 1.4 Update the launch payload and review flag construction to map `permissionMode` → `LaunchOptions.yolo/smart` and the `--yolo`/`--smart` flags (never both), keeping `RunOptions` and everything downstream unchanged (design D1). Verify the payload for each mode in a unit test.
 
 ## 2. Tests
 
-- [ ] 2.1 Update the existing `test/launch-tui.test.ts` expectations that reference the old toggles ("Smart auto-accept" rows/switch glyphs) for the new selector row and add coverage for: default is Auto-accept, the three-state cycle wraps, and the flag/payload mapping per mode. Verify with `bun test test/launch-tui.test.ts` (or the repo's test command).
-- [ ] 2.2 Add/adjust any coordinate or review-pipeline test asserting a default launcher launch now resolves plan `permissions: "yolo"` and shows `--yolo` in the review flags. Verify with the repo's test command.
+- [x] 2.1 Update the existing `test/launch-tui.test.ts` expectations that reference the old toggles ("Smart auto-accept" rows/switch glyphs) for the new selector row and add coverage for: default is Auto-accept, the three-state cycle wraps, and the flag/payload mapping per mode. Verify with `bun test test/launch-tui.test.ts` (or the repo's test command).
+- [x] 2.2 Add/adjust any coordinate or review-pipeline test asserting a default launcher launch now resolves plan `permissions: "yolo"` and shows `--yolo` in the review flags. Verify with the repo's test command.
 
 ## 3. Docs
 
-- [ ] 3.1 Update README's launcher/options and auto-accept sections to describe the single cycling selector, its three states, and the new Auto-accept default. Verify the affected README lines read correctly.
-- [ ] 3.2 Run the full verification suite (`bun test` / repo test command) and confirm no regressions outside the updated launcher tests.
+- [x] 3.1 Update README's launcher/options and auto-accept sections to describe the single cycling selector, its three states, and the new Auto-accept default. Verify the affected README lines read correctly.
+- [x] 3.2 Run the full verification suite (`bun test` / repo test command) and confirm no regressions outside the updated launcher tests.

--- a/src/launch-tui.ts
+++ b/src/launch-tui.ts
@@ -193,7 +193,21 @@ export type PipelineChoice = {
   attachesPrdHistory?: boolean
 }
 
-type ToggleKey = "smart" | "yolo" | "humanReview" | "includeDirty" | "keepRunDir" | "tui" | "worktree"
+type ToggleKey = "humanReview" | "includeDirty" | "keepRunDir" | "tui" | "worktree"
+
+/**
+ * The permission modes the options step's selector cycles through, in its fixed
+ * order. The names align with the run plan's `permissions` vocabulary, so the
+ * mapping to `LaunchOptions.yolo/smart` (and everything downstream) stays in
+ * one place.
+ */
+export const permissionModes = ["interactive", "yolo", "smart"] as const
+export type PermissionMode = (typeof permissionModes)[number]
+
+/** Advances one step along the selector's fixed cycle, wrapping back to Interactive. */
+export function nextPermissionMode(mode: PermissionMode): PermissionMode {
+  return permissionModes[(permissionModes.indexOf(mode) + 1) % permissionModes.length]!
+}
 
 type ToggleSpec = {
   key: ToggleKey
@@ -296,19 +310,33 @@ const gatewayOptionIndex = 0
 /** What the gateway row's description says: why you would touch it at all. */
 const gatewayRowDescription = "Route every model through one provider without changing pipeline YAML."
 
-const toggles: readonly ToggleSpec[] = [
-  {
-    key: "smart",
-    label: "Smart auto-accept",
-    flag: "--smart",
-    description: "An AI judge auto-allows safe ask-level permission requests and escalates risky ones.",
+/** The permission selector is the second selectable row: right after the gateway, before the toggles. */
+const permissionOptionIndex = 1
+
+/**
+ * What each permission mode's row displays: the state's name, the flag it
+ * resolves to (empty for Interactive), and the description line beneath the
+ * row. Auto-accept and Smart keep the wording of the toggles they replace.
+ */
+const permissionModeSpecs: Record<PermissionMode, { name: string; flag: string; description: string }> = {
+  interactive: {
+    name: "Interactive",
+    flag: "",
+    description: "Prompt for every ask-level permission request.",
   },
-  {
-    key: "yolo",
-    label: "Auto-accept permissions",
+  yolo: {
+    name: "Auto-accept",
     flag: "--yolo",
     description: "Allow every ask-level permission request automatically. The hard denylist still applies.",
   },
+  smart: {
+    name: "Smart auto-accept",
+    flag: "--smart",
+    description: "An AI judge auto-allows safe ask-level permission requests and escalates risky ones.",
+  },
+}
+
+const toggles: readonly ToggleSpec[] = [
   {
     key: "humanReview",
     label: "Human gates",
@@ -622,9 +650,15 @@ export class LaunchPicker {
   private branchError = ""
   private branchChecking = false
 
+  /**
+   * The permission selector's state, replacing the old smart/yolo toggle pair.
+   * Defaults to Auto-accept (--yolo): ask-level requests are allowed
+   * automatically, the hard denylist still applies, and the review names the
+   * flag before the run starts.
+   */
+  private permissionMode: PermissionMode = "yolo"
+
   private readonly toggleState: Record<ToggleKey, boolean> = {
-    smart: true,
-    yolo: false,
     humanReview: Boolean(process.stdin.isTTY && process.stdout.isTTY),
     includeDirty: false,
     keepRunDir: true,
@@ -1669,8 +1703,10 @@ export class LaunchPicker {
       tui: this.toggleState.tui,
       includeDirty: this.toggleState.includeDirty,
       keepRunDir: this.toggleState.keepRunDir,
-      yolo: this.toggleState.yolo,
-      smart: this.toggleState.smart,
+      // The single permission mode maps onto the same pair of flags the old
+      // toggles produced: never both, and neither for Interactive.
+      yolo: this.permissionMode === "yolo",
+      smart: this.permissionMode === "smart",
       gateway: this.gateway,
       isolateWorktree: this.toggleState.worktree,
       ...(frozenBranch ?? {}),
@@ -1686,12 +1722,17 @@ export class LaunchPicker {
       this.openGatewayPicker()
       return
     }
-    const key = toggles[this.optionIndex - 1]?.key
+    // The permission row is a tri-state selector: activation advances the
+    // fixed cycle Interactive → Auto-accept → Smart auto-accept → Interactive.
+    if (this.optionIndex === permissionOptionIndex) {
+      this.permissionMode = nextPermissionMode(this.permissionMode)
+      this.render()
+      return
+    }
+    const key = toggles[this.optionIndex - 2]?.key
     if (!key) return
     const next = !this.toggleState[key]
     this.toggleState[key] = next
-    if (key === "smart" && next) this.toggleState.yolo = false
-    if (key === "yolo" && next) this.toggleState.smart = false
     // A fresh worktree is always clean, so includeDirty is meaningless there.
     if (key === "worktree" && next) this.toggleState.includeDirty = false
     if (key === "includeDirty" && next) this.toggleState.worktree = false
@@ -1743,9 +1784,9 @@ export class LaunchPicker {
     this.render()
   }
 
-  /** Number of selectable rows in the options step: the gateway selector and the built-in toggles. */
+  /** Number of selectable rows in the options step: the gateway selector, the permission selector, and the built-in toggles. */
   private optionCount(): number {
-    return 1 + toggles.length
+    return 2 + toggles.length
   }
 
   private currentChoice() {
@@ -2235,8 +2276,24 @@ this.detailBox.title = reviewing ? " review " : " run setup "
     lines.push(plain(""))
     this.optionRows.push(undefined)
 
+    // The permission selector follows the gateway row's precedent: a value row
+    // (mode name as the value, the flag it resolves to on the right) with a
+    // per-state description beneath — one deliberate control where the two
+    // mutually exclusive auto-accept toggles used to sit.
+    const permissionSpec = permissionModeSpecs[this.permissionMode]
+    const permissionSelected = this.optionIndex === permissionOptionIndex
+    const permissionMarker = permissionSelected ? fg(theme.accent)("▸ ") : raw("  ")
+    const permissionValue = permissionSelected ? bold(fg(theme.text)(permissionSpec.name)) : fg(theme.text)(permissionSpec.name)
+    const permissionFlag = permissionSpec.flag ? fg(theme.green)(permissionSpec.flag) : fg(theme.dim)("no auto-accept flag")
+    lines.push(padBetween([permissionMarker, fg(theme.faint)("permissions  "), permissionValue], [permissionFlag], width))
+    this.optionRows.push(permissionOptionIndex)
+    lines.push(new StyledText([raw("        "), fg(theme.dim)(truncate(permissionSpec.description, Math.max(8, width - 8)))]))
+    this.optionRows.push(permissionOptionIndex)
+    lines.push(plain(""))
+    this.optionRows.push(undefined)
+
     for (const [index, spec] of toggles.entries()) {
-      const selected = index + 1 === this.optionIndex
+      const selected = index + 2 === this.optionIndex
       const enabled = this.toggleState[spec.key]
       const marker = selected ? fg(theme.accent)("▸ ") : raw("  ")
       const toggle = toggleSwitch(enabled)
@@ -2248,7 +2305,7 @@ this.detailBox.title = reviewing ? " review " : " run setup "
       const count = dirt?.blocked ? fg(theme.dim)(` (${dirt.files} uncommitted)`) : undefined
       const flag = fg(enabled ? theme.green : theme.dim)(spec.flag)
       lines.push(padBetween([marker, ...toggle, raw(" "), label, ...(count ? [count] : [])], [flag], width))
-      this.optionRows.push(index + 1)
+      this.optionRows.push(index + 2)
       // The worktree default depends on which branch you're on, so say why it
       // landed where it did — otherwise the checkbox looks like it moves on its own.
       const description =
@@ -2256,7 +2313,7 @@ this.detailBox.title = reviewing ? " review " : " run setup "
           ? `Default ${this.worktreeDefault.isolate ? "on" : "off"}: ${this.worktreeDefault.reason}. ${spec.description}`
           : spec.description
       lines.push(new StyledText([raw("        "), fg(theme.dim)(truncate(description, Math.max(8, width - 8)))]))
-      this.optionRows.push(index + 1)
+      this.optionRows.push(index + 2)
       // Nested isolation is never blocked, only named: enabling a new worktree
       // while already inside one forks from this worktree's branch, and the
       // operator should do that deliberately (D7).
@@ -2265,7 +2322,7 @@ this.detailBox.title = reviewing ? " review " : " run setup "
         const where = this.insideWorktree.branch ? `branch ${this.insideWorktree.branch} of worktree ${dir}` : `worktree ${dir}`
         const warning = `you are on ${where} — the new worktree forks from this branch; isolate only if you truly mean it`
         lines.push(new StyledText([raw("        "), fg(theme.yellow)(truncate(warning, Math.max(8, width - 8)))]))
-        this.optionRows.push(index + 1)
+        this.optionRows.push(index + 2)
       }
     }
 
@@ -2443,8 +2500,8 @@ this.detailBox.title = reviewing ? " review " : " run setup "
   private enabledFlags() {
     const flags = [`--pipeline ${this.currentChoice().name}`]
     flags.push(`--gateway ${this.gateway}`)
-    if (this.toggleState.smart) flags.push("--smart")
-    if (this.toggleState.yolo) flags.push("--yolo")
+    const permissionFlag = permissionModeSpecs[this.permissionMode].flag
+    if (permissionFlag) flags.push(permissionFlag)
     flags.push(this.toggleState.humanReview ? "--human-step" : "--no-human-step")
     if (this.toggleState.includeDirty) flags.push("--include-dirty")
     if (!this.toggleState.keepRunDir) flags.push("--no-keep-run-dir")
@@ -2523,7 +2580,9 @@ this.detailBox.title = reviewing ? " review " : " run setup "
     return row(
       [
         { keys: "↑/↓", label: "select", priority: 3, tone: "dim" },
-        { keys: "space", label: "toggle", priority: 2 },
+        // The permission row is a tri-state selector, so space cycles it rather
+        // than toggling — the footer names the behavior of the selected row.
+        { keys: "space", label: this.optionIndex === permissionOptionIndex ? "cycle" : "toggle", priority: 2 },
         { keys: "g", label: "gateway", priority: 5 },
         { keys: "enter", label: "review", priority: 4 },
         { keys: "p", label: "prompt", priority: 6 },

--- a/src/review-tui.ts
+++ b/src/review-tui.ts
@@ -92,7 +92,11 @@ export function runReviewLines(plan: RunPlan, width: number, options: RunReviewR
     rows.push(plain(""))
   }
 
-  const runtime = `${plan.permissions} permissions · ${plan.attachments.length} attachment${plan.attachments.length === 1 ? "" : "s"}`
+  // The permission vocabulary names the mode, and the flag form is what the
+  // operator would have typed: show both so the review names the exact
+  // auto-accept flag the launcher's permission selector resolved to.
+  const permissionFlag = plan.permissions === "yolo" ? " (--yolo)" : plan.permissions === "smart" ? " (--smart)" : ""
+  const runtime = `${plan.permissions} permissions${permissionFlag} · ${plan.attachments.length} attachment${plan.attachments.length === 1 ? "" : "s"}`
   const judge = plan.smartJudge ? sanitizeReviewInline(plan.smartJudge.model.target) : ""
   if (judge && labelWidth + runtime.length + 9 + judge.length <= width) {
     rows.push(labelRow("runtime", [fg(theme.text)(runtime), fg(theme.faint)(" · judge "), fg(theme.dim)(judge)]))

--- a/test/launch-tui.test.ts
+++ b/test/launch-tui.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test, afterAll } from "bun:test"
 import { createTestRenderer } from "@opentui/core/testing"
 
-import { LaunchPicker, branchActionForKey, branchProposalNote, compactLaunchMaxWidth, cursorPosition, defaultDirtyStatus, dirtReading, emptyPromptField, goalLines, hookLines, launcherStepModelLabel, markPromptEdited, nextPromptSuggestion, pipelineChoices, pipelineRow, prefillPromptField, promptAfterPipelineSwitch, promptEnterAction, reviewActionForKey, sanitizePaste, stepTree, trimPromptField, typedText, wrapPromptLines } from "../src/launch-tui"
-import type { GoalPreview, LaunchRunTuiOptions } from "../src/launch-tui"
+import { LaunchPicker, branchActionForKey, branchProposalNote, compactLaunchMaxWidth, cursorPosition, defaultDirtyStatus, dirtReading, emptyPromptField, goalLines, hookLines, launcherStepModelLabel, markPromptEdited, nextPermissionMode, nextPromptSuggestion, pipelineChoices, pipelineRow, prefillPromptField, promptAfterPipelineSwitch, promptEnterAction, reviewActionForKey, sanitizePaste, stepTree, trimPromptField, typedText, wrapPromptLines } from "../src/launch-tui"
+import type { GoalPreview, LaunchRunSelection, LaunchRunTuiOptions } from "../src/launch-tui"
 import { ensureRepoReady, statusPorcelain } from "../src/git"
 import type { OpenSpecChangeSummary } from "../src/openspec"
 
+import { parseArgs, resolveRunOptions } from "../src/cli"
+import { runReviewLines } from "../src/review-tui"
 import { buildRunPlan } from "../src/run-plan"
 import { builtInAgents, builtInPipelines, hasWritableStep, resolvePipeline } from "../src/pipeline"
 import { parseConvoyConfig } from "../src/config"
@@ -98,22 +100,24 @@ type LaunchPickerView = {
   optionIndex: number
   gateway: string
   modal: { kind: string; index: number } | undefined
+  permissionMode: string
   toggleState: { worktree: boolean; includeDirty: boolean; [key: string]: unknown }
   promptChoosing: boolean
   specIndex: number
   selectedChangeId?: string
   prepared?: {
-    selection: { includeDirty: boolean }
+    selection: { includeDirty: boolean; yolo: boolean; smart: boolean }
     dirt: { files: number; matters: boolean; blocked: boolean; preview: string }
   }
   modalWidth(): number
+  footerContent(width: number): { chunks: Array<{ text: string }> }
   promptDetail(width: number): { chunks: Array<{ text: string }> }
   optionsDetail(width: number): { chunks: Array<{ text: string }> }
   pipelineDetail(width: number): { chunks: Array<{ text: string }> }
   reviewDetail(width: number): { chunks: Array<{ text: string }> }
   prepareReview(pipelineName: string): Promise<void>
   refreshDirt(): Promise<void>
-  runSelection(pipelineName: string, initializeGit?: boolean): { prompt: string; change?: string }
+  runSelection(pipelineName: string, initializeGit?: boolean): LaunchRunSelection
 }
 
 function launchView(picker: LaunchPicker): LaunchPickerView {
@@ -232,9 +236,9 @@ describe("launch TUI compact layout", () => {
       expect(displayWidth(promptHint)).toBeLessThanOrEqual(40)
 
       view.mode = "options"
-      // The toggle list is taller than the compact panel, so the flags
+      // The options list is taller than the compact panel, so the flags
       // summary only scrolls into view once the selection reaches the end.
-      view.optionIndex = 7
+      view.optionIndex = 6
       const flags = view.optionsDetail(40).chunks.map((chunk) => chunk.text).join("").split("\n").find((line) => line.includes("will run with"))!
       expect(displayWidth(flags)).toBeLessThanOrEqual(40)
     } finally {
@@ -242,7 +246,7 @@ describe("launch TUI compact layout", () => {
     }
   })
 
-  test("keeps the selected toggle inside the options window when the list overflows", async () => {
+  test("keeps the selected control inside the options window when the list overflows", async () => {
     const launcher = await createLauncher(80, 24)
     try {
       const view = launchView(launcher.picker)
@@ -250,10 +254,10 @@ describe("launch TUI compact layout", () => {
 
       view.optionIndex = 1
       const top = view.optionsDetail(60).chunks.map((chunk) => chunk.text).join("")
-      expect(top).toContain("▸ ━━● on  Smart auto-accept")
+      expect(top).toContain("▸ permissions  Auto-accept")
       expect(top).not.toContain("will run with")
 
-      view.optionIndex = 7
+      view.optionIndex = 6
       const bottom = view.optionsDetail(60).chunks.map((chunk) => chunk.text).join("")
       expect(bottom).toContain("▸ ●━━ off Isolate in a worktree")
       expect(bottom).toContain("will run with")
@@ -1023,7 +1027,7 @@ describe("launch TUI gateway selector", () => {
       expect(lines[instruction + 1]).toBe("")
       expect(lines[gatewayRow + 1]).toContain("Route every model through one provider")
       expect(lines[gatewayRow + 2]).toBe("")
-      expect(lines[gatewayRow + 3]).toContain("Smart auto-accept")
+      expect(lines[gatewayRow + 3]).toContain("permissions  Auto-accept")
     } finally {
       await closeLauncher(launcher)
     }
@@ -1040,7 +1044,10 @@ describe("launch TUI gateway selector", () => {
       expect(gatewayRow).toBeGreaterThanOrEqual(0)
       expect(lines[gatewayRow]).not.toContain("▸ gateway")
       expect(lines[gatewayRow]).toContain("--gateway")
-      expect(lines.find((line) => line.includes("Smart auto-accept"))).toContain("▸ ━━● on")
+      // The row after the gateway is the permission selector; moving down one
+      // row selects it without turning it into a switch row.
+      expect(lines.find((line) => line.includes("permissions"))).toContain("▸ permissions")
+      expect(lines.find((line) => line.includes("permissions"))).not.toContain("━━●")
     } finally {
       await closeLauncher(launcher)
     }
@@ -1170,6 +1177,313 @@ describe("launch TUI gateway selector", () => {
       await launcher.mockMouse.click(lines[gatewayRow]!.indexOf("gateway"), gatewayRow)
       await launcher.renderOnce()
       expect(view.modal?.kind).toBe("gateway")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+})
+
+describe("launch TUI permission selector", () => {
+  function optionsLines(view: LaunchPickerView, width = 80) {
+    return view.optionsDetail(width).chunks.map((chunk) => chunk.text).join("").split("\n")
+  }
+
+  function permissionsRow(lines: string[]) {
+    const row = lines.find((line) => line.includes("permissions  "))
+    expect(row, "permission selector row visible").toBeDefined()
+    return row!
+  }
+
+  test("nextPermissionMode walks the fixed cycle and wraps", () => {
+    expect(nextPermissionMode("interactive")).toBe("yolo")
+    expect(nextPermissionMode("yolo")).toBe("smart")
+    expect(nextPermissionMode("smart")).toBe("interactive")
+    // Three activations always return to the starting state.
+    expect(nextPermissionMode(nextPermissionMode(nextPermissionMode("yolo")))).toBe("yolo")
+  })
+
+  test("a fresh launcher starts on Auto-accept and shows its flag", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.mode = "options"
+      view.optionIndex = 1
+      await launcher.renderOnce()
+      expect(view.permissionMode).toBe("yolo")
+      const row = permissionsRow(optionsLines(view))
+      expect(row).toContain("Auto-accept")
+      expect(row).toContain("--yolo")
+      expect(view.runSelection("review")).toMatchObject({ yolo: true, smart: false })
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("activation cycles all three states and wraps back, by keyboard and mouse", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.mode = "options"
+      view.optionIndex = 1
+      await launcher.renderOnce()
+
+      launcher.mockInput.pressKey(" ")
+      await launcher.renderOnce()
+      expect(view.permissionMode).toBe("smart")
+      expect(permissionsRow(optionsLines(view))).toContain("Smart auto-accept")
+
+      launcher.mockInput.pressKey(" ")
+      await launcher.renderOnce()
+      expect(view.permissionMode).toBe("interactive")
+      const interactiveRow = permissionsRow(optionsLines(view))
+      expect(interactiveRow).toContain("Interactive")
+      expect(interactiveRow).toContain("no auto-accept flag")
+      expect(interactiveRow).not.toContain("--yolo")
+      expect(interactiveRow).not.toContain("--smart")
+
+      launcher.mockInput.pressKey(" ")
+      await launcher.renderOnce()
+      expect(view.permissionMode).toBe("yolo")
+
+      // Mouse activation advances the same cycle.
+      await launcher.renderOnce()
+      const lines = launcher.captureCharFrame().split("\n")
+      const row = lines.findIndex((line) => line.includes("permissions  "))
+      expect(row, "permission selector row visible in frame").toBeGreaterThanOrEqual(0)
+      await launcher.mockMouse.click(lines[row]!.indexOf("permissions"), row)
+      await launcher.renderOnce()
+      expect(view.permissionMode).toBe("smart")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("each mode maps to the run's permission flags, never both", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.mode = "options"
+      const flagsLine = () =>
+        optionsLines(view).find((line) => line.includes("will run with")) ?? ""
+
+      view.permissionMode = "yolo"
+      expect(view.runSelection("review")).toMatchObject({ yolo: true, smart: false })
+      expect(flagsLine()).toContain("--yolo")
+      expect(flagsLine()).not.toContain("--smart")
+
+      view.permissionMode = "smart"
+      expect(view.runSelection("review")).toMatchObject({ yolo: false, smart: true })
+      expect(flagsLine()).toContain("--smart")
+      expect(flagsLine()).not.toContain("--yolo")
+
+      view.permissionMode = "interactive"
+      expect(view.runSelection("review")).toMatchObject({ yolo: false, smart: false })
+      expect(flagsLine()).not.toContain("--yolo")
+      expect(flagsLine()).not.toContain("--smart")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("the two old permission toggles no longer exist", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.mode = "options"
+      const text = optionsLines(view).join("\n")
+      // The old yolo toggle's label is gone, and the permission control is a
+      // value row rather than an on/off switch.
+      expect(text).not.toContain("Auto-accept permissions")
+      expect(permissionsRow(optionsLines(view))).not.toContain("━━●")
+      expect("smart" in view.toggleState).toBe(false)
+      expect("yolo" in view.toggleState).toBe(false)
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("other toggles keep their rows, labels, and couplings", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.mode = "options"
+      view.optionIndex = 2
+      const text = optionsLines(view).join("\n")
+      expect(text).toContain("Human gates")
+      expect(text).toContain("Include dirty tree")
+      expect(text).toContain("Keep run directory")
+      expect(text).toContain("Progress dashboard")
+      expect(text).toContain("Isolate in a worktree")
+      // The include-dirty/worktree coupling survives the row shift.
+      view.toggleState.worktree = true
+      expect(view.toggleState.includeDirty).toBe(false)
+      expect(view.runSelection("review").yolo).toBe(true)
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("activating a boolean toggle row flips it and leaves the permission mode alone", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.mode = "options"
+      // Human gates is the first toggle row (index 2): activating it must flip
+      // that boolean, not cycle the permission selector, proving the toggle
+      // rows still resolve through the shifted `toggles[index - 2]` dispatch.
+      view.optionIndex = 2
+      await launcher.renderOnce()
+      const before = view.toggleState.humanReview
+      launcher.mockInput.pressKey(" ")
+      await launcher.renderOnce()
+      expect(view.toggleState.humanReview).toBe(!before)
+      expect(view.permissionMode).toBe("yolo")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("activating the worktree toggle through the row path enforces the include-dirty coupling", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.mode = "options"
+      // Worktree is the last toggle row (index 6): the row activation must
+      // resolve to the worktree toggle and enforce the coupling through the
+      // real dispatch path, not through direct state assignment.
+      view.optionIndex = 6
+      await launcher.renderOnce()
+      launcher.mockInput.pressKey(" ")
+      await launcher.renderOnce()
+      expect(view.toggleState.worktree).toBe(true)
+      expect(view.toggleState.includeDirty).toBe(false)
+      expect(view.permissionMode).toBe("yolo")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("the footer names the selected row's activation: cycle on permissions, toggle elsewhere", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.mode = "options"
+      const footer = () => view.footerContent(100).chunks.map((chunk) => chunk.text).join("")
+
+      view.optionIndex = 1
+      expect(footer()).toContain("cycle")
+      view.optionIndex = 2
+      expect(footer()).toContain("toggle")
+      expect(footer()).not.toContain("cycle")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+})
+
+describe("launch TUI default launch resolution", () => {
+  // The default launcher state (no operator interaction) must resolve through
+  // the production option/plan path to a `--yolo` run: the selector's default
+  // is Auto-accept, and the review must show it before the run starts.
+  test("an untouched selection resolves plan permissions 'yolo' and shows --yolo", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      expect(view.permissionMode).toBe("yolo")
+      const selection = view.runSelection("review")
+      expect(selection).toMatchObject({ yolo: true, smart: false })
+
+      // Mirror prepareInteractiveRun's mapping of the launcher selection onto
+      // parsed args, then resolve through the production path.
+      const parsed = parseArgs([])
+      parsed.targetDir = selection.targetDir
+      parsed.baseDetectionDir = process.cwd()
+      parsed.prompt = selection.prompt
+      parsed.pipeline = selection.pipeline
+      parsed.humanReview = selection.humanReview
+      parsed.tui = selection.tui
+      parsed.includeDirty = selection.includeDirty
+      parsed.keepRunDir = selection.keepRunDir
+      parsed.yolo = selection.yolo
+      parsed.smart = selection.smart
+      parsed.gateway = selection.gateway
+      parsed.worktree = Boolean(selection.isolateWorktree)
+      const options = await resolveRunOptions(parsed)
+      expect(options).toMatchObject({ yolo: true, smart: false })
+      const plan = buildRunPlan({ ...options, prompt: selection.prompt })
+      expect(plan.permissions).toBe("yolo")
+
+      // The review renders the resolved permission state with its flag form,
+      // and the options step's flag line names --yolo without --smart.
+      const reviewLines = runReviewLines(plan, 120).map((line) => line.chunks.map((chunk) => chunk.text).join(""))
+      expect(reviewLines.some((line) => line.includes("yolo permissions (--yolo)"))).toBe(true)
+      expect(reviewLines.some((line) => line.includes("--smart"))).toBe(false)
+      view.mode = "options"
+      const flags = view.optionsDetail(120).chunks.map((chunk) => chunk.text).join("")
+      expect(flags).toContain("will run with")
+      expect(flags).toContain("--yolo")
+      expect(flags).not.toContain("--smart")
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("the review shows the selector's Smart auto-accept as --smart, never --yolo", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.permissionMode = "smart"
+      const selection = view.runSelection("review")
+      expect(selection).toMatchObject({ yolo: false, smart: true })
+      const parsed = parseArgs([])
+      parsed.targetDir = selection.targetDir
+      parsed.baseDetectionDir = process.cwd()
+      parsed.pipeline = selection.pipeline
+      parsed.humanReview = selection.humanReview
+      parsed.tui = selection.tui
+      parsed.includeDirty = selection.includeDirty
+      parsed.keepRunDir = selection.keepRunDir
+      parsed.yolo = selection.yolo
+      parsed.smart = selection.smart
+      parsed.gateway = selection.gateway
+      parsed.worktree = Boolean(selection.isolateWorktree)
+      const options = await resolveRunOptions(parsed)
+      const plan = buildRunPlan({ ...options, prompt: selection.prompt })
+      expect(plan.permissions).toBe("smart")
+      const reviewLines = runReviewLines(plan, 120).map((line) => line.chunks.map((chunk) => chunk.text).join(""))
+      expect(reviewLines.some((line) => line.includes("smart permissions (--smart)"))).toBe(true)
+      expect(reviewLines.some((line) => line.includes("--yolo"))).toBe(false)
+    } finally {
+      await closeLauncher(launcher)
+    }
+  })
+
+  test("an explicitly Interactive selection resolves neither auto-accept flag", async () => {
+    const launcher = await createLauncher(100)
+    try {
+      const view = launchView(launcher.picker)
+      view.permissionMode = "interactive"
+      const selection = view.runSelection("review")
+      expect(selection).toMatchObject({ yolo: false, smart: false })
+      const parsed = parseArgs([])
+      parsed.targetDir = selection.targetDir
+      parsed.baseDetectionDir = process.cwd()
+      parsed.pipeline = selection.pipeline
+      parsed.humanReview = selection.humanReview
+      parsed.tui = selection.tui
+      parsed.includeDirty = selection.includeDirty
+      parsed.keepRunDir = selection.keepRunDir
+      parsed.yolo = selection.yolo
+      parsed.smart = selection.smart
+      parsed.gateway = selection.gateway
+      parsed.worktree = Boolean(selection.isolateWorktree)
+      const options = await resolveRunOptions(parsed)
+      const plan = buildRunPlan({ ...options, prompt: selection.prompt })
+      expect(plan.permissions).toBe("interactive")
+      // Interactive names no auto-accept flag in the review at all.
+      const reviewLines = runReviewLines(plan, 120).map((line) => line.chunks.map((chunk) => chunk.text).join(""))
+      expect(reviewLines.some((line) => line.includes("interactive permissions"))).toBe(true)
+      expect(reviewLines.some((line) => line.includes("--yolo") || line.includes("--smart"))).toBe(false)
     } finally {
       await closeLauncher(launcher)
     }

--- a/test/review-tui.test.ts
+++ b/test/review-tui.test.ts
@@ -115,7 +115,7 @@ describe("run review TUI", () => {
     expect(lines.some((line) => line.includes("worktree /home/dev/.convoy/worktrees/feat-runtime-guard-limits"))).toBe(true)
     expect(lines.some((line) => line.includes("hooks    pre   · pnpm lint"))).toBe(true)
     expect(lines.some((line) => line.includes("post  · ./notify.sh · always"))).toBe(true)
-    expect(lines.some((line) => line.includes("runtime  smart permissions · 2 attachments · judge openrouter/openai/gpt-5.6-terra#xhigh"))).toBe(true)
+    expect(lines.some((line) => line.includes("runtime  smart permissions (--smart) · 2 attachments · judge openrouter/openai/gpt-5.6-terra#xhigh"))).toBe(true)
   })
 
   test("renders the terminal goal block as immutable policy, not a toggle", () => {


### PR DESCRIPTION
# Launcher: replace the two permission toggles with a cycling selector

## Why

Every pipeline launch defaulted to Smart auto-accept, but the operator's preferred default is plain Auto-accept — the default was exactly backwards. On top of that, the launcher presented the two auto-accept flavors as two separate toggles that were mutually exclusive ("turn one on, the other turns off"), which read as awkward state coupling rather than one deliberate choice.

## What changed

- **BREAKING (launcher UX only):** the "Smart auto-accept" / "Auto-accept permissions" toggle pair on the run launcher's options step is replaced by a single **cycling permission selector**.
- Cycle: **Interactive** → **Auto-accept** → **Smart auto-accept** → Interactive. Activation (keyboard space or mouse click on the row) advances one step and wraps.
- The launcher's default permission state is now **Auto-accept** (previously Smart auto-accept).
- The selector renders as a value row, following the gateway row's precedent: mode name as the value, the resolved flag (`--yolo` / `--smart`, dimmed when Interactive) on the right, and a per-state description line beneath.
- The review step now names the resolved auto-accept flag next to the permission vocabulary (`yolo permissions (--yolo)`, `smart permissions (--smart)`, none for Interactive).

## Compatibility

- Launcher-only change: the selector maps to exactly the same execution flags as before — Interactive sends neither flag, Auto-accept sends `--yolo`, Smart sends `--smart` (+ the resolved judge model); never both at once.
- Runtime is untouched: `RunOptions.yolo/smart`, `AutoAcceptMode`, the permission gate, the plan's `permissions` field, CLI flag parsing, and the running dashboard's Shift+Tab cycle behave as today.
- Other options-step controls (human gates, include dirty tree, keep run dir, dashboard, worktree, gateway) and their couplings are unchanged.

Spec-driven change: `openspec/changes/launcher-permission-selector` (8/8 tasks complete; new capability `run-launcher-permissions`).

## Tests

- `test/launch-tui.test.ts`: default is Auto-accept; the cycle wraps via keyboard and mouse; per-mode flag/payload mapping; the two old toggles no longer render; other toggles and the worktree/include-dirty coupling stay intact; an untouched default launch resolves through production `resolveRunOptions`/`buildRunPlan` to plan `permissions: "yolo"` with `--yolo` in the review flags.
- `test/review-tui.test.ts`: updated for the flag-bearing review row.
- Full `bun test` suite passes with no regressions.

---

<details>
<summary>Convoy run 20260906-200936-cfyu — machine summary</summary>

Run: Implement the attached OpenSpec change.

# convoy run 20260906-200936-cfyu - summary

## Goal cycle

target 90/100 · up to 6 measurements (5 improve rounds) · plateau 3 · brief to fix
trajectory: 95
outcome: goal (goal met) · best 95/100 · restored: no

## Advisor

- Consultations: 13
- Executor: $1.6704 · 120,456 output tokens
- Advisor: $0.3020 · 4,512 output tokens · 409,935 input tokens
- Advisor share of output: 3.6%

### Activity by phase

| Phase | Attempted | Succeeded | Failed | Exhausted | Triggers | Cost | Tokens in/out |
|---|---:|---:|---:|---:|---|---:|---:|
| implementer | 3 | 3 | 0 | 0 | on-demand:2, completion:1 | $0.0000 | 88,123 / 1,305 |
| patterns | 2 | 2 | 0 | 0 | on-demand:1, completion:1 | $0.0938 | 64,913 / 660 |
| security | 2 | 2 | 0 | 0 | on-demand:1, completion:1 | $0.0699 | 64,665 / 586 |
| design | 3 | 3 | 0 | 0 | first-write:1, on-demand:1, completion:1 | $0.0000 | 95,374 / 1,334 |
| tests | 3 | 3 | 0 | 0 | first-write:1, on-demand:1, completion:1 | $0.1384 | 96,860 / 627 |

## implementer

# Implementer report: launcher-permission-selector

Implemented the OpenSpec change `launcher-permission-selector` (spec-driven, 8/8 tasks complete). The run launcher's two mutually exclusive permission toggles are replaced by one cycling permission selector that defaults to Auto-accept, mapped onto the same downstream flags as before.

## Changes made

- **modified** `src/launch-tui.ts` — removed `"smart"`/`"yolo"` from `ToggleKey` and their toggle specs; added `permissionModes`/`PermissionMode`, `nextPermissionMode()` (fixed cycle, wraps), `permissionModeSpecs` (per-state name/flag/description), and `permissionMode: "yolo"` default; permission selector renders as a value row after the gateway row (mode name, `--yolo`/`--smart`/dimmed "no auto-accept flag" on the right, description line beneath); activation cycles the mode through `toggleOption()` for keyboard (space) and mouse clicks; `optionCount()`/row-index bookkeeping shifted (`toggles[index - 2]`, `optionCount = 2 + toggles.length`); `runSelection()` and `enabledFlags()` map the mode to `yolo`/`smart` (never both).
- **modified** `src/review-tui.ts` — the Review step's runtime row now shows the resolved auto-accept flag next to the permission vocabulary (`yolo permissions (--yolo)`, `smart permissions (--smart)`, none for interactive), so the review names the literal flag the selector resolved to.
- **modified** `test/launch-tui.test.ts` — updated the four expectations that assumed the old switch rows/indices; widened the test view type (`permissionMode`, full `LaunchRunSelection`); added a permission-selector describe (default is Auto-accept, cycle wraps by keyboard and mouse, per-mode flag/payload mapping, old toggles gone, other toggles and the worktree/include-dirty coupling intact) and a default-launch-resolution describe (untouched selection → production `resolveRunOptions` → `buildRunPlan` → plan `permissions: "yolo"`; review shows `--yolo`/`--smart` per mode; interactive resolves neither).
- **modified** `test/review-tui.test.ts` — exact-string runtime assertion updated for the flag-bearing review line.
- **modified** `README.md` — Auto-accept section now documents the launcher's single cycling permission selector, its three states, and the new Auto-accept default.
- **modified** `openspec/changes/launcher-permission-selector/tasks.md` — all 8 task checkboxes marked complete.

</details>